### PR TITLE
Add Actions token auth for desktop Pages publish

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Run Desktop Release Script
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $args = @(
             "-ExecutionPolicy", "Bypass",

--- a/scripts/publish_pages_branch.ps1
+++ b/scripts/publish_pages_branch.ps1
@@ -22,6 +22,11 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($remoteUrl)) {
     throw "Could not resolve git remote URL for '$Remote'."
 }
 
+$remoteUri = $null
+if ($remoteUrl -match '^https://') {
+    $remoteUri = [System.Uri]$remoteUrl
+}
+
 $versionInfo = Get-VersionInfo -RepoRoot $repoRoot
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("icarus-pages-" + [System.Guid]::NewGuid().ToString("N"))
 
@@ -30,6 +35,21 @@ New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
 try {
     Invoke-RepoCommand -WorkingDirectory $tempRoot -Command "git" -Arguments @("init")
     Invoke-RepoCommand -WorkingDirectory $tempRoot -Command "git" -Arguments @("remote", "add", $Remote, $remoteUrl)
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN) -and $null -ne $remoteUri) {
+        $tokenBytes = [System.Text.Encoding]::ASCII.GetBytes("x-access-token:$($env:GITHUB_TOKEN)")
+        $tokenHeader = "AUTHORIZATION: basic {0}" -f [System.Convert]::ToBase64String($tokenBytes)
+        Push-Location $tempRoot
+        try {
+            & git config ("http.https://{0}/.extraheader" -f $remoteUri.Host) $tokenHeader
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to configure authenticated git access for $($remoteUri.Host)."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
 
     $branchExists = $false
     $branchProbe = & git -C $repoRoot ls-remote --heads $Remote $Branch 2>$null


### PR DESCRIPTION
## Summary
- pass the built-in `GITHUB_TOKEN` into the desktop release workflow step
- configure authenticated HTTPS git access in the temporary gh-pages publishing repo without storing the token in the remote URL
- keep the token out of command logs while setting up git auth

## Testing
- not run locally; intended to be verified by rerunning the Release Desktop workflow