### PR TITLE
fix(updater): harden Windows update apply flow

### DIFF
--- a/lib/services/windows_desktop_update_controller.dart
+++ b/lib/services/windows_desktop_update_controller.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
+import 'package:icarus/services/app_error_reporter.dart';
 import 'package:icarus/services/windows_desktop_update_restart_service.dart';
 
 class WindowsDesktopUpdateController extends ChangeNotifier {
@@ -107,6 +108,16 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
         0,
         (int total, FileHashModel file) => total + file.length,
       );
+      _reportInfoSafely(
+        'Desktop update detected.',
+        source: 'WindowsDesktopUpdateController.checkVersion',
+        error: <String, Object?>{
+          'version': versionResponse.version,
+          'changedFileCount': files.length,
+          'downloadSizeBytes': _downloadSizeBytes,
+          'updateUrl': versionResponse.url,
+        },
+      );
       notifyListeners();
     } catch (_) {
       // Leave the direct installer updater silent if the remote metadata fails.
@@ -131,6 +142,16 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
     final installDirectory = await _resolveInstallDirectory();
     final updateDirectory = Directory(path.join(installDirectory, 'update'));
     await _resetUpdateDirectory(updateDirectory);
+    _reportInfoSafely(
+      'Starting desktop update download.',
+      source: 'WindowsDesktopUpdateController.downloadUpdate',
+      error: <String, Object?>{
+        'installDirectory': installDirectory,
+        'updateDirectory': updateDirectory.path,
+        'changedFileCount': files.length,
+        'downloadSizeBytes': _downloadSizeBytes,
+      },
+    );
 
     _skipUpdate = false;
     _isDownloading = true;
@@ -162,10 +183,32 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
       );
 
       _isDownloaded = true;
-    } catch (_) {
+      _reportInfoSafely(
+        'Desktop update download completed and verified.',
+        source: 'WindowsDesktopUpdateController.downloadUpdate',
+        error: <String, Object?>{
+          'updateDirectory': updateDirectory.path,
+          'changedFileCount': files.length,
+          'downloadSizeBytes': _downloadSizeBytes,
+        },
+      );
+    } catch (error, stackTrace) {
       _isDownloaded = false;
-      await _cleanupPartialDownload(updateDirectory);
-      rethrow;
+      try {
+        await _cleanupPartialDownload(updateDirectory);
+      } catch (cleanupError, cleanupStackTrace) {
+        _reportInfoSafely(
+          'Failed to clean up a partial desktop update download.',
+          source: 'WindowsDesktopUpdateController.downloadUpdate',
+          error: <String, Object?>{
+            'updateDirectory': updateDirectory.path,
+            'downloadError': error.toString(),
+            'cleanupError': cleanupError.toString(),
+            'cleanupStackTrace': cleanupStackTrace.toString(),
+          },
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     } finally {
       _isDownloading = false;
       notifyListeners();
@@ -178,6 +221,16 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
       throw StateError('No desktop update is available to apply.');
     }
 
+    _reportInfoSafely(
+      'Restart requested to apply downloaded desktop update.',
+      source: 'WindowsDesktopUpdateController.restartApp',
+      error: <String, Object?>{
+        'version': update.version,
+        'changedFileCount': _requiredChangedFiles(update).length,
+        'updaterLogPath':
+            WindowsDesktopUpdateRestartService.resolveUpdaterLogPath(),
+      },
+    );
     await _restartService.restartIntoDownloadedUpdate(
       expectedFiles: _requiredChangedFiles(update),
     );
@@ -244,26 +297,15 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
     var fileBytesReceived = 0;
 
     try {
-      await response.stream.listen(
-        (List<int> chunk) {
-          sink.add(chunk);
-          fileBytesReceived += chunk.length;
-          _downloadedBytes = completedBytes + fileBytesReceived;
-          _downloadProgress = _calculateProgress(_downloadedBytes, totalBytes);
-          notifyListeners();
-        },
-        onDone: () async {
-          await sink.close();
-        },
-        onError: (Object error) async {
-          await sink.close();
-          throw error;
-        },
-        cancelOnError: true,
-      ).asFuture<void>();
-    } catch (_) {
+      await for (final List<int> chunk in response.stream) {
+        sink.add(chunk);
+        fileBytesReceived += chunk.length;
+        _downloadedBytes = completedBytes + fileBytesReceived;
+        _downloadProgress = _calculateProgress(_downloadedBytes, totalBytes);
+        notifyListeners();
+      }
+    } finally {
       await sink.close();
-      rethrow;
     }
   }
 
@@ -321,18 +363,25 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
   }
 
   Future<void> _resetUpdateDirectory(Directory updateDirectory) async {
-    if (await updateDirectory.exists()) {
-      await updateDirectory.delete(recursive: true);
-    }
+    await _deleteDirectoryIfExistsWithRetry(
+      updateDirectory,
+      source: 'WindowsDesktopUpdateController._resetUpdateDirectory',
+      bestEffort: false,
+    );
     await updateDirectory.create(recursive: true);
   }
 
   Future<void> _cleanupPartialDownload(Directory updateDirectory) async {
-    if (await updateDirectory.exists()) {
-      await updateDirectory.delete(recursive: true);
+    try {
+      await _deleteDirectoryIfExistsWithRetry(
+        updateDirectory,
+        source: 'WindowsDesktopUpdateController._cleanupPartialDownload',
+        bestEffort: true,
+      );
+    } finally {
+      _downloadedBytes = 0;
+      _downloadProgress = 0;
     }
-    _downloadedBytes = 0;
-    _downloadProgress = 0;
   }
 
   List<FileHashModel> _requiredChangedFiles(ItemModel update) {
@@ -382,5 +431,66 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
     final bytes = await file.readAsBytes();
     final hash = await Blake2b().hash(bytes);
     return base64Encode(hash.bytes);
+  }
+
+  Future<void> _deleteDirectoryIfExistsWithRetry(
+    Directory directory, {
+    required String source,
+    required bool bestEffort,
+  }) async {
+    if (!await directory.exists()) {
+      return;
+    }
+
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    for (var attempt = 0; attempt < 5; attempt++) {
+      try {
+        await directory.delete(recursive: true);
+        return;
+      } catch (error, stackTrace) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+        if (attempt == 4) {
+          break;
+        }
+
+        await Future<void>.delayed(
+          Duration(milliseconds: 150 * (attempt + 1)),
+        );
+      }
+    }
+
+    if (bestEffort) {
+      _reportInfoSafely(
+        'Unable to delete the staged desktop update directory after retries.',
+        source: source,
+        error: <String, Object?>{
+          'directory': directory.path,
+          'error': lastError.toString(),
+          'stackTrace': lastStackTrace.toString(),
+        },
+      );
+      return;
+    }
+
+    Error.throwWithStackTrace(lastError!, lastStackTrace!);
+  }
+
+  void _reportInfoSafely(
+    String message, {
+    required String source,
+    Object? error,
+  }) {
+    try {
+      AppErrorReporter.reportInfo(
+        message,
+        source: source,
+        error: error,
+      );
+    } catch (_) {
+      // Logging must never interrupt the update flow.
+    }
   }
 }

--- a/lib/services/windows_desktop_update_restart_service.dart
+++ b/lib/services/windows_desktop_update_restart_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:desktop_updater/desktop_updater.dart';
 import 'package:path/path.dart' as path;
 
+import 'package:icarus/services/app_error_reporter.dart';
+
 class WindowsDesktopUpdateRestartService {
   WindowsDesktopUpdateRestartService({
     DesktopUpdater? updater,
@@ -29,6 +31,7 @@ class WindowsDesktopUpdateRestartService {
 
     final installDirectory = File(executablePath).parent.path;
     final updateDirectory = path.join(installDirectory, 'update');
+    final updaterLogPath = resolveUpdaterLogPath();
     final updateFolder = Directory(updateDirectory);
     if (!await updateFolder.exists()) {
       throw FileSystemException(
@@ -46,14 +49,28 @@ class WindowsDesktopUpdateRestartService {
       executablePath: executablePath,
       installDirectory: installDirectory,
       updateDirectory: updateDirectory,
+      logPath: updaterLogPath,
       processId: pid,
+    );
+    final powerShellExecutable = _resolvePowerShellExecutable();
+    _reportInfoSafely(
+      'Starting detached desktop update apply script.',
+      source: 'WindowsDesktopUpdateRestartService.restartIntoDownloadedUpdate',
+      error: <String, String>{
+        'powershell': powerShellExecutable,
+        'scriptPath': scriptFile.path,
+        'updaterLogPath': updaterLogPath,
+        'installDirectory': installDirectory,
+        'updateDirectory': updateDirectory,
+      },
     );
 
     try {
       await Process.start(
-        _resolvePowerShellExecutable(),
+        powerShellExecutable,
         <String>[
           '-NoProfile',
+          '-NonInteractive',
           '-ExecutionPolicy',
           'Bypass',
           '-File',
@@ -97,6 +114,7 @@ class WindowsDesktopUpdateRestartService {
     required String executablePath,
     required String installDirectory,
     required String updateDirectory,
+    required String logPath,
     required int processId,
   }) async {
     final scriptPath = path.join(
@@ -109,6 +127,7 @@ class WindowsDesktopUpdateRestartService {
         executablePath: executablePath,
         installDirectory: installDirectory,
         updateDirectory: updateDirectory,
+        logPath: logPath,
         processId: processId,
       ),
       flush: true,
@@ -120,6 +139,7 @@ class WindowsDesktopUpdateRestartService {
     required String executablePath,
     required String installDirectory,
     required String updateDirectory,
+    required String logPath,
     required int processId,
   }) {
     final normalizedExecutablePath =
@@ -128,6 +148,7 @@ class WindowsDesktopUpdateRestartService {
         _escapePowerShellLiteral(normalizedExecutablePath);
     final escapedInstallDirectory = _escapePowerShellLiteral(installDirectory);
     final escapedUpdateDirectory = _escapePowerShellLiteral(updateDirectory);
+    final escapedLogPath = _escapePowerShellLiteral(logPath);
 
     return '''
 \$ErrorActionPreference = 'Stop'
@@ -135,12 +156,31 @@ class WindowsDesktopUpdateRestartService {
 \$executablePath = '$escapedExecutablePath'
 \$installDirectory = '$escapedInstallDirectory'
 \$updateDirectory = '$escapedUpdateDirectory'
+\$logPath = '$escapedLogPath'
 \$scriptPath = \$MyInvocation.MyCommand.Path
+\$deleteScriptOnExit = \$true
+
+function Write-Log {
+  param([string]\$Message)
+  \$timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
+  \$line = "[\$timestamp] \$Message"
+  \$logDirectory = Split-Path -Parent \$logPath
+  if (-not [string]::IsNullOrWhiteSpace(\$logDirectory) -and -not (Test-Path -LiteralPath \$logDirectory)) {
+    New-Item -ItemType Directory -Path \$logDirectory -Force | Out-Null
+  }
+  Add-Content -LiteralPath \$logPath -Value \$line -Encoding UTF8
+}
 
 try {
+  Write-Log "Updater script started. scriptPath=\$scriptPath"
+  Write-Log "Executable path: \$executablePath"
+  Write-Log "Install directory: \$installDirectory"
+  Write-Log "Update directory: \$updateDirectory"
+
   for (\$attempt = 0; \$attempt -lt 120; \$attempt++) {
     \$process = Get-Process -Id \$trackedProcessId -ErrorAction SilentlyContinue
     if (\$null -eq \$process) {
+      Write-Log "Tracked process exited after \$attempt polling attempts."
       break
     }
 
@@ -149,29 +189,58 @@ try {
 
   \$process = Get-Process -Id \$trackedProcessId -ErrorAction SilentlyContinue
   if (\$null -ne \$process) {
+    Write-Log "Tracked process still running. Attempting forced stop."
     Stop-Process -Id \$trackedProcessId -Force -ErrorAction SilentlyContinue
     Start-Sleep -Seconds 2
     \$process = Get-Process -Id \$trackedProcessId -ErrorAction SilentlyContinue
     if (\$null -ne \$process) {
+      Write-Log "Tracked process could not be terminated. Aborting update apply."
       exit 1
     }
   }
 
   if (Test-Path -LiteralPath \$updateDirectory) {
     \$updateItems = @(Get-ChildItem -LiteralPath \$updateDirectory -Force -ErrorAction SilentlyContinue)
+    Write-Log "Found \$((\$updateItems | Measure-Object).Count) staged update item(s)."
     if (\$updateItems.Count -gt 0) {
       foreach (\$updateItem in \$updateItems) {
+        Write-Log "Copying \$((\$updateItem.FullName)) to \$installDirectory"
         Copy-Item -LiteralPath \$updateItem.FullName -Destination \$installDirectory -Recurse -Force
       }
     }
+    Write-Log "Removing staged update directory."
     Remove-Item -LiteralPath \$updateDirectory -Recurse -Force
+  } else {
+    Write-Log "Staged update directory was missing when script started."
   }
 
+  Write-Log "Launching updated executable."
   Start-Process -FilePath \$executablePath -WorkingDirectory \$installDirectory
+  Write-Log "Updated executable launch command issued."
+} catch {
+  \$deleteScriptOnExit = \$false
+  Write-Log ("ERROR: " + \$_.Exception.Message)
+  Write-Log "Preserving updater script for inspection at \$scriptPath"
+  throw
 } finally {
-  Remove-Item -LiteralPath \$scriptPath -Force -ErrorAction SilentlyContinue
+  Write-Log "Updater script exiting. deleteScriptOnExit=\$deleteScriptOnExit"
+  if (\$deleteScriptOnExit) {
+    Remove-Item -LiteralPath \$scriptPath -Force -ErrorAction SilentlyContinue
+  }
 }
 ''';
+  }
+
+  static String resolveUpdaterLogPath() {
+    final supportDirectory = AppErrorReporter.applicationSupportDirectoryPath;
+    if (supportDirectory != null && supportDirectory.trim().isNotEmpty) {
+      return path.join(supportDirectory, 'windows_desktop_updater.log');
+    }
+
+    return path.join(
+      Directory.systemTemp.path,
+      'icarus_windows_desktop_updater.log',
+    );
   }
 
   static List<String> _splitRelativePath(String filePath) {
@@ -207,5 +276,21 @@ try {
     }
 
     return normalized;
+  }
+
+  void _reportInfoSafely(
+    String message, {
+    required String source,
+    Object? error,
+  }) {
+    try {
+      AppErrorReporter.reportInfo(
+        message,
+        source: source,
+        error: error,
+      );
+    } catch (_) {
+      // Logging must never interrupt the update flow.
+    }
   }
 }

--- a/test/windows_desktop_update_controller_test.dart
+++ b/test/windows_desktop_update_controller_test.dart
@@ -125,6 +125,82 @@ void main() {
     expect(controller.downloadProgress, 1);
     expect(requestCounts['icarus.exe'], 2);
   });
+
+  test('downloadUpdate preserves verification errors during cleanup', () async {
+    final installDirectory =
+        await Directory.systemTemp.createTemp('icarus_update_cleanup_');
+    final executablePath = '${installDirectory.path}\\icarus.exe';
+    await File(executablePath).writeAsBytes(utf8.encode('old exe'));
+    addTearDown(() async {
+      if (await installDirectory.exists()) {
+        await installDirectory.delete(recursive: true);
+      }
+    });
+
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() async {
+      await server.close(force: true);
+    });
+
+    final fileBytes = utf8.encode('corrupted payload');
+    server.listen((HttpRequest request) async {
+      request.response.statusCode = HttpStatus.ok;
+      request.response.contentLength = fileBytes.length;
+      request.response.add(fileBytes);
+      await request.response.close();
+    });
+
+    final update = ItemModel(
+      version: '4.0.6+60',
+      shortVersion: 60,
+      changes: <ChangeModel>[
+        ChangeModel(message: 'Cleanup regression test'),
+      ],
+      date: '2026-04-10',
+      mandatory: false,
+      url: 'http://${server.address.host}:${server.port}/updates',
+      platform: 'windows',
+      changedFiles: <FileHashModel>[
+        FileHashModel(
+          filePath: 'icarus.exe',
+          calculatedHash: await _hashBytes(utf8.encode('expected payload')),
+          length: fileBytes.length,
+        ),
+      ],
+      appName: 'Icarus',
+    );
+
+    final controller = WindowsDesktopUpdateController(
+      appArchiveUrl: Uri.parse('https://example.com/app-archive.json'),
+      updater: _FakeDesktopUpdater(
+        executablePath: '$executablePath\u0000',
+        update: update,
+      ),
+      autoCheck: false,
+    );
+    addTearDown(controller.dispose);
+
+    await controller.checkVersion();
+
+    await expectLater(
+      controller.downloadUpdate(),
+      throwsA(
+        isA<FileSystemException>().having(
+          (error) => error.message,
+          'message',
+          contains('hash mismatch'),
+        ),
+      ),
+    );
+
+    expect(
+      await Directory('${installDirectory.path}${Platform.pathSeparator}update')
+          .exists(),
+      isFalse,
+    );
+    expect(controller.isDownloaded, isFalse);
+    expect(controller.downloadProgress, 0);
+  });
 }
 
 class _FakeDesktopUpdater extends DesktopUpdater {

--- a/test/windows_desktop_update_restart_service_test.dart
+++ b/test/windows_desktop_update_restart_service_test.dart
@@ -7,6 +7,8 @@ void main() {
       executablePath: "C:\\Users\\Alice\\App's\\Icarus\\icarus.exe\u0000",
       installDirectory: r"C:\Users\Alice\App's\Icarus",
       updateDirectory: r"C:\Users\Alice\App's\Icarus\update",
+      logPath:
+          r"C:\Users\Alice\AppData\Roaming\Icarus\windows_desktop_updater.log",
       processId: 4242,
     );
 
@@ -23,6 +25,12 @@ void main() {
     expect(
       script,
       contains(r"$updateDirectory = 'C:\Users\Alice\App''s\Icarus\update'"),
+    );
+    expect(
+      script,
+      contains(
+        r"$logPath = 'C:\Users\Alice\AppData\Roaming\Icarus\windows_desktop_updater.log'",
+      ),
     );
     expect(
       script,
@@ -62,6 +70,22 @@ void main() {
         r'Remove-Item -LiteralPath $scriptPath -Force -ErrorAction SilentlyContinue',
       ),
     );
+    expect(script, contains('function Write-Log {'));
+    expect(
+        script,
+        contains(
+            r'Write-Log "Updater script started. scriptPath=$scriptPath"'));
+    expect(script,
+        contains(r'Write-Log "Updated executable launch command issued."'));
+    expect(script, contains(r'Write-Log ("ERROR: " + $_.Exception.Message)'));
+    expect(
+        script,
+        contains(
+            r'Write-Log "Preserving updater script for inspection at $scriptPath"'));
+    expect(
+        script,
+        contains(
+            r'Write-Log "Updater script exiting. deleteScriptOnExit=$deleteScriptOnExit"'));
     expect(script, isNot(contains(r'xcopy /E /I /Y "update\*" "."')));
   });
 


### PR DESCRIPTION
## Summary
- harden Windows desktop update downloads so staged files are fully closed before cleanup runs
- retry and soften staged update directory cleanup so transient file locks do not mask the real failure
- add updater logging and focused regression tests for download cleanup and restart script behavior

## Test plan
- [x] `fvm flutter test test/windows_desktop_update_controller_test.dart test/windows_desktop_update_restart_service_test.dart`
- [ ] Verify the Windows auto-update flow manually from a prerelease build