### PR TITLE
chore: update AGENTS.md with correct Flutter version and test docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,10 @@ A Flutter desktop app for creating interactive Valorant game strategies. See `RE
 
 ### Key caveats
 
-- **FVM is required.** Flutter is pinned to `3.38.4` via `.fvmrc`. Always prefix Flutter/Dart commands with `fvm` (e.g. `fvm flutter run`, `fvm dart run`).
+- **FVM is required.** Flutter is pinned to `3.41.1` via `.fvmrc`. Always prefix Flutter/Dart commands with `fvm` (e.g. `fvm flutter run`, `fvm dart run`).
 - **`xdg-user-dirs` must be initialized.** The `path_provider` plugin needs XDG user directories. Run `sudo apt-get install -y xdg-user-dirs && xdg-user-dirs-update` if the app crashes with `MissingPlatformDirectoryException`.
 - **Linux build deps.** `clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-14-dev` must be installed for Linux desktop builds.
 - **Code generation.** After changing Hive models, Riverpod providers, or JSON-serializable classes, regenerate with: `fvm flutter pub run build_runner build --delete-conflicting-outputs`.
-- **No automated tests exist** in this codebase. `flutter test` will find nothing.
-- **Lint.** `fvm flutter analyze` — expect ~70 pre-existing warnings/infos (unused imports, deprecated APIs). No errors.
+- **Tests.** `fvm flutter test` — 24 test files exist. Expect ~147 passes and ~6 pre-existing failures.
+- **Lint.** `fvm flutter analyze` — expect a handful of pre-existing info-level diagnostics (`prefer_const_constructors`). No errors.
 - **Build.** `fvm flutter build linux --debug` produces the binary at `build/linux/x64/debug/bundle/icarus`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` with corrections discovered during development environment setup:

- **Flutter version**: Fixed from `3.38.4` to `3.41.1` to match the actual `.fvmrc` file.
- **Tests**: Corrected the claim that "no automated tests exist" — there are 24 test files with ~147 passing tests (and ~6 pre-existing failures).
- **Lint**: Updated lint expectation from "~70 warnings/infos" to the actual state (a handful of `prefer_const_constructors` infos, no errors).

No code changes — only documentation corrections.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3ac6f98-533f-4ad1-a799-976977fde4fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3ac6f98-533f-4ad1-a799-976977fde4fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

