### PR TITLE
Fix prerelease updater channel detection

### DIFF
--- a/lib/const/settings.dart
+++ b/lib/const/settings.dart
@@ -8,10 +8,29 @@ const String kUpdateChannel = String.fromEnvironment(
   'ICARUS_UPDATE_CHANNEL',
   defaultValue: 'stable',
 );
+final String kResolvedUpdateChannel = normalizeUpdateChannel(kUpdateChannel);
+
+String normalizeUpdateChannel(String channel) {
+  switch (channel.trim().toLowerCase()) {
+    case 'prerelease':
+    case 'pre-release':
+    case 'pre_release':
+      return 'prerelease';
+    case 'stable':
+    default:
+      return 'stable';
+  }
+}
+
+String updateChannelLabel(String channel) {
+  return switch (normalizeUpdateChannel(channel)) {
+    'prerelease' => 'Pre-release',
+    _ => 'Stable',
+  };
+}
 
 Uri buildDesktopUpdaterArchiveUrl(String channel) {
-  final trimmedChannel = channel.trim();
-  final resolvedChannel = trimmedChannel.isEmpty ? 'stable' : trimmedChannel;
+  final resolvedChannel = normalizeUpdateChannel(channel);
   return Uri.parse(
     "https://sunkenintime.github.io/icarus/updates/windows/$resolvedChannel/app-archive.json",
   );
@@ -66,7 +85,7 @@ class Settings {
   static const int versionNumber = 65;
   static const String versionName = "4.2.2";
   static final Uri desktopUpdaterArchiveUrl =
-      buildDesktopUpdaterArchiveUrl(kUpdateChannel);
+      buildDesktopUpdaterArchiveUrl(kResolvedUpdateChannel);
 
   static const double sideBarContentWidth = 325;
   static const double sideBarPanelWidth = sideBarContentWidth + 20;

--- a/lib/services/app_error_reporter.dart
+++ b/lib/services/app_error_reporter.dart
@@ -173,6 +173,12 @@ class AppErrorReporter {
       ..writeln('Icarus Debug Report')
       ..writeln('Generated: ${formatDebugLogTimestamp(DateTime.now())}')
       ..writeln(
+        'Update channel: '
+        '${updateChannelLabel(kResolvedUpdateChannel)} ($kResolvedUpdateChannel)',
+      )
+      ..writeln(
+          'Desktop updater manifest: ${Settings.desktopUpdaterArchiveUrl}')
+      ..writeln(
         'Application support directory: '
         '${_applicationSupportDirectoryPath ?? 'Unavailable'}',
       );

--- a/lib/widgets/dialogs/in_app_debug_dialog.dart
+++ b/lib/widgets/dialogs/in_app_debug_dialog.dart
@@ -15,11 +15,12 @@ class InAppDebugDialog extends ConsumerWidget {
     final supportDirectory =
         AppErrorReporter.applicationSupportDirectoryPath ?? 'Unavailable';
     final persistedLogPath = AppErrorReporter.persistedLogPath;
+    final updateChannel = updateChannelLabel(kResolvedUpdateChannel);
 
     return ShadDialog(
-      title: const Text('In-App Debug Logs'),
-      description: const Text(
-        'Use Copy to send the latest debug report.',
+      title: Text('In-App Debug Logs ($updateChannel Channel)'),
+      description: Text(
+        'Use Copy to send the latest debug report. Current channel: $updateChannel.',
       ),
       constraints: const BoxConstraints(maxWidth: 720, maxHeight: 620),
       actions: [
@@ -124,6 +125,24 @@ class _RuntimeInfoCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
+          SelectableText(
+            'Update channel: ${updateChannelLabel(kResolvedUpdateChannel)} ($kResolvedUpdateChannel)',
+            style: const TextStyle(
+              fontFamily: 'Consolas',
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          SelectableText(
+            'Desktop updater manifest: ${Settings.desktopUpdaterArchiveUrl}',
+            style: const TextStyle(
+              fontFamily: 'Consolas',
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
           SelectableText(
             'Support directory: $supportDirectory',
             style: const TextStyle(

--- a/lib/widgets/folder_navigator.dart
+++ b/lib/widgets/folder_navigator.dart
@@ -190,7 +190,7 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
             !kIsWeb && Platform.isWindows && !result.isSupported;
         if (isDirectWindowsInstall && _desktopUpdaterController == null) {
           debugPrint(
-            'Desktop updater channel: $kUpdateChannel | Manifest: ${Settings.desktopUpdaterArchiveUrl}',
+            'Desktop updater channel: $kResolvedUpdateChannel | Manifest: ${Settings.desktopUpdaterArchiveUrl}',
           );
           _desktopUpdaterController = WindowsDesktopUpdateController(
             appArchiveUrl: Settings.desktopUpdaterArchiveUrl,

--- a/test/settings_update_channel_test.dart
+++ b/test/settings_update_channel_test.dart
@@ -20,8 +20,29 @@ void main() {
     );
   });
 
+  test('buildDesktopUpdaterArchiveUrl normalizes pre-release alias', () {
+    final uri = buildDesktopUpdaterArchiveUrl('pre-release');
+
+    expect(
+      uri.toString(),
+      'https://sunkenintime.github.io/icarus/updates/windows/prerelease/app-archive.json',
+    );
+  });
+
+  test('normalizeUpdateChannel resolves prerelease aliases', () {
+    expect(normalizeUpdateChannel('prerelease'), 'prerelease');
+    expect(normalizeUpdateChannel('pre-release'), 'prerelease');
+    expect(normalizeUpdateChannel('pre_release'), 'prerelease');
+  });
+
+  test('updateChannelLabel returns stable and prerelease labels', () {
+    expect(updateChannelLabel('stable'), 'Stable');
+    expect(updateChannelLabel('pre-release'), 'Pre-release');
+  });
+
   test('default update channel remains stable', () {
     expect(kUpdateChannel, 'stable');
+    expect(kResolvedUpdateChannel, 'stable');
     expect(
       Settings.desktopUpdaterArchiveUrl,
       buildDesktopUpdaterArchiveUrl('stable'),


### PR DESCRIPTION
## Summary
- normalize desktop update channel values so prerelease aliases resolve to the prerelease manifest
- show the active update channel and manifest URL in the F12 debug dialog and copied debug report
- use the resolved channel in desktop updater diagnostics and add focused channel-resolution tests

## Validation
- fvm flutter test test/settings_update_channel_test.dart
- fvm flutter analyze *(reports 4 pre-existing info-level lints in test/square_icon_counter_rotation_test.dart)*