### PR TITLE
Improve ability names and drag hover labels

### DIFF
--- a/lib/const/abilities.dart
+++ b/lib/const/abilities.dart
@@ -13,6 +13,11 @@ import 'package:icarus/widgets/draggable_widgets/ability/sector_circle_widget.da
 import 'package:icarus/widgets/draggable_widgets/ability/simple_image_ability_widget.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
+// Ability range inputs are gameplay measurements. CircleAbility and
+// SectorCircleAbility treat size/innerRangeSize as radii and convert them with
+// AgentData.inGameMetersDiameter; other shapes use AgentData.inGameMeters where
+// their dimensions represent direct lengths.
+
 bool isRotatable(Ability ability) {
   switch (ability) {
     case SquareAbility():
@@ -162,12 +167,15 @@ class CircleAbility extends Ability {
     this.rangeFillColor,
     this.innerRangeColor,
     this.opacity,
-    this.innerRangeSize,
+    double? innerRangeSize,
   })  : assert(
           innerRangeSize == null || innerRangeColor != null,
           'innerRangeColor is required when innerRangeSize is set',
         ),
-        size = size * AgentData.inGameMetersDiameter;
+        size = size * AgentData.inGameMetersDiameter,
+        innerRangeSize = innerRangeSize != null
+            ? innerRangeSize * AgentData.inGameMetersDiameter
+            : null;
 
   final double size;
   final Color rangeOutlineColor;
@@ -242,12 +250,15 @@ class SectorCircleAbility extends Ability {
     this.rangeFillColor,
     this.innerRangeColor,
     this.opacity = 70,
-    this.innerRangeSize,
+    double? innerRangeSize,
   })  : assert(
           innerRangeSize == null || innerRangeColor != null,
           'innerRangeColor is required when innerRangeSize is set',
         ),
-        size = size * AgentData.inGameMetersDiameter;
+        size = size * AgentData.inGameMetersDiameter,
+        innerRangeSize = innerRangeSize != null
+            ? innerRangeSize * AgentData.inGameMetersDiameter
+            : null;
 
   final double size;
   final Color rangeOutlineColor;

--- a/lib/const/agents.dart
+++ b/lib/const/agents.dart
@@ -504,15 +504,7 @@ class AgentData implements DraggableData {
 
       agent.abilities.first.abilityData = CircleAbility(
         iconPath: agent.abilities.first.iconPath,
-        size: 5.5,
-        rangeOutlineColor: const Color(0xFF6A0EB6),
-        hasCenterDot: true,
-      );
-
-      // Ultimate
-      agent.abilities[3].abilityData = CircleAbility(
-        iconPath: agent.abilities[3].iconPath,
-        size: 32.5,
+        size: 4.71,
         rangeOutlineColor: const Color(0xFF6A0EB6),
         hasCenterDot: true,
       );
@@ -523,7 +515,7 @@ class AgentData implements DraggableData {
         size: 40,
         rangeOutlineColor: Colors.white,
         hasCenterDot: true,
-        innerRangeSize: 54.48,
+        innerRangeSize: 5.5,
         innerRangeColor: const Color.fromARGB(255, 106, 14, 182),
       );
 
@@ -535,6 +527,14 @@ class AgentData implements DraggableData {
         hasCenterDot: true,
         opacity: 0,
         rangeFillColor: Colors.transparent,
+      );
+
+      // Ultimate
+      agent.abilities[3].abilityData = CircleAbility(
+        iconPath: agent.abilities[3].iconPath,
+        size: 32.5,
+        rangeOutlineColor: const Color(0xFF6A0EB6),
+        hasCenterDot: true,
       );
 
       return agent;

--- a/lib/const/agents.dart
+++ b/lib/const/agents.dart
@@ -178,11 +178,12 @@ class AgentData implements DraggableData {
     required this.type,
     required this.role,
     required this.name,
+    List<String>? abilityNames,
   })  : iconPath = 'assets/agents/$name/icon.webp',
         abilities = List.generate(
           4,
           (index) => AbilityInfo(
-            name: 'Ability ${index + 1}', // You can override this later
+            name: abilityNames?[index] ?? 'Ability ${index + 1}',
             iconPath: 'assets/agents/$name/${index + 1}.webp',
             type: type,
             index: index,
@@ -196,6 +197,12 @@ class AgentData implements DraggableData {
       type: AgentType.jett,
       role: AgentRole.duelist,
       name: "Jett",
+      abilityNames: const [
+        "Cloudburst",
+        "Updraft",
+        "Tailwind",
+        "Blade Storm",
+      ],
     )..abilities[0] =
           // Override the default abilities
           AbilityInfo(
@@ -210,12 +217,24 @@ class AgentData implements DraggableData {
       type: AgentType.raze,
       role: AgentRole.duelist,
       name: "Raze",
+      abilityNames: const [
+        "Boom Bot",
+        "Blast Pack",
+        "Paint Shells",
+        "Showstopper",
+      ],
     ),
     AgentType.pheonix: (() {
       final agent = AgentData(
         type: AgentType.pheonix,
         role: AgentRole.duelist,
         name: "Phoenix",
+        abilityNames: const [
+          "Blaze",
+          "Hot Hands",
+          "Curveball",
+          "Run it Back",
+        ],
       );
       agent.abilities.first.abilityData = SquareAbility(
         width: 5,
@@ -238,10 +257,16 @@ class AgentData implements DraggableData {
         type: AgentType.astra,
         role: AgentRole.controller,
         name: "Astra",
+        abilityNames: const [
+          "Gravity Well",
+          "Nova Pulse",
+          "Nebula/Dissipate",
+          "Cosmic Divide",
+        ],
       )..abilities[2] = AbilityInfo(
           type: AgentType.astra,
           index: 2,
-          name: "Nebula",
+          name: "Nebula/Dissipate",
           iconPath: 'assets/agents/Astra/3.webp',
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Astra/Smoke.webp',
@@ -285,6 +310,12 @@ class AgentData implements DraggableData {
         type: AgentType.breach,
         role: AgentRole.initiator,
         name: "Breach",
+        abilityNames: const [
+          "Aftershock",
+          "Flashpoint",
+          "Fault Line",
+          "Rolling Thunder",
+        ],
       );
       agent.abilities.first.abilityData = SquareAbility(
         width: 3 * inGameMetersDiameter,
@@ -317,10 +348,16 @@ class AgentData implements DraggableData {
         type: AgentType.viper,
         role: AgentRole.controller,
         name: "Viper",
+        abilityNames: const [
+          "Snake Bite",
+          "Poison Cloud",
+          "Toxic Screen",
+          "Viper's Pit",
+        ],
       )..abilities[1] = AbilityInfo(
           type: AgentType.viper,
           index: 1,
-          name: "Sky Smoke",
+          name: "Poison Cloud",
           iconPath: 'assets/agents/Viper/2.webp',
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Viper/Smoke.webp',
@@ -349,12 +386,24 @@ class AgentData implements DraggableData {
       type: AgentType.yoru,
       role: AgentRole.duelist,
       name: "Yoru",
+      abilityNames: const [
+        "Fakeout",
+        "Blindside",
+        "Gatecrash",
+        "Dimensional Drift",
+      ],
     ),
     AgentType.sova: (() {
       final agent = AgentData(
         type: AgentType.sova,
         role: AgentRole.initiator,
         name: "Sova",
+        abilityNames: const [
+          "Owl Drone",
+          "Shock Bolt",
+          "Recon Bolt",
+          "Hunter's Fury",
+        ],
       );
 
       agent.abilities[1].abilityData = CircleAbility(
@@ -385,6 +434,12 @@ class AgentData implements DraggableData {
         type: AgentType.skye,
         role: AgentRole.initiator,
         name: "Skye",
+        abilityNames: const [
+          "Regrowth",
+          "Trailblazer",
+          "Guiding Light",
+          "Seekers",
+        ],
       );
 
       // Heal
@@ -402,6 +457,12 @@ class AgentData implements DraggableData {
         type: AgentType.kayo,
         role: AgentRole.initiator,
         name: "Kayo",
+        abilityNames: const [
+          "FRAG/ment",
+          "FLASH/drive",
+          "ZERO/point",
+          "NULL/cmd",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -433,6 +494,12 @@ class AgentData implements DraggableData {
         type: AgentType.killjoy,
         role: AgentRole.sentinel,
         name: "Killjoy",
+        abilityNames: const [
+          "Nanoswarm",
+          "Alarmbot",
+          "Turret",
+          "Lockdown",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -477,6 +544,12 @@ class AgentData implements DraggableData {
         type: AgentType.brimstone,
         role: AgentRole.controller,
         name: "Brimstone",
+        abilityNames: const [
+          "Stim Beacon",
+          "Incendiary",
+          "Sky Smoke",
+          "Orbital Strike",
+        ],
       )..abilities[2] = AbilityInfo(
           type: AgentType.brimstone,
           index: 2,
@@ -518,6 +591,12 @@ class AgentData implements DraggableData {
         type: AgentType.cypher,
         role: AgentRole.sentinel,
         name: "Cypher",
+        abilityNames: const [
+          "Trapwire",
+          "Cyber Cage",
+          "Spycam",
+          "Neural Theft",
+        ],
       );
       agent.abilities.first.abilityData = ResizableSquareAbility(
         width: 3,
@@ -542,6 +621,12 @@ class AgentData implements DraggableData {
         type: AgentType.chamber,
         role: AgentRole.sentinel,
         name: "Chamber",
+        abilityNames: const [
+          "Trademark",
+          "Headhunter",
+          "Rendezvous",
+          "Tour De Force",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -565,6 +650,12 @@ class AgentData implements DraggableData {
         type: AgentType.fade,
         role: AgentRole.initiator,
         name: "Fade",
+        abilityNames: const [
+          "Prowler",
+          "Seize",
+          "Haunt",
+          "Nightfall",
+        ],
       );
 
       agent.abilities[1].abilityData = CircleAbility(
@@ -595,6 +686,12 @@ class AgentData implements DraggableData {
         type: AgentType.neon,
         role: AgentRole.duelist,
         name: "Neon",
+        abilityNames: const [
+          "Fast Lane",
+          "Relay Bolt",
+          "High Gear",
+          "Overdrive",
+        ],
       );
 
       agent.abilities.first.abilityData = ResizableSquareAbility(
@@ -622,10 +719,16 @@ class AgentData implements DraggableData {
         type: AgentType.omen,
         role: AgentRole.controller,
         name: "Omen",
+        abilityNames: const [
+          "Shrouded Step",
+          "Paranoia",
+          "Dark Cover",
+          "From the Shadows",
+        ],
       )..abilities[2] = AbilityInfo(
           type: AgentType.omen,
           index: 2,
-          name: "Smoke",
+          name: "Dark Cover",
           iconPath: 'assets/agents/Omen/3.webp',
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Omen/Smoke.webp',
@@ -647,6 +750,12 @@ class AgentData implements DraggableData {
         type: AgentType.reyna,
         role: AgentRole.duelist,
         name: "Reyna",
+        abilityNames: const [
+          "Leer",
+          "Devour",
+          "Dismiss",
+          "Empress",
+        ],
       );
       return agent;
     })(),
@@ -655,6 +764,12 @@ class AgentData implements DraggableData {
         type: AgentType.sage,
         role: AgentRole.sentinel,
         name: "Sage",
+        abilityNames: const [
+          "Barrier Orb",
+          "Slow Orb",
+          "Healing Orb",
+          "Resurrection",
+        ],
       );
 
       agent.abilities.first.abilityData = RotatableImageAbility(
@@ -677,10 +792,16 @@ class AgentData implements DraggableData {
         type: AgentType.clove,
         role: AgentRole.controller,
         name: "Clove",
+        abilityNames: const [
+          "Pick-me-up",
+          "Meddle",
+          "Ruse",
+          "Not Dead Yet",
+        ],
       )..abilities[2] = AbilityInfo(
           type: AgentType.clove,
           index: 2,
-          name: "Sky Smoke",
+          name: "Ruse",
           iconPath: 'assets/agents/Clove/3.webp',
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Clove/Smoke.webp',
@@ -702,6 +823,12 @@ class AgentData implements DraggableData {
         type: AgentType.iso,
         role: AgentRole.duelist,
         name: "Iso",
+        abilityNames: const [
+          "Contingency",
+          "Undercut",
+          "Double Tap",
+          "Kill Contract",
+        ],
       );
 
       agent.abilities.first.abilityData = SquareAbility(
@@ -734,6 +861,12 @@ class AgentData implements DraggableData {
         type: AgentType.deadlock,
         role: AgentRole.sentinel,
         name: "Deadlock",
+        abilityNames: const [
+          "Barrier Mesh",
+          "Sonic Sensor",
+          "GravNet",
+          "Annihilation",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -762,6 +895,12 @@ class AgentData implements DraggableData {
         type: AgentType.gekko,
         role: AgentRole.initiator,
         name: "Gekko",
+        abilityNames: const [
+          "Mosh Pit",
+          "Wingman",
+          "Dizzy",
+          "Thrash",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -778,10 +917,16 @@ class AgentData implements DraggableData {
         type: AgentType.harbor,
         role: AgentRole.controller,
         name: "Harbor",
+        abilityNames: const [
+          "Storm Surge",
+          "High Tide",
+          "Cove",
+          "Reckoning",
+        ],
       )..abilities[2] = AbilityInfo(
           type: AgentType.harbor,
           index: 2,
-          name: "Sky Smoke",
+          name: "Cove",
           iconPath: 'assets/agents/Harbor/3.webp',
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Harbor/Smoke.webp',
@@ -822,6 +967,12 @@ class AgentData implements DraggableData {
         type: AgentType.vyse,
         role: AgentRole.sentinel,
         name: "Vyse",
+        abilityNames: const [
+          "Razorvine",
+          "Shear",
+          "Arc Rose",
+          "Steel Garden",
+        ],
       );
 
       agent.abilities.first.abilityData = SquareAbility(
@@ -852,6 +1003,12 @@ class AgentData implements DraggableData {
         type: AgentType.tejo,
         role: AgentRole.initiator,
         name: "Tejo",
+        abilityNames: const [
+          "Stealth Drone",
+          "Special Delivery",
+          "Guided Salvo",
+          "Armageddon",
+        ],
       );
 
       agent.abilities.first.abilityData = CircleAbility(
@@ -886,7 +1043,16 @@ class AgentData implements DraggableData {
     })(),
     AgentType.waylay: (() {
       final agent = AgentData(
-          type: AgentType.waylay, role: AgentRole.duelist, name: "Waylay");
+        type: AgentType.waylay,
+        role: AgentRole.duelist,
+        name: "Waylay",
+        abilityNames: const [
+          "Saturate",
+          "Lightspeed",
+          "Refract",
+          "Convergent Paths",
+        ],
+      );
 
       agent.abilities.first.abilityData = CircleAbility(
         iconPath: agent.abilities.first.iconPath,
@@ -907,7 +1073,16 @@ class AgentData implements DraggableData {
     })(),
     AgentType.veto: (() {
       final agent = AgentData(
-          type: AgentType.veto, role: AgentRole.sentinel, name: "Veto");
+        type: AgentType.veto,
+        role: AgentRole.sentinel,
+        name: "Veto",
+        abilityNames: const [
+          "Crosscut",
+          "Chokehold",
+          "Interceptor",
+          "Evolution",
+        ],
+      );
 
       agent.abilities.first.abilityData = CircleAbility(
         iconPath: agent.abilities.first.iconPath,
@@ -937,12 +1112,18 @@ class AgentData implements DraggableData {
         type: AgentType.miks,
         role: AgentRole.controller,
         name: "Miks",
+        abilityNames: const [
+          "M-pulse Concuss",
+          "M-pulse Healing",
+          "Harmonize",
+          "Waveform",
+        ],
       );
       // agent.abilities.
       final miksConcuss = AbilityInfo(
         type: AgentType.miks,
         index: 0,
-        name: "Concussive Blast",
+        name: "M-pulse Concuss",
         iconPath: 'assets/agents/Miks/1.webp',
         abilityData: CircleAbility(
           iconPath: agent.abilities[0].iconPath,
@@ -954,7 +1135,7 @@ class AgentData implements DraggableData {
       final miksHeal = AbilityInfo(
         type: AgentType.miks,
         index: 1,
-        name: "Healing Blast",
+        name: "M-pulse Healing",
         iconPath: 'assets/agents/Miks/2.webp',
         abilityData: CircleAbility(
           iconPath: agent.abilities[1].iconPath,
@@ -963,20 +1144,27 @@ class AgentData implements DraggableData {
           hasCenterDot: true,
         ),
       );
-      final miksSmoke = AbilityInfo(
+      final miksHarmonize = AbilityInfo(
         type: AgentType.miks,
         index: 2,
-        name: "Miks Smoke",
+        name: "Harmonize",
         iconPath: 'assets/agents/Miks/3.webp',
         abilityData: ImageAbility(
             imagePath: 'assets/agents/Miks/Smoke.webp',
             size: 4.1 * inGameMetersDiameter),
       );
+      final miksWaveform = AbilityInfo(
+        type: AgentType.miks,
+        index: 3,
+        name: "Waveform",
+        iconPath: 'assets/agents/Miks/4.webp',
+        abilityData: BaseAbility(iconPath: 'assets/agents/Miks/4.webp'),
+      );
 
       final miksUlt = AbilityInfo(
         type: AgentType.miks,
         index: 4,
-        name: "Miks Ult",
+        name: "Bassquake",
         iconPath: 'assets/agents/Miks/5.webp',
         abilityData: SectorCircleAbility(
           iconPath: "assets/agents/Miks/5.webp",
@@ -987,7 +1175,8 @@ class AgentData implements DraggableData {
       );
       agent.abilities[0] = miksConcuss;
       agent.abilities[1] = miksHeal;
-      agent.abilities[2] = miksSmoke;
+      agent.abilities[2] = miksHarmonize;
+      agent.abilities[3] = miksWaveform;
       agent.abilities.add(miksUlt);
 
       return agent;

--- a/lib/const/agents.dart
+++ b/lib/const/agents.dart
@@ -179,7 +179,11 @@ class AgentData implements DraggableData {
     required this.role,
     required this.name,
     List<String>? abilityNames,
-  })  : iconPath = 'assets/agents/$name/icon.webp',
+  })  : assert(
+          abilityNames == null || abilityNames.length == 4,
+          'abilityNames must contain exactly 4 entries',
+        ),
+        iconPath = 'assets/agents/$name/icon.webp',
         abilities = List.generate(
           4,
           (index) => AbilityInfo(

--- a/lib/interactive_map.dart
+++ b/lib/interactive_map.dart
@@ -18,6 +18,7 @@ import 'package:icarus/widgets/dot_painter.dart';
 import 'package:icarus/widgets/drawing_painter.dart';
 import 'package:icarus/widgets/draggable_widgets/placed_widget_builder.dart';
 import 'package:icarus/widgets/delete_area.dart';
+import 'package:icarus/widgets/hovered_map_item_name_card.dart';
 import 'package:icarus/widgets/lineup_control_buttons.dart';
 import 'package:icarus/widgets/page_transition_overlay.dart';
 import 'package:icarus/widgets/image_drop_target.dart';
@@ -388,7 +389,14 @@ class _InteractiveMapState extends ConsumerState<InteractiveMap> {
                       Positioned(
                         top: 0,
                         right: 0,
-                        child: DeleteArea(),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: const [
+                            HoveredMapItemNameCard(),
+                            DeleteArea(),
+                          ],
+                        ),
                       ),
                       Align(
                         alignment: Alignment.bottomRight,

--- a/lib/providers/hovered_map_item_name_provider.dart
+++ b/lib/providers/hovered_map_item_name_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final hoveredMapItemNameProvider = StateProvider<String?>((ref) => null);
+
+void clearHoveredMapItemNameIfCurrent(WidgetRef ref, String name) {
+  final currentName = ref.read(hoveredMapItemNameProvider);
+  if (currentName == name) {
+    ref.read(hoveredMapItemNameProvider.notifier).state = null;
+  }
+}

--- a/lib/widgets/hovered_map_item_name_card.dart
+++ b/lib/widgets/hovered_map_item_name_card.dart
@@ -26,16 +26,54 @@ class _HoveredMapItemNameCardState
   Timer? _hideTimer;
   String? _visibleName;
   int _visibleNameVersion = 0;
+  late final List<ProviderSubscription<dynamic>> _subscriptions;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscriptions = [
+      ref.listenManual(hoveredLineUpTargetProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(lineUpProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(hoveredDeleteTargetProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(agentProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(abilityProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(hoveredMapItemNameProvider, (_, __) {
+        _syncVisibleName();
+      }),
+      ref.listenManual(screenshotProvider, (_, __) {
+        _syncVisibleName();
+      }),
+    ];
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _syncVisibleName();
+      }
+    });
+  }
 
   @override
   void dispose() {
     _hideTimer?.cancel();
+    for (final subscription in _subscriptions) {
+      subscription.close();
+    }
     super.dispose();
   }
 
-  String? _resolveLineUpName(WidgetRef ref, HoveredLineUpTarget target) {
+  String? _resolveLineUpName(HoveredLineUpTarget target) {
     LineUpGroup? group;
-    for (final candidate in ref.watch(lineUpProvider).groups) {
+    for (final candidate in ref.read(lineUpProvider).groups) {
       if (candidate.id == target.groupId) {
         group = candidate;
         break;
@@ -59,34 +97,34 @@ class _HoveredMapItemNameCardState
     return AgentData.agents[group.agent.type]?.name;
   }
 
-  String? _resolveHoveredName(WidgetRef ref) {
-    final lineUpTarget = ref.watch(hoveredLineUpTargetProvider);
+  String? _resolveHoveredName() {
+    final lineUpTarget = ref.read(hoveredLineUpTargetProvider);
     if (lineUpTarget != null) {
-      return _resolveLineUpName(ref, lineUpTarget);
+      return _resolveLineUpName(lineUpTarget);
     }
 
-    final hoveredTarget = ref.watch(hoveredDeleteTargetProvider);
+    final hoveredTarget = ref.read(hoveredDeleteTargetProvider);
     if (hoveredTarget == null) {
-      return ref.watch(hoveredMapItemNameProvider);
+      return ref.read(hoveredMapItemNameProvider);
     }
 
     switch (hoveredTarget.type) {
       case DeleteTargetType.agent:
-        for (final agent in ref.watch(agentProvider)) {
+        for (final agent in ref.read(agentProvider)) {
           if (agent.id == hoveredTarget.id) {
             return AgentData.agents[agent.type]?.name;
           }
         }
         return null;
       case DeleteTargetType.ability:
-        for (final ability in ref.watch(abilityProvider)) {
+        for (final ability in ref.read(abilityProvider)) {
           if (ability.id == hoveredTarget.id) {
             return ability.data.name;
           }
         }
         return null;
       case DeleteTargetType.lineup:
-        for (final group in ref.watch(lineUpProvider).groups) {
+        for (final group in ref.read(lineUpProvider).groups) {
           if (group.id == hoveredTarget.id) {
             return AgentData.agents[group.agent.type]?.name;
           }
@@ -95,21 +133,24 @@ class _HoveredMapItemNameCardState
       case DeleteTargetType.text:
       case DeleteTargetType.image:
       case DeleteTargetType.utility:
-        return ref.watch(hoveredMapItemNameProvider);
+        return ref.read(hoveredMapItemNameProvider);
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final name = _resolveHoveredName(ref);
-    final isScreenshot = ref.watch(screenshotProvider);
+  void _syncVisibleName() {
+    if (!mounted) return;
+    final name = _resolveHoveredName();
+    final isScreenshot = ref.read(screenshotProvider);
     final nextName = isScreenshot ? null : name?.trim();
+
     if (nextName != null && nextName.isNotEmpty) {
       _hideTimer?.cancel();
       _hideTimer = null;
       if (_visibleName != nextName) {
-        _visibleNameVersion++;
-        _visibleName = nextName;
+        setState(() {
+          _visibleNameVersion++;
+          _visibleName = nextName;
+        });
       }
     } else if (_visibleName != null && _hideTimer == null) {
       _hideTimer = Timer(_hideDelay, () {
@@ -120,7 +161,10 @@ class _HoveredMapItemNameCardState
         });
       });
     }
+  }
 
+  @override
+  Widget build(BuildContext context) {
     final visibleName = _visibleName;
     final shouldShow = visibleName != null && visibleName.isNotEmpty;
 

--- a/lib/widgets/hovered_map_item_name_card.dart
+++ b/lib/widgets/hovered_map_item_name_card.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/line_provider.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/providers/ability_provider.dart';
+import 'package:icarus/providers/agent_provider.dart';
+import 'package:icarus/providers/hovered_delete_target_provider.dart';
+import 'package:icarus/providers/hovered_map_item_name_provider.dart';
+import 'package:icarus/providers/screenshot_provider.dart';
+
+class HoveredMapItemNameCard extends ConsumerStatefulWidget {
+  const HoveredMapItemNameCard({super.key});
+
+  @override
+  ConsumerState<HoveredMapItemNameCard> createState() =>
+      _HoveredMapItemNameCardState();
+}
+
+class _HoveredMapItemNameCardState
+    extends ConsumerState<HoveredMapItemNameCard> {
+  static const Duration _hideDelay = Duration(milliseconds: 125);
+
+  Timer? _hideTimer;
+  String? _visibleName;
+  int _visibleNameVersion = 0;
+
+  @override
+  void dispose() {
+    _hideTimer?.cancel();
+    super.dispose();
+  }
+
+  String? _resolveLineUpName(WidgetRef ref, HoveredLineUpTarget target) {
+    LineUpGroup? group;
+    for (final candidate in ref.watch(lineUpProvider).groups) {
+      if (candidate.id == target.groupId) {
+        group = candidate;
+        break;
+      }
+    }
+    if (group == null) {
+      return null;
+    }
+
+    if (target.kind == LineUpHoverKind.item && target.itemId != null) {
+      LineUpItem? item;
+      for (final candidate in group.items) {
+        if (candidate.id == target.itemId) {
+          item = candidate;
+          break;
+        }
+      }
+      return item?.ability.data.name;
+    }
+
+    return AgentData.agents[group.agent.type]?.name;
+  }
+
+  String? _resolveHoveredName(WidgetRef ref) {
+    final lineUpTarget = ref.watch(hoveredLineUpTargetProvider);
+    if (lineUpTarget != null) {
+      return _resolveLineUpName(ref, lineUpTarget);
+    }
+
+    final hoveredTarget = ref.watch(hoveredDeleteTargetProvider);
+    if (hoveredTarget == null) {
+      return ref.watch(hoveredMapItemNameProvider);
+    }
+
+    switch (hoveredTarget.type) {
+      case DeleteTargetType.agent:
+        for (final agent in ref.watch(agentProvider)) {
+          if (agent.id == hoveredTarget.id) {
+            return AgentData.agents[agent.type]?.name;
+          }
+        }
+        return null;
+      case DeleteTargetType.ability:
+        for (final ability in ref.watch(abilityProvider)) {
+          if (ability.id == hoveredTarget.id) {
+            return ability.data.name;
+          }
+        }
+        return null;
+      case DeleteTargetType.lineup:
+        for (final group in ref.watch(lineUpProvider).groups) {
+          if (group.id == hoveredTarget.id) {
+            return AgentData.agents[group.agent.type]?.name;
+          }
+        }
+        return null;
+      case DeleteTargetType.text:
+      case DeleteTargetType.image:
+      case DeleteTargetType.utility:
+        return ref.watch(hoveredMapItemNameProvider);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final name = _resolveHoveredName(ref);
+    final isScreenshot = ref.watch(screenshotProvider);
+    final nextName = isScreenshot ? null : name?.trim();
+    if (nextName != null && nextName.isNotEmpty) {
+      _hideTimer?.cancel();
+      _hideTimer = null;
+      if (_visibleName != nextName) {
+        _visibleNameVersion++;
+        _visibleName = nextName;
+      }
+    } else if (_visibleName != null && _hideTimer == null) {
+      _hideTimer = Timer(_hideDelay, () {
+        if (!mounted) return;
+        setState(() {
+          _visibleName = null;
+          _hideTimer = null;
+        });
+      });
+    }
+
+    final visibleName = _visibleName;
+    final shouldShow = visibleName != null && visibleName.isNotEmpty;
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, top: 16),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 120),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeOutCubic,
+        child: shouldShow
+            ? IntrinsicWidth(
+                key: ValueKey('hovered-map-item-$_visibleNameVersion'),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minWidth: 48,
+                    maxWidth: 160,
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 7,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Settings.abilityBGColor,
+                      borderRadius: const BorderRadius.all(Radius.circular(4)),
+                      border: Border.all(
+                        color: Settings.tacticalVioletTheme.border,
+                        width: 2,
+                      ),
+                      boxShadow: const [Settings.cardForegroundBackdrop],
+                    ),
+                    child: Text(
+                      visibleName,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                            color: Settings.tacticalVioletTheme.foreground,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                  ),
+                ),
+              )
+            : const SizedBox(
+                key: ValueKey('empty-hovered-map-item-name'),
+                height: 0,
+                width: 0,
+              ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/sidebar_widgets/ability_bar.dart
+++ b/lib/widgets/sidebar_widgets/ability_bar.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_bar_provider.dart';
+import 'package:icarus/providers/hovered_map_item_name_provider.dart';
 import 'package:icarus/providers/interaction_state_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/screen_zoom_provider.dart';
@@ -57,8 +58,6 @@ class AbiilityBar extends ConsumerWidget {
         ),
         boxShadow: const [
           Settings.cardForegroundBackdrop,
-          
-
         ],
       ),
       child: Column(
@@ -68,9 +67,11 @@ class AbiilityBar extends ConsumerWidget {
           ...List.generate(
             activeAgent.abilities.length,
             (index) {
+              final ability = activeAgent.abilities[index];
               return Draggable<AbilityInfo>(
-                data: activeAgent.abilities[index],
+                data: ability,
                 onDragStarted: () {
+                  clearHoveredMapItemNameIfCurrent(ref, ability.name);
                   if (ref.read(interactionStateProvider) ==
                           InteractionState.drawing ||
                       ref.read(interactionStateProvider) ==
@@ -96,8 +97,7 @@ class AbiilityBar extends ConsumerWidget {
                 feedback: Opacity(
                   opacity: Settings.feedbackOpacity,
                   child: ZoomTransform(
-                    child:
-                        activeAgent.abilities[index].abilityData!.createWidget(
+                    child: ability.abilityData!.createWidget(
                       id: null,
                       isAlly: ref.watch(teamProvider),
                       mapScale: mapScale,
@@ -106,15 +106,25 @@ class AbiilityBar extends ConsumerWidget {
                 ),
 
                 // dragAnchorStrategy: centerDragStrategy,
-                child: InkWell(
-                  mouseCursor: SystemMouseCursors.click,
-                  onTap: () {},
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: SizedBox(
-                      height: 55,
-                      width: 55,
-                      child: Image.asset(activeAgent.abilities[index].iconPath),
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  onEnter: (_) {
+                    ref.read(hoveredMapItemNameProvider.notifier).state =
+                        ability.name;
+                  },
+                  onExit: (_) {
+                    clearHoveredMapItemNameIfCurrent(ref, ability.name);
+                  },
+                  child: InkWell(
+                    mouseCursor: SystemMouseCursors.click,
+                    onTap: () {},
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: SizedBox(
+                        height: 55,
+                        width: 55,
+                        child: Image.asset(ability.iconPath),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/widgets/sidebar_widgets/agent_dragable.dart
+++ b/lib/widgets/sidebar_widgets/agent_dragable.dart
@@ -206,6 +206,7 @@ class _AgentDragableState extends ConsumerState<AgentDragable>
               clipBehavior: Clip.none,
               children: [
                 InkWell(
+                  key: ValueKey('agent-tile-${agent.type.name}'),
                   mouseCursor: shouldDisableForLockedAddItem
                       ? SystemMouseCursors.forbidden
                       : SystemMouseCursors.click,

--- a/lib/widgets/sidebar_widgets/agent_dragable.dart
+++ b/lib/widgets/sidebar_widgets/agent_dragable.dart
@@ -8,6 +8,7 @@ import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_bar_provider.dart';
 import 'package:icarus/providers/favorite_agents_provider.dart';
+import 'package:icarus/providers/hovered_map_item_name_provider.dart';
 import 'package:icarus/providers/interaction_state_provider.dart';
 import 'package:icarus/providers/screen_zoom_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
@@ -185,8 +186,12 @@ class _AgentDragableState extends ConsumerState<AgentDragable>
           cursor: shouldDisableForLockedAddItem
               ? SystemMouseCursors.forbidden
               : SystemMouseCursors.click,
-          onEnter: (_) => setState(() => _isTileHovered = true),
+          onEnter: (_) {
+            ref.read(hoveredMapItemNameProvider.notifier).state = agent.name;
+            setState(() => _isTileHovered = true);
+          },
           onExit: (_) {
+            clearHoveredMapItemNameIfCurrent(ref, agent.name);
             setState(() {
               _isTileHovered = false;
               _isStarHovered = false;

--- a/lib/widgets/sidebar_widgets/agent_dragable.dart
+++ b/lib/widgets/sidebar_widgets/agent_dragable.dart
@@ -156,6 +156,7 @@ class _AgentDragableState extends ConsumerState<AgentDragable>
       child: Draggable(
         data: agent,
         onDragStarted: () {
+          clearHoveredMapItemNameIfCurrent(ref, agent.name);
           if (ref.read(interactionStateProvider) == InteractionState.drawing ||
               ref.read(interactionStateProvider) == InteractionState.erasing) {
             ref

--- a/test/agent_ability_names_test.dart
+++ b/test/agent_ability_names_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/agents.dart';
+
+void main() {
+  test('agent abilities use wiki names in C Q E X order', () {
+    final expectedNames = <AgentType, List<String>>{
+      AgentType.jett: ['Cloudburst', 'Updraft', 'Tailwind', 'Blade Storm'],
+      AgentType.raze: ['Boom Bot', 'Blast Pack', 'Paint Shells', 'Showstopper'],
+      AgentType.pheonix: ['Blaze', 'Hot Hands', 'Curveball', 'Run it Back'],
+      AgentType.astra: [
+        'Gravity Well',
+        'Nova Pulse',
+        'Nebula/Dissipate',
+        'Cosmic Divide',
+        'Astra Star',
+      ],
+      AgentType.clove: ['Pick-me-up', 'Meddle', 'Ruse', 'Not Dead Yet'],
+      AgentType.breach: [
+        'Aftershock',
+        'Flashpoint',
+        'Fault Line',
+        'Rolling Thunder',
+      ],
+      AgentType.iso: ['Contingency', 'Undercut', 'Double Tap', 'Kill Contract'],
+      AgentType.viper: [
+        'Snake Bite',
+        'Poison Cloud',
+        'Toxic Screen',
+        "Viper's Pit",
+      ],
+      AgentType.deadlock: [
+        'Barrier Mesh',
+        'Sonic Sensor',
+        'GravNet',
+        'Annihilation',
+      ],
+      AgentType.yoru: [
+        'Fakeout',
+        'Blindside',
+        'Gatecrash',
+        'Dimensional Drift',
+      ],
+      AgentType.sova: [
+        'Owl Drone',
+        'Shock Bolt',
+        'Recon Bolt',
+        "Hunter's Fury",
+      ],
+      AgentType.skye: ['Regrowth', 'Trailblazer', 'Guiding Light', 'Seekers'],
+      AgentType.kayo: ['FRAG/ment', 'FLASH/drive', 'ZERO/point', 'NULL/cmd'],
+      AgentType.killjoy: ['Nanoswarm', 'Alarmbot', 'Turret', 'Lockdown'],
+      AgentType.brimstone: [
+        'Stim Beacon',
+        'Incendiary',
+        'Sky Smoke',
+        'Orbital Strike',
+      ],
+      AgentType.cypher: ['Trapwire', 'Cyber Cage', 'Spycam', 'Neural Theft'],
+      AgentType.chamber: [
+        'Trademark',
+        'Headhunter',
+        'Rendezvous',
+        'Tour De Force',
+      ],
+      AgentType.fade: ['Prowler', 'Seize', 'Haunt', 'Nightfall'],
+      AgentType.gekko: ['Mosh Pit', 'Wingman', 'Dizzy', 'Thrash'],
+      AgentType.harbor: ['Storm Surge', 'High Tide', 'Cove', 'Reckoning'],
+      AgentType.neon: ['Fast Lane', 'Relay Bolt', 'High Gear', 'Overdrive'],
+      AgentType.omen: [
+        'Shrouded Step',
+        'Paranoia',
+        'Dark Cover',
+        'From the Shadows',
+      ],
+      AgentType.reyna: ['Leer', 'Devour', 'Dismiss', 'Empress'],
+      AgentType.sage: [
+        'Barrier Orb',
+        'Slow Orb',
+        'Healing Orb',
+        'Resurrection',
+      ],
+      AgentType.vyse: ['Razorvine', 'Shear', 'Arc Rose', 'Steel Garden'],
+      AgentType.tejo: [
+        'Stealth Drone',
+        'Special Delivery',
+        'Guided Salvo',
+        'Armageddon',
+      ],
+      AgentType.waylay: [
+        'Saturate',
+        'Lightspeed',
+        'Refract',
+        'Convergent Paths',
+      ],
+      AgentType.veto: ['Crosscut', 'Chokehold', 'Interceptor', 'Evolution'],
+      AgentType.miks: [
+        'M-pulse Concuss',
+        'M-pulse Healing',
+        'Harmonize',
+        'Waveform',
+        'Bassquake',
+      ],
+    };
+
+    expect(AgentData.agents.keys.toSet(), expectedNames.keys.toSet());
+
+    for (final entry in expectedNames.entries) {
+      final agent = AgentData.agents[entry.key]!;
+      expect(
+        agent.abilities.map((ability) => ability.name),
+        entry.value,
+        reason: '${agent.name} ability names should match VALORANT Wiki order',
+      );
+    }
+  });
+}

--- a/test/agent_dragable_lineup_state_test.dart
+++ b/test/agent_dragable_lineup_state_test.dart
@@ -61,13 +61,8 @@ Finder _opacityFinder(AgentType type) {
   return find.byKey(ValueKey('agent-dim-opacity-${type.name}'));
 }
 
-Finder _tileTapTarget(AgentType type) {
-  return find
-      .descendant(
-        of: _opacityFinder(type),
-        matching: find.byType(InkWell),
-      )
-      .first;
+Finder _tileFinder(AgentType type) {
+  return find.byKey(ValueKey('agent-tile-${type.name}'));
 }
 
 void main() {
@@ -121,7 +116,7 @@ void main() {
 
     await _pumpHarness(tester, container: container);
 
-    await tester.tap(_tileTapTarget(AgentType.sova), warnIfMissed: false);
+    await tester.tap(_tileFinder(AgentType.sova), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     expect(container.read(abilityBarProvider)?.type, AgentType.sova);
@@ -200,7 +195,7 @@ void main() {
 
     await _pumpHarness(tester, container: container);
 
-    await tester.tap(_tileTapTarget(AgentType.sova), warnIfMissed: false);
+    await tester.tap(_tileFinder(AgentType.sova), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     expect(container.read(abilityBarProvider)?.type, AgentType.breach);
@@ -238,7 +233,7 @@ void main() {
     await _pumpHarness(tester, container: container);
 
     await tester.drag(
-      _tileTapTarget(AgentType.sova),
+      _tileFinder(AgentType.sova),
       const Offset(30, 0),
       warnIfMissed: false,
     );


### PR DESCRIPTION
## Summary
- Replace placeholder ability labels with agent-specific ability names and cover them with focused regression coverage.
- Correct circular ability inner-range unit conversion so radius-based values use the same diameter scaling as outer circular ranges.
- Show hovered agent/ability names while dragging or hovering sidebar/map items, with drag-start clearing for agent and ability drags.

## Validation
- `fvm flutter test test/agent_dragable_lineup_state_test.dart test/agent_ability_names_test.dart` passed.
- `fvm flutter analyze --no-fatal-infos` passed; it still reports four existing info-level `prefer_const_constructors` notes in `test/square_icon_counter_rotation_test.dart`.
- GitHub Actions `validate` passed on head `a613a65`.

## Risk / Compatibility
- UI-only hover label behavior plus data-label corrections; no storage format or updater changes.
- Circular ability range rendering changes are limited to radius-style abilities and existing constants.