### PR TITLE
Line up web view taps

### DIFF
--- a/lib/widgets/youtube_view.dart
+++ b/lib/widgets/youtube_view.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' show log;
 
+import 'package:flutter/foundation.dart' show Factory;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';

--- a/lib/widgets/youtube_view.dart
+++ b/lib/widgets/youtube_view.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' show log;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:icarus/const/youtube_handler.dart';
@@ -49,10 +50,16 @@ class _YoutubeViewState extends State<YoutubeView>
     with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
+  static final Set<Factory<OneSequenceGestureRecognizer>>
+      _youtubeGestureRecognizers = {
+    Factory<OneSequenceGestureRecognizer>(() => EagerGestureRecognizer()),
+  };
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
+    final videoId =
+        YoutubeHandler.extractYoutubeIdWithTimestamp(widget.youtubeLink);
 
     if (!isWebViewInitialized) {
       // showShadDialog<void>(
@@ -71,6 +78,7 @@ class _YoutubeViewState extends State<YoutubeView>
         ),
         Positioned.fill(
           child: InAppWebView(
+            gestureRecognizers: _youtubeGestureRecognizers,
             onLoadStart: (controller, url) {
               log("Youtube view loading");
             },
@@ -81,8 +89,7 @@ class _YoutubeViewState extends State<YoutubeView>
             initialSettings:
                 InAppWebViewSettings(allowBackgroundAudioPlaying: false),
             initialUrlRequest: URLRequest(
-                url: WebUri(
-                    "https://embed.icarus-strats.xyz/?v=${YoutubeHandler.extractYoutubeIdWithTimestamp(widget.youtubeLink)}")),
+                url: WebUri("https://embed.icarus-strats.xyz/?v=$videoId")),
           ),
         ),
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `EagerGestureRecognizer` to `InAppWebView` in `YoutubeView` to fix unresponsive YouTube video controls.

The `InAppWebView` was losing pointer events to parent `PageView` gestures, preventing interaction with embedded YouTube controls like the quality settings menu.

---
<p><a href="https://cursor.com/agents/bc-2f7c4906-3a42-457c-94b0-957231e6b7e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f7c4906-3a42-457c-94b0-957231e6b7e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->