### PR TITLE
[codex] Add registry-backed folder icons

### DIFF
--- a/lib/const/folder_icons.dart
+++ b/lib/const/folder_icons.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:icarus/const/custom_icons.dart';
+
+const int folderIconRegistryVersion = 91;
+
+enum FolderIconRenderKind {
+  material,
+  asset,
+}
+
+class FolderIconDefinition {
+  const FolderIconDefinition.material({
+    required this.id,
+    required IconData icon,
+    this.hiddenFromPicker = false,
+  })  : kind = FolderIconRenderKind.material,
+        iconData = icon,
+        assetPath = null;
+
+  const FolderIconDefinition.asset({
+    required this.id,
+    required this.assetPath,
+    this.hiddenFromPicker = false,
+  })  : kind = FolderIconRenderKind.asset,
+        iconData = null,
+        assert(assetPath != null);
+
+  final int id;
+  final FolderIconRenderKind kind;
+  final IconData? iconData;
+  final String? assetPath;
+  final bool hiddenFromPicker;
+
+  String get stableSignature {
+    final icon = iconData;
+    if (icon != null) {
+      return [
+        'material',
+        icon.codePoint,
+        icon.fontFamily ?? '',
+        icon.fontPackage ?? '',
+        icon.matchTextDirection,
+        icon.fontFamilyFallback?.join(',') ?? '',
+      ].join('|');
+    }
+    return 'asset|$assetPath';
+  }
+}
+
+class FolderIconRegistry {
+  FolderIconRegistry._();
+
+  static const int legacyFolderId = 0;
+  static const int defaultId = 1;
+  static const int controllerRoleId = 1000;
+  static const int duelistRoleId = 1001;
+  static const int initiatorRoleId = 1002;
+  static const int sentinelRoleId = 1003;
+
+  static const List<FolderIconDefinition> entries = [
+    FolderIconDefinition.material(
+      id: legacyFolderId,
+      icon: Icons.folder,
+      hiddenFromPicker: true,
+    ),
+    FolderIconDefinition.material(id: 1, icon: Icons.star_rate_rounded),
+    FolderIconDefinition.material(id: 2, icon: Icons.ac_unit_sharp),
+    FolderIconDefinition.material(id: 3, icon: Icons.bug_report),
+    FolderIconDefinition.material(id: 4, icon: Icons.cake),
+    FolderIconDefinition.material(id: 5, icon: Icons.code),
+    FolderIconDefinition.material(id: 6, icon: Icons.add_shopping_cart_rounded),
+    FolderIconDefinition.material(id: 7, icon: Icons.airline_stops_sharp),
+    FolderIconDefinition.material(id: 8, icon: Icons.all_inclusive),
+    FolderIconDefinition.material(id: 9, icon: Icons.api_rounded),
+    FolderIconDefinition.material(id: 10, icon: Icons.drive_folder_upload),
+    FolderIconDefinition.material(id: 11, icon: Icons.folder_shared),
+    FolderIconDefinition.material(id: 12, icon: Icons.folder_special),
+    FolderIconDefinition.material(id: 13, icon: Icons.workspaces),
+    FolderIconDefinition.material(id: 14, icon: Icons.category),
+    FolderIconDefinition.material(id: 15, icon: Icons.collections_bookmark),
+    FolderIconDefinition.material(id: 16, icon: Icons.library_books),
+    FolderIconDefinition.material(id: 17, icon: Icons.archive),
+    FolderIconDefinition.material(id: 18, icon: Icons.assignment),
+    FolderIconDefinition.material(id: 19, icon: Icons.assignment_turned_in),
+    FolderIconDefinition.material(id: 20, icon: Icons.dashboard),
+    FolderIconDefinition.material(id: 21, icon: Icons.anchor),
+    FolderIconDefinition.material(
+        id: 22, icon: Icons.hourglass_bottom_outlined),
+    FolderIconDefinition.material(id: 23, icon: Icons.image_search),
+    FolderIconDefinition.material(id: 24, icon: Icons.view_quilt),
+    FolderIconDefinition.material(id: 25, icon: Icons.map),
+    FolderIconDefinition.material(id: 26, icon: Icons.place),
+    FolderIconDefinition.material(id: 27, icon: Icons.explore),
+    FolderIconDefinition.material(id: 28, icon: Icons.explore_off),
+    FolderIconDefinition.material(id: 29, icon: Icons.flag),
+    FolderIconDefinition.material(id: 30, icon: Icons.outlined_flag),
+    FolderIconDefinition.material(id: 31, icon: Icons.emoji_objects),
+    FolderIconDefinition.material(id: 32, icon: Icons.lightbulb),
+    FolderIconDefinition.material(id: 33, icon: Icons.track_changes),
+    FolderIconDefinition.material(id: 34, icon: Icons.timeline),
+    FolderIconDefinition.material(id: 35, icon: Icons.sports_esports),
+    FolderIconDefinition.material(id: 36, icon: CustomIcons.sword),
+    FolderIconDefinition.material(id: 37, icon: Icons.military_tech),
+    FolderIconDefinition.material(id: 38, icon: Icons.shield),
+    FolderIconDefinition.material(id: 39, icon: Icons.security),
+    FolderIconDefinition.material(id: 40, icon: Icons.bolt),
+    FolderIconDefinition.material(id: 41, icon: Icons.psychology),
+    FolderIconDefinition.asset(
+      id: controllerRoleId,
+      assetPath: 'assets/agents/controller.webp',
+    ),
+    FolderIconDefinition.asset(
+      id: duelistRoleId,
+      assetPath: 'assets/agents/duelist.webp',
+    ),
+    FolderIconDefinition.asset(
+      id: initiatorRoleId,
+      assetPath: 'assets/agents/initiator.webp',
+    ),
+    FolderIconDefinition.asset(
+      id: sentinelRoleId,
+      assetPath: 'assets/agents/sentinel.webp',
+    ),
+  ];
+
+  static final Map<int, FolderIconDefinition> _byId = {
+    for (final entry in entries) entry.id: entry,
+  };
+
+  static final List<FolderIconDefinition> pickerEntries = [
+    for (final entry in entries)
+      if (!entry.hiddenFromPicker) entry,
+  ];
+
+  static FolderIconDefinition resolve(int id) {
+    return _byId[id] ?? _byId[defaultId]!;
+  }
+
+  static bool isKnownId(int id) => _byId.containsKey(id);
+
+  static int idForStoredValue(Object? value) {
+    return switch (value) {
+      final int id => id,
+      final IconData icon => idForLegacyIconData(icon),
+      _ => defaultId,
+    };
+  }
+
+  static int idForLegacyIconData(IconData icon) {
+    return tryIdForLegacyIconData(icon) ?? defaultId;
+  }
+
+  static int? tryIdForLegacyIconData(IconData icon) {
+    for (final entry in entries) {
+      final candidate = entry.iconData;
+      if (candidate != null && _sameIconData(candidate, icon)) {
+        return entry.id;
+      }
+    }
+    return null;
+  }
+
+  static IconData legacyIconDataForId(int id) {
+    return _byId[id]?.iconData ?? _byId[defaultId]!.iconData!;
+  }
+
+  static bool _sameIconData(IconData a, IconData b) {
+    return a.codePoint == b.codePoint &&
+        a.fontFamily == b.fontFamily &&
+        a.fontPackage == b.fontPackage &&
+        a.matchTextDirection == b.matchTextDirection &&
+        _sameFontFamilyFallback(a.fontFamilyFallback, b.fontFamilyFallback);
+  }
+
+  static bool _sameFontFamilyFallback(List<String>? a, List<String>? b) {
+    if (a == null || a.isEmpty) {
+      return b == null || b.isEmpty;
+    }
+    if (b == null || b.length != a.length) {
+      return false;
+    }
+    for (var index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+class FolderIconView extends StatelessWidget {
+  const FolderIconView({
+    super.key,
+    required this.iconId,
+    required this.size,
+    required this.color,
+  });
+
+  final int iconId;
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final definition = FolderIconRegistry.resolve(iconId);
+    final icon = definition.iconData;
+    if (icon != null) {
+      return Icon(
+        icon,
+        color: color,
+        size: size,
+      );
+    }
+
+    return SizedBox.square(
+      dimension: size,
+      child: Image.asset(
+        definition.assetPath!,
+        fit: BoxFit.contain,
+      ),
+    );
+  }
+}

--- a/lib/const/folder_icons.dart
+++ b/lib/const/folder_icons.dart
@@ -15,20 +15,19 @@ class FolderIconDefinition {
     this.hiddenFromPicker = false,
   })  : kind = FolderIconRenderKind.material,
         iconData = icon,
-        assetPath = null;
+        assetPath = '';
 
   const FolderIconDefinition.asset({
     required this.id,
     required this.assetPath,
     this.hiddenFromPicker = false,
   })  : kind = FolderIconRenderKind.asset,
-        iconData = null,
-        assert(assetPath != null);
+        iconData = null;
 
   final int id;
   final FolderIconRenderKind kind;
   final IconData? iconData;
-  final String? assetPath;
+  final String assetPath;
   final bool hiddenFromPicker;
 
   String get stableSignature {
@@ -215,8 +214,10 @@ class FolderIconView extends StatelessWidget {
     return SizedBox.square(
       dimension: size,
       child: Image.asset(
-        definition.assetPath!,
+        definition.assetPath,
         fit: BoxFit.contain,
+        color: color,
+        colorBlendMode: BlendMode.srcIn,
       ),
     );
   }

--- a/lib/const/settings.dart
+++ b/lib/const/settings.dart
@@ -86,8 +86,8 @@ class Settings {
   static final Uri dicordLink = Uri.parse("https://discord.gg/PN2uKwCqYB");
 
   static const Duration autoSaveOffset = Duration(seconds: 15);
-  static const int versionNumber = 90;
-  static const String versionName = "4.3.6";
+  static const int versionNumber = 91;
+  static const String versionName = "4.3.7";
   static final Uri desktopUpdaterArchiveUrl =
       buildDesktopUpdaterArchiveUrl(kResolvedUpdateChannel);
 

--- a/lib/hive/hive_adapters.dart
+++ b/lib/hive/hive_adapters.dart
@@ -8,6 +8,7 @@ import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/bounding_box.dart';
 import 'package:icarus/const/drawing_element.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
@@ -313,7 +314,7 @@ class FolderAdapter extends TypeAdapter<Folder> {
       id: fields[1] as String,
       parentID: fields[2] as String?,
       dateCreated: fields[3] as DateTime,
-      icon: fields[4] as IconData,
+      iconId: FolderIconRegistry.idForStoredValue(fields[4]),
       color: fields[5] as FolderColor? ?? FolderColor.red,
       customColor: switch (fields[6]) {
         final int colorValue => Color(colorValue),
@@ -337,7 +338,7 @@ class FolderAdapter extends TypeAdapter<Folder> {
       ..writeByte(3)
       ..write(obj.dateCreated)
       ..writeByte(4)
-      ..write(obj.icon)
+      ..write(obj.iconId)
       ..writeByte(5)
       ..write(obj.color)
       ..writeByte(6)

--- a/lib/providers/folder_provider.dart
+++ b/lib/providers/folder_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_ce_flutter/adapters.dart';
-import 'package:icarus/const/custom_icons.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/strategy_provider.dart';
@@ -22,7 +22,7 @@ class Folder extends HiveObject {
   final String id;
   final DateTime dateCreated;
   String? parentID; // null for root folders, clearer than empty string
-  IconData icon;
+  int iconId;
   FolderColor color;
   Color? customColor;
 
@@ -30,11 +30,15 @@ class Folder extends HiveObject {
     required this.name,
     required this.id,
     required this.dateCreated,
-    required this.icon,
+    int? iconId,
+    IconData? icon,
     this.color = FolderColor.red,
     this.parentID, // Optional, defaults to null (root)
     this.customColor,
-  });
+  }) : iconId = iconId ??
+            (icon == null
+                ? FolderIconRegistry.defaultId
+                : FolderIconRegistry.idForLegacyIconData(icon));
 
   static Map<FolderColor, Color> folderColorMap = {
     FolderColor.red: Colors.red,
@@ -54,58 +58,19 @@ class Folder extends HiveObject {
     FolderColor.generic,
   ];
 
-  static List<IconData> folderIcons = [
-    // 📂 Folder & File Related
+  @Deprecated('Use iconId and FolderIconRegistry instead.')
+  IconData get icon => FolderIconRegistry.legacyIconDataForId(iconId);
 
-    Icons.star_rate_rounded,
-    Icons.ac_unit_sharp,
-    Icons.bug_report,
-    Icons.cake,
-    Icons.code,
-    Icons.add_shopping_cart_rounded,
-    Icons.airline_stops_sharp,
-    Icons.all_inclusive,
-    Icons.api_rounded,
+  @Deprecated('Use iconId and FolderIconRegistry instead.')
+  set icon(IconData icon) {
+    iconId = FolderIconRegistry.idForLegacyIconData(icon);
+  }
 
-    Icons.drive_folder_upload,
-    Icons.folder_shared,
-    Icons.folder_special,
-    Icons.workspaces,
-
-    // 🗂️ Organization & Structure
-    Icons.category,
-    Icons.collections_bookmark,
-    Icons.library_books,
-    Icons.archive,
-    Icons.assignment,
-    Icons.assignment_turned_in,
-    Icons.dashboard,
-    Icons.anchor,
-    Icons.hourglass_bottom_outlined,
-    Icons.image_search,
-    Icons.view_quilt,
-
-    // 🎯 Strategy & Planning
-    Icons.map,
-    Icons.place,
-    Icons.explore,
-    Icons.explore_off,
-    Icons.flag,
-    Icons.outlined_flag,
-    Icons.emoji_objects,
-    Icons.lightbulb,
-    Icons.track_changes,
-    Icons.timeline,
-
-    // ⚔️ Valorant / Tactical Feel
-    Icons.sports_esports,
-    CustomIcons.sword,
-    Icons.military_tech,
-    Icons.shield,
-    Icons.security,
-    Icons.bolt,
-    Icons.psychology,
-  ];
+  @Deprecated('Use FolderIconRegistry.pickerEntries instead.')
+  static List<IconData> get folderIcons => [
+        for (final entry in FolderIconRegistry.pickerEntries)
+          if (entry.iconData != null) entry.iconData!,
+      ];
 
   bool get isRoot => parentID == null;
 }
@@ -116,13 +81,13 @@ final folderProvider =
 class FolderProvider extends Notifier<String?> {
   Future<Folder> createFolder({
     required String name,
-    required IconData icon,
+    required int iconId,
     required FolderColor color,
     Color? customColor,
     String? parentID,
   }) async {
     final newFolder = Folder(
-      icon: icon,
+      iconId: iconId,
       name: name,
       id: const Uuid().v4(),
       dateCreated: DateTime.now(),
@@ -160,8 +125,6 @@ class FolderProvider extends Notifier<String?> {
     return pathIDs;
   }
 
-  // I want to be able
-
   List<Folder> findFolderChildren(String id) {
     return Hive.box<Folder>(HiveBoxNames.foldersBox)
         .values
@@ -196,12 +159,12 @@ class FolderProvider extends Notifier<String?> {
   void editFolder({
     required Folder folder,
     required String newName,
-    required IconData newIcon,
+    required int newIconId,
     required FolderColor newColor,
     required Color? newCustomColor,
   }) async {
     folder.name = newName;
-    folder.icon = newIcon;
+    folder.iconId = newIconId;
     folder.customColor = newCustomColor;
     folder.color = newColor;
     await folder.save();

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -16,6 +16,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/abilities.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/migrations/ability_scale_migration.dart';
@@ -1547,7 +1548,9 @@ class StrategyProvider extends Notifier<StrategyState> {
   }) {
     return ref.read(folderProvider.notifier).createFolder(
           name: name,
-          icon: Icons.drive_folder_upload,
+          iconId: FolderIconRegistry.idForLegacyIconData(
+            Icons.drive_folder_upload,
+          ),
           color: FolderColor.generic,
           parentID: parentFolderId,
         );
@@ -1954,7 +1957,7 @@ class StrategyProvider extends Notifier<StrategyState> {
       final createdFolder =
           await ref.read(folderProvider.notifier).createFolder(
                 name: folderEntry.name,
-                icon: folderEntry.icon.toIconData(),
+                iconId: folderEntry.iconId,
                 color: folderEntry.color,
                 customColor: folderEntry.customColorValue == null
                     ? null
@@ -2476,7 +2479,7 @@ class StrategyProvider extends Notifier<StrategyState> {
       final createdFolder =
           await ref.read(folderProvider.notifier).createFolder(
                 name: folderEntry.name,
-                icon: folderEntry.icon.toIconData(),
+                iconId: folderEntry.iconId,
                 color: folderEntry.color,
                 customColor: folderEntry.customColorValue == null
                     ? null
@@ -3282,7 +3285,7 @@ class StrategyProvider extends Notifier<StrategyState> {
         name: currentFolder.name,
         parentManifestId: parentManifestId,
         archivePath: normalizeArchivePath(currentArchivePath),
-        icon: ArchiveIconDescriptor.fromIconData(currentFolder.icon),
+        iconId: currentFolder.iconId,
         color: currentFolder.color,
         customColorValue: currentFolder.customColor?.toARGB32(),
       ),

--- a/lib/services/archive_manifest.dart
+++ b/lib/services/archive_manifest.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/providers/folder_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
 import 'package:path/path.dart' as path;
@@ -75,20 +76,25 @@ class ArchiveIconDescriptor {
 }
 
 class ArchiveFolderEntry {
-  const ArchiveFolderEntry({
+  ArchiveFolderEntry({
     required this.manifestId,
     required this.name,
     required this.parentManifestId,
     required this.archivePath,
-    required this.icon,
+    required this.iconId,
+    ArchiveIconDescriptor? icon,
     required this.color,
     required this.customColorValue,
-  });
+  }) : icon = icon ??
+            ArchiveIconDescriptor.fromIconData(
+              FolderIconRegistry.legacyIconDataForId(iconId),
+            );
 
   final String manifestId;
   final String name;
   final String? parentManifestId;
   final String archivePath;
+  final int iconId;
   final ArchiveIconDescriptor icon;
   final FolderColor color;
   final int? customColorValue;
@@ -99,7 +105,7 @@ class ArchiveFolderEntry {
       'name': name,
       'parentManifestId': parentManifestId,
       'archivePath': archivePath,
-      'icon': icon.toJson(),
+      'iconId': iconId,
       'color': color.name,
       if (customColorValue != null) 'customColorValue': customColorValue,
     };
@@ -107,13 +113,22 @@ class ArchiveFolderEntry {
 
   factory ArchiveFolderEntry.fromJson(Map<String, dynamic> json) {
     final colorName = _readRequiredString(json, 'color');
+    final legacyIcon = json['icon'] == null
+        ? null
+        : ArchiveIconDescriptor.fromJson(_readRequiredMap(json, 'icon'));
     return ArchiveFolderEntry(
       manifestId: _readRequiredString(json, 'manifestId'),
       name: _readRequiredString(json, 'name'),
       parentManifestId: _readNullableString(json, 'parentManifestId'),
       archivePath:
           normalizeArchivePath(_readStringAllowEmpty(json, 'archivePath')),
-      icon: ArchiveIconDescriptor.fromJson(_readRequiredMap(json, 'icon')),
+      iconId: _readNullableInt(json, 'iconId') ??
+          (legacyIcon == null
+              ? FolderIconRegistry.defaultId
+              : FolderIconRegistry.idForLegacyIconData(
+                  legacyIcon.toIconData(),
+                )),
+      icon: legacyIcon,
       color: FolderColor.values.firstWhere(
         (candidate) => candidate.name == colorName,
         orElse: () => throw FormatException('Unknown folder color: $colorName'),

--- a/lib/widgets/folder_edit_dialog.dart
+++ b/lib/widgets/folder_edit_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/folder_provider.dart';
 import 'package:icarus/widgets/better_color_picker.dart';
@@ -25,7 +26,7 @@ class FolderEditDialog extends ConsumerStatefulWidget {
 class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
   final TextEditingController _folderNameController = TextEditingController();
 
-  IconData _selectedIcon = Folder.folderIcons[0];
+  int _selectedIconId = FolderIconRegistry.defaultId;
   FolderColor _selectedColor = FolderColor.red;
   Color? _customColor;
   @override
@@ -41,7 +42,7 @@ class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
     _selectedColor = widget.folder?.color ?? FolderColor.generic;
     if (widget.folder != null) {
       _folderNameController.text = widget.folder!.name;
-      _selectedIcon = widget.folder!.icon;
+      _selectedIconId = widget.folder!.iconId;
       _customColor = widget.folder!.customColor;
     }
     _folderNameController.addListener(() {
@@ -73,7 +74,7 @@ class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
                       newName: _folderNameController.text.isEmpty
                           ? "New Folder"
                           : _folderNameController.text,
-                      newIcon: _selectedIcon,
+                      newIconId: _selectedIconId,
                       newColor: _selectedColor,
                       newCustomColor: _customColor,
                     );
@@ -84,7 +85,7 @@ class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
                     name: _folderNameController.text.isEmpty
                         ? "New Folder"
                         : _folderNameController.text,
-                    icon: _selectedIcon,
+                    iconId: _selectedIconId,
                     color: _selectedColor,
                     customColor: _customColor,
                   );
@@ -130,7 +131,7 @@ class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
                           color: Colors.transparent,
                           child: FolderPill(
                             folder: Folder(
-                              icon: _selectedIcon,
+                              iconId: _selectedIconId,
                               name: _folderNameController.text,
                               id: "null",
                               dateCreated: DateTime.now(),
@@ -238,22 +239,23 @@ class _FolderEditDialogState extends ConsumerState<FolderEditDialog> {
                   crossAxisSpacing: 8,
                   childAspectRatio: 1,
                 ),
-                itemCount: Folder.folderIcons.length,
+                itemCount: FolderIconRegistry.pickerEntries.length,
                 itemBuilder: (context, index) {
+                  final iconId = FolderIconRegistry.pickerEntries[index].id;
                   return IconButton(
                       onPressed: () {
                         setState(() {
-                          _selectedIcon = Folder.folderIcons[index];
+                          _selectedIconId = iconId;
                         });
                       },
-                      isSelected: _selectedIcon == Folder.folderIcons[index],
-                      icon: Icon(
-                        Folder.folderIcons[index],
+                      isSelected: _selectedIconId == iconId,
+                      icon: FolderIconView(
+                        iconId: iconId,
                         size: 24,
                         color: Colors.white,
                       ),
-                      selectedIcon: Icon(
-                        Folder.folderIcons[index],
+                      selectedIcon: FolderIconView(
+                        iconId: iconId,
                         size: 24,
                         color: Settings.tacticalVioletTheme.primary,
                       ));

--- a/lib/widgets/folder_pill.dart
+++ b/lib/widgets/folder_pill.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/providers/folder_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
@@ -135,8 +136,8 @@ class _FolderPillState extends ConsumerState<FolderPill>
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Icon(
-                              widget.folder.icon,
+                            FolderIconView(
+                              iconId: widget.folder.iconId,
                               color: Colors.white,
                               size: 20,
                             ),
@@ -253,8 +254,8 @@ class _FolderPillState extends ConsumerState<FolderPill>
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
-                widget.folder.icon,
+              FolderIconView(
+                iconId: widget.folder.iconId,
                 color: Colors.white,
                 size: 20,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "A new Flutter project."
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 4.3.6+90 #version number
+version: 4.3.7+91 #version number
 
 environment:
   sdk: ">=3.4.3 <4.0.0"
@@ -63,7 +63,7 @@ msix_config:
   identity_name: DaraA.IcarusValorantStrategiesLineups
   publisher: CN=39055448-F6AA-42E9-91F6-9CF8828C444C
   logo_path: windows\runner\resources\app_icon.ico
-  msix_version: 4.3.6.0 #verion number #last 0 needs to be there for msix to work
+  msix_version: 4.3.7.0 #verion number #last 0 needs to be there for msix to work
   file_extension: .ica
   store: true
 

--- a/release/metadata/4.3.7+91.json
+++ b/release/metadata/4.3.7+91.json
@@ -1,0 +1,26 @@
+{
+  "version": "4.3.7+91",
+  "shortVersion": 91,
+  "title": "4.3.7 Release",
+  "description": "Desktop release metadata for Icarus.",
+  "date": "2026-06-27",
+  "mandatory": false,
+  "channels": [
+    "desktop",
+    "prerelease",
+    "stable"
+  ],
+  "platforms": [
+    "windows"
+  ],
+  "changes": [
+    {
+      "message": "Added registry-backed folder icons so folders can use bundled agent role image icons.",
+      "type": "feature"
+    },
+    {
+      "message": "Migrated folder icon persistence and archive metadata to stable icon ids with legacy IconData compatibility.",
+      "type": "improvement"
+    }
+  ]
+}

--- a/test/agent_dragable_lineup_state_test.dart
+++ b/test/agent_dragable_lineup_state_test.dart
@@ -61,6 +61,15 @@ Finder _opacityFinder(AgentType type) {
   return find.byKey(ValueKey('agent-dim-opacity-${type.name}'));
 }
 
+Finder _tileTapTarget(AgentType type) {
+  return find
+      .descendant(
+        of: _opacityFinder(type),
+        matching: find.byType(InkWell),
+      )
+      .first;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -112,7 +121,7 @@ void main() {
 
     await _pumpHarness(tester, container: container);
 
-    await tester.tap(find.byType(InkWell).at(1), warnIfMissed: false);
+    await tester.tap(_tileTapTarget(AgentType.sova), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     expect(container.read(abilityBarProvider)?.type, AgentType.sova);
@@ -191,7 +200,7 @@ void main() {
 
     await _pumpHarness(tester, container: container);
 
-    await tester.tap(find.byType(InkWell).at(1), warnIfMissed: false);
+    await tester.tap(_tileTapTarget(AgentType.sova), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     expect(container.read(abilityBarProvider)?.type, AgentType.breach);
@@ -229,7 +238,7 @@ void main() {
     await _pumpHarness(tester, container: container);
 
     await tester.drag(
-      find.byType(InkWell).at(1),
+      _tileTapTarget(AgentType.sova),
       const Offset(30, 0),
       warnIfMissed: false,
     );

--- a/test/folder_icon_registry_test.dart
+++ b/test/folder_icon_registry_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/custom_icons.dart';
+import 'package:icarus/const/folder_icons.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/services/archive_manifest.dart';
+import 'package:icarus/providers/folder_provider.dart';
+
+void main() {
+  test('folder icon registry migration version matches app version', () {
+    expect(folderIconRegistryVersion, Settings.versionNumber);
+  });
+
+  test('folder icon registry ids are unique and picker-safe', () {
+    final ids = FolderIconRegistry.entries.map((entry) => entry.id).toList();
+    expect(ids.toSet(), hasLength(ids.length));
+
+    expect(
+      FolderIconRegistry.pickerEntries.map((entry) => entry.id),
+      isNot(contains(FolderIconRegistry.legacyFolderId)),
+    );
+    expect(
+      FolderIconRegistry.pickerEntries.map((entry) => entry.id),
+      containsAll([
+        FolderIconRegistry.controllerRoleId,
+        FolderIconRegistry.duelistRoleId,
+        FolderIconRegistry.initiatorRoleId,
+        FolderIconRegistry.sentinelRoleId,
+      ]),
+    );
+  });
+
+  test('folder icon registry keeps stable id signatures', () {
+    expect(
+      {
+        for (final entry in FolderIconRegistry.entries)
+          entry.id: entry.stableSignature,
+      },
+      {
+        0: _materialSignature(Icons.folder),
+        1: _materialSignature(Icons.star_rate_rounded),
+        2: _materialSignature(Icons.ac_unit_sharp),
+        3: _materialSignature(Icons.bug_report),
+        4: _materialSignature(Icons.cake),
+        5: _materialSignature(Icons.code),
+        6: _materialSignature(Icons.add_shopping_cart_rounded),
+        7: _materialSignature(Icons.airline_stops_sharp),
+        8: _materialSignature(Icons.all_inclusive),
+        9: _materialSignature(Icons.api_rounded),
+        10: _materialSignature(Icons.drive_folder_upload),
+        11: _materialSignature(Icons.folder_shared),
+        12: _materialSignature(Icons.folder_special),
+        13: _materialSignature(Icons.workspaces),
+        14: _materialSignature(Icons.category),
+        15: _materialSignature(Icons.collections_bookmark),
+        16: _materialSignature(Icons.library_books),
+        17: _materialSignature(Icons.archive),
+        18: _materialSignature(Icons.assignment),
+        19: _materialSignature(Icons.assignment_turned_in),
+        20: _materialSignature(Icons.dashboard),
+        21: _materialSignature(Icons.anchor),
+        22: _materialSignature(Icons.hourglass_bottom_outlined),
+        23: _materialSignature(Icons.image_search),
+        24: _materialSignature(Icons.view_quilt),
+        25: _materialSignature(Icons.map),
+        26: _materialSignature(Icons.place),
+        27: _materialSignature(Icons.explore),
+        28: _materialSignature(Icons.explore_off),
+        29: _materialSignature(Icons.flag),
+        30: _materialSignature(Icons.outlined_flag),
+        31: _materialSignature(Icons.emoji_objects),
+        32: _materialSignature(Icons.lightbulb),
+        33: _materialSignature(Icons.track_changes),
+        34: _materialSignature(Icons.timeline),
+        35: _materialSignature(Icons.sports_esports),
+        36: _materialSignature(CustomIcons.sword),
+        37: _materialSignature(Icons.military_tech),
+        38: _materialSignature(Icons.shield),
+        39: _materialSignature(Icons.security),
+        40: _materialSignature(Icons.bolt),
+        41: _materialSignature(Icons.psychology),
+        1000: 'asset|assets/agents/controller.webp',
+        1001: 'asset|assets/agents/duelist.webp',
+        1002: 'asset|assets/agents/initiator.webp',
+        1003: 'asset|assets/agents/sentinel.webp',
+      },
+    );
+  });
+
+  test('legacy IconData values migrate to registry ids', () {
+    expect(
+      FolderIconRegistry.idForLegacyIconData(Icons.flag),
+      29,
+    );
+    expect(
+      FolderIconRegistry.idForLegacyIconData(CustomIcons.sword),
+      36,
+    );
+    expect(
+      FolderIconRegistry.idForLegacyIconData(Icons.folder),
+      FolderIconRegistry.legacyFolderId,
+    );
+  });
+
+  test('legacy archive icon descriptor maps to icon id', () {
+    final entry = ArchiveFolderEntry.fromJson({
+      'manifestId': 'legacy',
+      'name': 'Legacy',
+      'parentManifestId': null,
+      'archivePath': '',
+      'icon': ArchiveIconDescriptor.fromIconData(Icons.lightbulb).toJson(),
+      'color': FolderColor.red.name,
+    });
+
+    expect(
+      entry.iconId,
+      FolderIconRegistry.idForLegacyIconData(Icons.lightbulb),
+    );
+  });
+
+  test('new archive folder entries write only canonical icon ids', () {
+    final entry = ArchiveFolderEntry(
+      manifestId: 'duelist',
+      name: 'Duelist',
+      parentManifestId: null,
+      archivePath: '',
+      iconId: FolderIconRegistry.duelistRoleId,
+      color: FolderColor.red,
+      customColorValue: null,
+    );
+
+    expect(entry.toJson(),
+        containsPair('iconId', FolderIconRegistry.duelistRoleId));
+    expect(entry.toJson(), isNot(contains('icon')));
+  });
+
+  test('role asset ids use material fallback for legacy archives', () {
+    final entry = ArchiveFolderEntry(
+      manifestId: 'duelist',
+      name: 'Duelist',
+      parentManifestId: null,
+      archivePath: '',
+      iconId: FolderIconRegistry.duelistRoleId,
+      color: FolderColor.red,
+      customColorValue: null,
+    );
+
+    expect(entry.iconId, FolderIconRegistry.duelistRoleId);
+    expect(
+      entry.icon.toJson(),
+      ArchiveIconDescriptor.fromIconData(
+        FolderIconRegistry.legacyIconDataForId(
+            FolderIconRegistry.duelistRoleId),
+      ).toJson(),
+    );
+  });
+}
+
+String _materialSignature(IconData icon) {
+  return [
+    'material',
+    icon.codePoint,
+    icon.fontFamily ?? '',
+    icon.fontPackage ?? '',
+    icon.matchTextDirection,
+    icon.fontFamilyFallback?.join(',') ?? '',
+  ].join('|');
+}

--- a/test/page_transition_overlay_test.dart
+++ b/test/page_transition_overlay_test.dart
@@ -3,11 +3,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/widgets/page_transition_overlay.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 const Color _expectedMutedAllyBgColor = Color.fromARGB(255, 60, 60, 60);
+
+class _FixedMapProvider extends MapProvider {
+  @override
+  MapState build() => MapState(currentMap: MapValue.ascent, isAttack: true);
+
+  @override
+  void fromHive(MapValue map, bool isAttack) {}
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -24,7 +35,7 @@ void main() {
   }) {
     return UncontrolledProviderScope(
       container: container,
-      child: MaterialApp(
+      child: ShadApp(
         home: Scaffold(
           body: PlacedWidgetPreview.build(
             agent,
@@ -40,7 +51,7 @@ void main() {
 
   testWidgets('dead agents stay in dead state in transition previews',
       (tester) async {
-    final container = ProviderContainer();
+    final container = _createContainer();
     addTearDown(container.dispose);
 
     final agent = PlacedAgent(
@@ -66,7 +77,7 @@ void main() {
 
   testWidgets('alive agents do not render dead-state styling in previews',
       (tester) async {
-    final container = ProviderContainer();
+    final container = _createContainer();
     addTearDown(container.dispose);
 
     final agent = PlacedAgent(
@@ -92,7 +103,7 @@ void main() {
 
   testWidgets('partial dead-state progress lerps styling for transition',
       (tester) async {
-    final container = ProviderContainer();
+    final container = _createContainer();
     addTearDown(container.dispose);
 
     final agent = PlacedAgent(
@@ -130,4 +141,12 @@ void main() {
     );
     await tester.pump();
   });
+}
+
+ProviderContainer _createContainer() {
+  return ProviderContainer(
+    overrides: [
+      mapProvider.overrideWith(_FixedMapProvider.new),
+    ],
+  );
 }

--- a/test/resizable_square_ability_test.dart
+++ b/test/resizable_square_ability_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/const/abilities.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/providers/ability_provider.dart';
+import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/custom_square_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/placed_ability_widget.dart';
@@ -183,7 +185,7 @@ void main() {
       length: 0,
     );
 
-    final container = ProviderContainer();
+    final container = _createContainer();
     addTearDown(() async {
       await tester.pumpWidget(const SizedBox.shrink());
       container.dispose();
@@ -223,7 +225,7 @@ void main() {
 
     final ability = AgentData.agents[AgentType.neon]!.abilities.first
         .abilityData! as ResizableSquareAbility;
-    final container = ProviderContainer();
+    final container = _createContainer();
     final abilitySize = container.read(strategySettingsProvider).abilitySize;
 
     addTearDown(() async {
@@ -265,7 +267,7 @@ void main() {
 
     final ability = AgentData.agents[AgentType.viper]!.abilities[2].abilityData!
         as SquareAbility;
-    final container = ProviderContainer();
+    final container = _createContainer();
     final abilitySize = container.read(strategySettingsProvider).abilitySize;
 
     addTearDown(() async {
@@ -371,4 +373,20 @@ void main() {
       expect(placedAbility.rotation, closeTo(initialRotation + pi, 0.0001));
     });
   });
+}
+
+class _FixedMapProvider extends MapProvider {
+  @override
+  MapState build() => MapState(currentMap: MapValue.ascent, isAttack: true);
+
+  @override
+  void fromHive(MapValue map, bool isAttack) {}
+}
+
+ProviderContainer _createContainer() {
+  return ProviderContainer(
+    overrides: [
+      mapProvider.overrideWith(_FixedMapProvider.new),
+    ],
+  );
 }

--- a/test/sector_circle_ability_test.dart
+++ b/test/sector_circle_ability_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/const/abilities.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/providers/ability_provider.dart';
+import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/ability_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/placed_ability_widget.dart';
@@ -387,7 +389,7 @@ void main() {
         position: const Offset(100, 100),
       );
 
-      final container = ProviderContainer();
+      final container = _createContainer();
       addTearDown(() async {
         await tester.pumpWidget(const SizedBox.shrink());
         container.dispose();
@@ -420,8 +422,7 @@ void main() {
       expect(rotatable.buttonTop, isNull);
     });
 
-    testWidgets('icon-only sector hides the rotation handle',
-        (tester) async {
+    testWidgets('icon-only sector hides the rotation handle', (tester) async {
       final abilityInfo = AbilityInfo(
         name: 'Sector',
         iconPath: 'assets/agents/Cypher/1.webp',
@@ -444,7 +445,7 @@ void main() {
         ),
       );
 
-      final container = ProviderContainer();
+      final container = _createContainer();
       addTearDown(() async {
         await tester.pumpWidget(const SizedBox.shrink());
         container.dispose();
@@ -545,6 +546,22 @@ void main() {
   });
 }
 
+class _FixedMapProvider extends MapProvider {
+  @override
+  MapState build() => MapState(currentMap: MapValue.ascent, isAttack: true);
+
+  @override
+  void fromHive(MapValue map, bool isAttack) {}
+}
+
+ProviderContainer _createContainer() {
+  return ProviderContainer(
+    overrides: [
+      mapProvider.overrideWith(_FixedMapProvider.new),
+    ],
+  );
+}
+
 class _PlacedSectorAbilityHarness extends ConsumerWidget {
   const _PlacedSectorAbilityHarness();
 
@@ -567,7 +584,7 @@ class _PlacedSectorAbilityHarness extends ConsumerWidget {
 }
 
 Future<void> _pumpWidget(WidgetTester tester, Widget child) async {
-  final container = ProviderContainer();
+  final container = _createContainer();
   addTearDown(() async {
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
@@ -626,4 +643,3 @@ SectorCirclePainter _sectorPainter(WidgetTester tester) {
 
   return customPaint.painter! as SectorCirclePainter;
 }
-

--- a/test/strategy_folder_import_test.dart
+++ b/test/strategy_folder_import_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/app_provider_container.dart';
 import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/folder_icons.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/settings.dart';
@@ -324,7 +325,7 @@ void main() {
       container,
       name: 'Retakes',
       parentID: rootFolder.id,
-      icon: Icons.lightbulb,
+      iconId: FolderIconRegistry.duelistRoleId,
       color: FolderColor.blue,
     );
 
@@ -348,6 +349,15 @@ void main() {
       expect(decoded['archiveType'], ArchiveType.folderTree.jsonValue);
       expect((decoded['folders'] as List).length, 2);
       expect((decoded['strategies'] as List).length, 2);
+      final decodedFolders = (decoded['folders'] as List)
+          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .toList();
+      expect(
+          decodedFolders.map((entry) => entry['iconId']),
+          containsAll([
+            FolderIconRegistry.idForLegacyIconData(Icons.flag),
+            FolderIconRegistry.duelistRoleId,
+          ]));
 
       final zipFile = await _zipDirectory(
         sourceDirectory: exportedRoot,
@@ -368,10 +378,13 @@ void main() {
 
       final importedRoot = _folderByName('Utility / Pack');
       final importedChild = _folderByName('Retakes');
-      expect(importedRoot.icon.codePoint, Icons.flag.codePoint);
+      expect(
+        importedRoot.iconId,
+        FolderIconRegistry.idForLegacyIconData(Icons.flag),
+      );
       expect(importedRoot.color, FolderColor.custom);
       expect(importedRoot.customColor, const Color(0xFF22C55E));
-      expect(importedChild.icon.codePoint, Icons.lightbulb.codePoint);
+      expect(importedChild.iconId, FolderIconRegistry.duelistRoleId);
       expect(importedChild.color, FolderColor.blue);
       expect(importedChild.parentID, importedRoot.id);
       expect(_strategyByName('default').folderID, importedRoot.id);
@@ -704,6 +717,7 @@ ArchiveManifest _buildBrokenFolderTreeManifest() {
         name: 'Manifest Root',
         parentManifestId: null,
         archivePath: '',
+        iconId: FolderIconRegistry.idForLegacyIconData(Icons.folder),
         icon: defaultIcon,
         color: FolderColor.red,
         customColorValue: null,
@@ -713,6 +727,7 @@ ArchiveManifest _buildBrokenFolderTreeManifest() {
         name: 'Broken Child',
         parentManifestId: 'deep-parent',
         archivePath: 'b',
+        iconId: FolderIconRegistry.idForLegacyIconData(Icons.folder),
         icon: defaultIcon,
         color: FolderColor.red,
         customColorValue: null,
@@ -722,6 +737,7 @@ ArchiveManifest _buildBrokenFolderTreeManifest() {
         name: 'Deep Parent',
         parentManifestId: 'root',
         archivePath: 'b/c',
+        iconId: FolderIconRegistry.idForLegacyIconData(Icons.folder),
         icon: defaultIcon,
         color: FolderColor.red,
         customColorValue: null,
@@ -760,6 +776,7 @@ Future<Folder> _createFolder(
   required String name,
   required String? parentID,
   IconData icon = Icons.folder,
+  int? iconId,
   FolderColor color = FolderColor.red,
   Color? customColor,
   bool setCurrent = false,
@@ -767,7 +784,7 @@ Future<Folder> _createFolder(
   final notifier = container.read(folderProvider.notifier);
   final folder = await notifier.createFolder(
     name: name,
-    icon: icon,
+    iconId: iconId ?? FolderIconRegistry.idForLegacyIconData(icon),
     color: color,
     customColor: customColor,
     parentID: parentID,


### PR DESCRIPTION
## Summary

Adds a unified, registry-backed folder icon system so folders can use both existing Material/custom icons and bundled agent role image icons through stable ids.

## Details

- Stores folder visuals as stable `iconId` values instead of serialized `IconData`.
- Keeps legacy Hive compatibility by mapping old `IconData` field values into registry ids on read.
- Keeps legacy archive import compatibility while making new archives write canonical `iconId` data only.
- Adds role icon assets to the folder icon picker through the same renderer used for existing icons.
- Bumps the app/release metadata to `4.3.7+91`, matching the folder icon registry migration version.

## Validation

- `fvm flutter test test\folder_icon_registry_test.dart test\strategy_folder_import_test.dart`
- `git diff --check`
- `fvm flutter analyze` was run; it still reports four pre-existing unrelated `prefer_const_constructors` infos in `test\square_icon_counter_rotation_test.dart`.