### PR TITLE
Add strategy and folder pinning

### DIFF
--- a/lib/const/hive_boxes.dart
+++ b/lib/const/hive_boxes.dart
@@ -4,4 +4,5 @@ class HiveBoxNames {
   static const mapThemeProfilesBox = "map_theme_profiles_box";
   static const appPreferencesBox = "app_preferences_box";
   static const favoriteAgentsBox = "favorite_agents_box";
+  static const pinnedItemsBox = "pinned_items_box";
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,6 +79,7 @@ Future<void> main(List<String> args) async {
       await Hive.openBox<MapThemeProfile>(HiveBoxNames.mapThemeProfilesBox);
       await Hive.openBox<AppPreferences>(HiveBoxNames.appPreferencesBox);
       await Hive.openBox<bool>(HiveBoxNames.favoriteAgentsBox);
+      await Hive.openBox<int>(HiveBoxNames.pinnedItemsBox);
 
       await MapThemeProfilesProvider.bootstrap();
 

--- a/lib/providers/folder_provider.dart
+++ b/lib/providers/folder_provider.dart
@@ -4,6 +4,7 @@ import 'package:hive_ce_flutter/adapters.dart';
 import 'package:icarus/const/custom_icons.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:uuid/uuid.dart';
 
@@ -174,6 +175,7 @@ class FolderProvider extends Notifier<String?> {
   }
 
   void deleteFolder(String folderID) async {
+    await ref.read(pinnedItemsProvider.notifier).removePin(folderID);
     // state = state.where((folder) => folder.id != folderID).toList();
 
     final strategyList =

--- a/lib/providers/pinned_items_provider.dart
+++ b/lib/providers/pinned_items_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:icarus/const/hive_boxes.dart';
+
+final pinnedItemsProvider =
+    NotifierProvider<PinnedItemsProvider, Map<String, int>>(
+        PinnedItemsProvider.new);
+
+/// Tracks which strategies/folders are pinned to the home screen.
+///
+/// Stored as a Hive box keyed by the item's id, with the pin timestamp
+/// (milliseconds since epoch) as the value. The timestamp gives us ordering.
+/// State is a `Map<String, int>` of id -> pinnedAt.
+class PinnedItemsProvider extends Notifier<Map<String, int>> {
+  Box<int> get _box => Hive.box<int>(HiveBoxNames.pinnedItemsBox);
+
+  @override
+  Map<String, int> build() {
+    return _readFromBox();
+  }
+
+  bool isPinned(String id) => state.containsKey(id);
+
+  /// Pinned ids, most recently pinned first.
+  List<String> pinnedIdsByRecency() {
+    final entries = state.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return entries.map((e) => e.key).toList();
+  }
+
+  Future<void> togglePin(String id) async {
+    if (isPinned(id)) {
+      await removePin(id);
+      return;
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _box.put(id, now);
+    state = {...state, id: now};
+  }
+
+  Future<void> removePin(String id) async {
+    if (!isPinned(id)) return;
+    await _box.delete(id);
+    state = {...state}..remove(id);
+  }
+
+  Map<String, int> _readFromBox() {
+    final result = <String, int>{};
+    for (final key in _box.keys) {
+      if (key is! String) continue; // resilient to stale/invalid keys
+      final value = _box.get(key);
+      if (value == null) continue;
+      result[key] = value;
+    }
+    return result;
+  }
+}

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -27,6 +27,7 @@ import 'package:icarus/providers/agent_provider.dart';
 import 'package:icarus/providers/auto_save_notifier.dart';
 import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/folder_provider.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:icarus/providers/favorite_agents_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
@@ -3561,6 +3562,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> deleteStrategy(String strategyID) async {
+    await ref.read(pinnedItemsProvider.notifier).removePin(strategyID);
     await Hive.box<StrategyData>(HiveBoxNames.strategiesBox).delete(strategyID);
 
     final directory = await getApplicationSupportDirectory();

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -12,6 +12,7 @@ import 'package:icarus/widgets/custom_search_field.dart';
 import 'package:icarus/widgets/ica_drop_target.dart';
 import 'package:icarus/widgets/dot_painter.dart';
 import 'package:icarus/widgets/folder_pill.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 // ... your existing imports
 
@@ -171,8 +172,44 @@ class FolderContent extends ConsumerWidget {
                         folders.sort(
                             (a, b) => a.dateCreated.compareTo(b.dateCreated));
 
+                        // Pinned section is only shown at the home/root screen.
+                        final isRoot = folder == null;
+                        final pinned = ref.watch(pinnedItemsProvider);
+                        final pinnedIds = ref
+                            .read(pinnedItemsProvider.notifier)
+                            .pinnedIdsByRecency();
+
+                        List<StrategyData> pinnedStrategies = [];
+                        List<Folder> pinnedFolders = [];
+                        if (isRoot && pinned.isNotEmpty) {
+                          final allStrategies = strategyBox.values.toList();
+                          final allFolders = folderBox.values.toList();
+                          final strategyById = {
+                            for (final s in allStrategies) s.id: s
+                          };
+                          final folderById = {
+                            for (final f in allFolders) f.id: f
+                          };
+
+                          for (final id in pinnedIds) {
+                            final s = strategyById[id];
+                            if (s != null) {
+                              pinnedStrategies.add(s);
+                              continue;
+                            }
+                            final f = folderById[id];
+                            if (f != null) pinnedFolders.add(f);
+                          }
+
+                          strategies.removeWhere((s) => pinned.containsKey(s.id));
+                          folders.removeWhere((f) => pinned.containsKey(f.id));
+                        }
+
                         // Check if both folders and strategies are empty
-                        if (folders.isEmpty && strategies.isEmpty) {
+                        if (folders.isEmpty &&
+                            strategies.isEmpty &&
+                            pinnedFolders.isEmpty &&
+                            pinnedStrategies.isEmpty) {
                           return const IcaDropTarget(
                             child: Center(
                               child: Column(
@@ -205,6 +242,59 @@ class FolderContent extends ConsumerWidget {
 
                             return CustomScrollView(
                               slivers: [
+                                if (pinnedFolders.isNotEmpty ||
+                                    pinnedStrategies.isNotEmpty) ...[
+                                  const SliverToBoxAdapter(
+                                    child: Padding(
+                                      padding: EdgeInsets.fromLTRB(16, 16, 16, 4),
+                                      child: Text(
+                                        'Pinned',
+                                        style: TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  if (pinnedFolders.isNotEmpty)
+                                    SliverToBoxAdapter(
+                                      child: Padding(
+                                        padding: const EdgeInsets.fromLTRB(
+                                            16, 4, 16, 8),
+                                        child: Wrap(
+                                          spacing: 10,
+                                          runSpacing: 10,
+                                          children: pinnedFolders
+                                              .map((f) => FolderPill(folder: f))
+                                              .toList(),
+                                        ),
+                                      ),
+                                    ),
+                                  if (pinnedStrategies.isNotEmpty)
+                                    SliverPadding(
+                                      padding: const EdgeInsets.fromLTRB(
+                                          16, 4, 16, 8),
+                                      sliver: SliverGrid(
+                                        gridDelegate:
+                                            SliverGridDelegateWithFixedCrossAxisCount(
+                                          crossAxisCount: crossAxisCount,
+                                          mainAxisExtent: 250,
+                                          crossAxisSpacing: 20,
+                                          mainAxisSpacing: 20,
+                                        ),
+                                        delegate: SliverChildBuilderDelegate(
+                                          (context, index) => StrategyTile(
+                                            strategyData:
+                                                pinnedStrategies[index],
+                                          ),
+                                          childCount: pinnedStrategies.length,
+                                        ),
+                                      ),
+                                    ),
+                                  const SliverToBoxAdapter(
+                                    child: Divider(indent: 16, endIndent: 16),
+                                  ),
+                                ],
                                 // Folder pills section (wrap row)
                                 if (folders.isNotEmpty)
                                   SliverToBoxAdapter(

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -172,25 +172,25 @@ class FolderContent extends ConsumerWidget {
                         folders.sort(
                             (a, b) => a.dateCreated.compareTo(b.dateCreated));
 
-                        // Pinned section is only shown at the home/root screen.
+                        // At the home/root screen (and only when not searching),
+                        // pinned items — which may live in any folder — float to
+                        // the top of the normal lists. They render exactly like
+                        // every other tile/pill, just ordered first.
                         final isRoot = folder == null;
                         final pinned = ref.watch(pinnedItemsProvider);
-                        final pinnedIds = ref
-                            .read(pinnedItemsProvider.notifier)
-                            .pinnedIdsByRecency();
-
-                        List<StrategyData> pinnedStrategies = [];
-                        List<Folder> pinnedFolders = [];
-                        if (isRoot && pinned.isNotEmpty) {
-                          final allStrategies = strategyBox.values.toList();
-                          final allFolders = folderBox.values.toList();
+                        if (isRoot && pinned.isNotEmpty && search.isEmpty) {
+                          final pinnedIds = ref
+                              .read(pinnedItemsProvider.notifier)
+                              .pinnedIdsByRecency();
                           final strategyById = {
-                            for (final s in allStrategies) s.id: s
+                            for (final s in strategyBox.values) s.id: s
                           };
                           final folderById = {
-                            for (final f in allFolders) f.id: f
+                            for (final f in folderBox.values) f.id: f
                           };
 
+                          final pinnedStrategies = <StrategyData>[];
+                          final pinnedFolders = <Folder>[];
                           for (final id in pinnedIds) {
                             final s = strategyById[id];
                             if (s != null) {
@@ -201,15 +201,16 @@ class FolderContent extends ConsumerWidget {
                             if (f != null) pinnedFolders.add(f);
                           }
 
+                          // Remove pinned items from their normal position, then
+                          // re-insert at the front so they sort to the top.
                           strategies.removeWhere((s) => pinned.containsKey(s.id));
                           folders.removeWhere((f) => pinned.containsKey(f.id));
+                          strategies.insertAll(0, pinnedStrategies);
+                          folders.insertAll(0, pinnedFolders);
                         }
 
                         // Check if both folders and strategies are empty
-                        if (folders.isEmpty &&
-                            strategies.isEmpty &&
-                            pinnedFolders.isEmpty &&
-                            pinnedStrategies.isEmpty) {
+                        if (folders.isEmpty && strategies.isEmpty) {
                           return const IcaDropTarget(
                             child: Center(
                               child: Column(
@@ -242,92 +243,6 @@ class FolderContent extends ConsumerWidget {
 
                             return CustomScrollView(
                               slivers: [
-                                if (pinnedFolders.isNotEmpty ||
-                                    pinnedStrategies.isNotEmpty) ...[
-                                  SliverToBoxAdapter(
-                                    child: Padding(
-                                      padding: const EdgeInsets.fromLTRB(
-                                          16, 16, 16, 4),
-                                      child: Row(
-                                        children: [
-                                          Icon(
-                                            Icons.push_pin,
-                                            size: 18,
-                                            color: Settings
-                                                .tacticalVioletTheme.primary,
-                                          ),
-                                          const SizedBox(width: 6),
-                                          Text(
-                                            'Pinned',
-                                            style: TextStyle(
-                                              fontSize: 18,
-                                              fontWeight: FontWeight.w700,
-                                              color: Settings
-                                                  .tacticalVioletTheme.primary,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
-                                  if (pinnedFolders.isNotEmpty)
-                                    SliverToBoxAdapter(
-                                      child: Padding(
-                                        padding: const EdgeInsets.fromLTRB(
-                                            16, 4, 16, 8),
-                                        child: Wrap(
-                                          spacing: 10,
-                                          runSpacing: 10,
-                                          children: pinnedFolders
-                                              .map((f) => FolderPill(folder: f))
-                                              .toList(),
-                                        ),
-                                      ),
-                                    ),
-                                  if (pinnedStrategies.isNotEmpty)
-                                    SliverPadding(
-                                      padding: const EdgeInsets.fromLTRB(
-                                          16, 4, 16, 8),
-                                      sliver: SliverGrid(
-                                        gridDelegate:
-                                            SliverGridDelegateWithFixedCrossAxisCount(
-                                          crossAxisCount: crossAxisCount,
-                                          mainAxisExtent: 250,
-                                          crossAxisSpacing: 20,
-                                          mainAxisSpacing: 20,
-                                        ),
-                                        delegate: SliverChildBuilderDelegate(
-                                          (context, index) => StrategyTile(
-                                            strategyData:
-                                                pinnedStrategies[index],
-                                          ),
-                                          childCount: pinnedStrategies.length,
-                                        ),
-                                      ),
-                                    ),
-                                  const SliverToBoxAdapter(
-                                    child: Divider(indent: 16, endIndent: 16),
-                                  ),
-                                  // Header for the normal (un-pinned) section,
-                                  // shown only alongside the Pinned section so
-                                  // the two read as distinct groups.
-                                  if (folders.isNotEmpty || strategies.isNotEmpty)
-                                    SliverToBoxAdapter(
-                                      child: Padding(
-                                        padding: const EdgeInsets.fromLTRB(
-                                            16, 8, 16, 4),
-                                        child: Text(
-                                          'All',
-                                          style: TextStyle(
-                                            fontSize: 18,
-                                            fontWeight: FontWeight.w700,
-                                            color: Settings
-                                                .tacticalVioletTheme.foreground,
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                ],
                                 // Folder pills section (wrap row)
                                 if (folders.isNotEmpty)
                                   SliverToBoxAdapter(

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -244,15 +244,29 @@ class FolderContent extends ConsumerWidget {
                               slivers: [
                                 if (pinnedFolders.isNotEmpty ||
                                     pinnedStrategies.isNotEmpty) ...[
-                                  const SliverToBoxAdapter(
+                                  SliverToBoxAdapter(
                                     child: Padding(
-                                      padding: EdgeInsets.fromLTRB(16, 16, 16, 4),
-                                      child: Text(
-                                        'Pinned',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.w600,
-                                        ),
+                                      padding: const EdgeInsets.fromLTRB(
+                                          16, 16, 16, 4),
+                                      child: Row(
+                                        children: [
+                                          Icon(
+                                            Icons.push_pin,
+                                            size: 18,
+                                            color: Settings
+                                                .tacticalVioletTheme.primary,
+                                          ),
+                                          const SizedBox(width: 6),
+                                          Text(
+                                            'Pinned',
+                                            style: TextStyle(
+                                              fontSize: 18,
+                                              fontWeight: FontWeight.w700,
+                                              color: Settings
+                                                  .tacticalVioletTheme.primary,
+                                            ),
+                                          ),
+                                        ],
                                       ),
                                     ),
                                   ),
@@ -294,6 +308,25 @@ class FolderContent extends ConsumerWidget {
                                   const SliverToBoxAdapter(
                                     child: Divider(indent: 16, endIndent: 16),
                                   ),
+                                  // Header for the normal (un-pinned) section,
+                                  // shown only alongside the Pinned section so
+                                  // the two read as distinct groups.
+                                  if (folders.isNotEmpty || strategies.isNotEmpty)
+                                    SliverToBoxAdapter(
+                                      child: Padding(
+                                        padding: const EdgeInsets.fromLTRB(
+                                            16, 8, 16, 4),
+                                        child: Text(
+                                          'All',
+                                          style: TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.w700,
+                                            color: Settings
+                                                .tacticalVioletTheme.foreground,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
                                 ],
                                 // Folder pills section (wrap row)
                                 if (folders.isNotEmpty)

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -14,7 +14,7 @@ import 'package:icarus/widgets/dot_painter.dart';
 import 'package:icarus/widgets/folder_pill.dart';
 import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
-// ... your existing imports
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 class FolderContent extends ConsumerWidget {
   FolderContent({super.key, this.folder});

--- a/lib/widgets/folder_pill.dart
+++ b/lib/widgets/folder_pill.dart
@@ -5,6 +5,7 @@ import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
 import 'package:icarus/widgets/folder_edit_dialog.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class FolderPill extends ConsumerStatefulWidget {
@@ -191,7 +192,17 @@ class _FolderPillState extends ConsumerState<FolderPill>
   }
 
   List<ShadContextMenuItem> _buildMenuItems() {
+    final isPinned =
+        ref.watch(pinnedItemsProvider).containsKey(widget.folder.id);
     return [
+      ShadContextMenuItem(
+        leading: Icon(isPinned ? Icons.push_pin : Icons.push_pin_outlined),
+        child: Text(isPinned ? 'Unpin' : 'Pin'),
+        onPressed: () {
+          if (widget.isDemo) return;
+          ref.read(pinnedItemsProvider.notifier).togglePin(widget.folder.id);
+        },
+      ),
       ShadContextMenuItem(
         leading: const Icon(Icons.text_fields),
         child: const Text('Edit'),

--- a/lib/widgets/strategy_tile/strategy_tile.dart
+++ b/lib/widgets/strategy_tile/strategy_tile.dart
@@ -10,6 +10,7 @@ import 'package:icarus/widgets/dialogs/strategy/delete_strategy_alert_dialog.dar
 import 'package:icarus/widgets/dialogs/strategy/rename_strategy_dialog.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
 import 'package:icarus/widgets/strategy_tile/strategy_tile_sections.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class StrategyTile extends ConsumerStatefulWidget {
@@ -116,7 +117,16 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
   }
 
   List<ShadContextMenuItem> _buildMenuItems() {
+    final isPinned =
+        ref.watch(pinnedItemsProvider).containsKey(widget.strategyData.id);
     return [
+      ShadContextMenuItem(
+        leading: Icon(isPinned ? Icons.push_pin : Icons.push_pin_outlined),
+        child: Text(isPinned ? 'Unpin' : 'Pin'),
+        onPressed: () => ref
+            .read(pinnedItemsProvider.notifier)
+            .togglePin(widget.strategyData.id),
+      ),
       ShadContextMenuItem(
         leading: const Icon(LucideIcons.pencil),
         child: const Text('Rename'),

--- a/test/pinned_items_provider_test.dart
+++ b/test/pinned_items_provider_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:icarus/const/hive_boxes.dart';
+import 'package:icarus/providers/pinned_items_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late ProviderContainer container;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('icarus-pins-');
+    Hive.init(tempDir.path);
+    await Hive.openBox<int>(HiveBoxNames.pinnedItemsBox);
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('pinning an id makes it pinned, toggling again unpins', () async {
+    final notifier = container.read(pinnedItemsProvider.notifier);
+
+    expect(notifier.isPinned('a'), false);
+
+    await notifier.togglePin('a');
+    expect(notifier.isPinned('a'), true);
+
+    await notifier.togglePin('a');
+    expect(notifier.isPinned('a'), false);
+  });
+
+  test('pinnedIdsByRecency returns most-recently-pinned first', () async {
+    final notifier = container.read(pinnedItemsProvider.notifier);
+
+    await notifier.togglePin('first');
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    await notifier.togglePin('second');
+
+    expect(notifier.pinnedIdsByRecency(), ['second', 'first']);
+  });
+
+  test('removePin is a no-op when the id is not pinned', () async {
+    final notifier = container.read(pinnedItemsProvider.notifier);
+
+    await notifier.removePin('missing'); // should not throw
+    expect(notifier.isPinned('missing'), false);
+  });
+}


### PR DESCRIPTION
## Summary
Original pinning PR. I attempted to push the manual pinned-order follow-up directly here, but the fork branch `njiedev/icarus:feature/strategy-pinning` rejected maintainer writes with 403 from my environment.

Manual pinned ordering is available in follow-up PR #77 from `SunkenInTime/icarus:devin/manual-pinned-order`: new pins enter at the top, pinned items ignore the app’s normal ordering while pinned, and users can reorder pins via `Move Pin to Top`, `Move Pin Up`, and `Move Pin Down`.

Link to Devin session: https://app.devin.ai/sessions/026effa9989f4a9c9d8ef2da902bc575
Requested by: @SunkenInTime