### PR TITLE
Write release JSON as UTF-8 and log desktop update failures

### DIFF
--- a/lib/services/windows_desktop_update_controller.dart
+++ b/lib/services/windows_desktop_update_controller.dart
@@ -94,6 +94,13 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
       );
 
       if (versionResponse == null) {
+        _reportInfoSafely(
+          'No desktop update detected.',
+          source: 'WindowsDesktopUpdateController.checkVersion',
+          error: <String, Object?>{
+            'appArchiveUrl': _appArchiveUrl.toString(),
+          },
+        );
         return;
       }
 
@@ -119,7 +126,16 @@ class WindowsDesktopUpdateController extends ChangeNotifier {
         },
       );
       notifyListeners();
-    } catch (_) {
+    } catch (error, stackTrace) {
+      _reportInfoSafely(
+        'Desktop update check failed.',
+        source: 'WindowsDesktopUpdateController.checkVersion',
+        error: <String, Object?>{
+          'appArchiveUrl': _appArchiveUrl.toString(),
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        },
+      );
       // Leave the direct installer updater silent if the remote metadata fails.
     }
   }

--- a/release/metadata/4.3.3+87.json
+++ b/release/metadata/4.3.3+87.json
@@ -55,7 +55,7 @@
                         "type":  "improvement"
                     },
                     {
-                        "message":  "Online is coming soon\u2122.",
+                        "message":  "Online is coming soon.",
                         "type":  "other"
                     }
                 ]

--- a/scripts/build_desktop_release.ps1
+++ b/scripts/build_desktop_release.ps1
@@ -62,7 +62,7 @@ if (-not (Test-Path $metadataPath)) {
         )
     }
 
-    $metadata | ConvertTo-Json -Depth 6 | Set-Content -Path $metadataPath
+    Write-JsonFileUtf8 -Value $metadata -Path $metadataPath -Depth 6
     Write-Host "Created release metadata at $metadataPath"
 }
 else {
@@ -73,7 +73,7 @@ else {
 
     if ($missingChannels.Count -gt 0) {
         $metadata.channels = @($channels + $missingChannels)
-        $metadata | ConvertTo-Json -Depth 6 | Set-Content -Path $metadataPath
+        Write-JsonFileUtf8 -Value $metadata -Path $metadataPath -Depth 6
         Write-Host ("Updated release metadata channels at {0}: {1}" -f $metadataPath, ($metadata.channels -join ", "))
     }
 }

--- a/scripts/build_store_release.ps1
+++ b/scripts/build_store_release.ps1
@@ -43,6 +43,6 @@ $packageInfo = [ordered]@{
     sourcePath = $primaryPackage.FullName
 }
 
-$packageInfo | ConvertTo-Json -Depth 4 | Set-Content -Path (Join-Path $outputRoot "package-info.json")
+Write-JsonFileUtf8 -Value $packageInfo -Path (Join-Path $outputRoot "package-info.json") -Depth 4
 
 Write-Host "Store package staged at $stagedPackagePath" -ForegroundColor Green

--- a/scripts/common_release.ps1
+++ b/scripts/common_release.ps1
@@ -101,3 +101,22 @@ function Invoke-RepoCommand {
         Pop-Location
     }
 }
+
+function Write-JsonFileUtf8 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Value,
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter()]
+        [int]$Depth = 8
+    )
+
+    $json = $Value | ConvertTo-Json -Depth $Depth
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText(
+        [System.IO.Path]::GetFullPath($Path),
+        $json + [System.Environment]::NewLine,
+        $utf8NoBom
+    )
+}

--- a/scripts/generate_update_manifest.ps1
+++ b/scripts/generate_update_manifest.ps1
@@ -97,5 +97,5 @@ $manifest = [ordered]@{
     items = @($sortedItems)
 }
 
-$manifest | ConvertTo-Json -Depth 8 | Set-Content -Path $OutputPath
+Write-JsonFileUtf8 -Value $manifest -Path $OutputPath -Depth 8
 Write-Host "Generated desktop updater manifest at $OutputPath" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Adds a shared PowerShell helper to write JSON files as UTF-8 without BOM, then uses it across desktop release and manifest generation scripts.
- Updates release metadata generation and store packaging outputs to use the new UTF-8 writer.
- Improves Windows desktop update checks by logging missing metadata and caught failures with context instead of silently swallowing them.
- Removes the trademark symbol from the online status copy in the release metadata.

## Testing
- Not run (not requested).
- Reviewed the PowerShell scripts for the new UTF-8 JSON write path.
- Reviewed the Windows update controller change to confirm failures now report source, archive URL, and exception details.