### PR TITLE
Load strategies with a strategy view skeleton

### DIFF
--- a/lib/const/coordinate_system.dart
+++ b/lib/const/coordinate_system.dart
@@ -23,8 +23,9 @@ class CoordinateSystem {
 
   Size get effectiveSize => _effectiveSize;
   // The normalized coordinate space will maintain this aspect ratio
+  static const double defaultMapAspectRatio = 1.24;
   final double normalizedHeight = 1000.0;
-  final double mapAspectRatio = 1.24;
+  final double mapAspectRatio = defaultMapAspectRatio;
   final double worldAspectRatio = 16 / 9;
 
   double get mapNormalizedWidth => normalizedHeight * mapAspectRatio;

--- a/lib/strategy_view.dart
+++ b/lib/strategy_view.dart
@@ -80,6 +80,7 @@ class _StrategyViewState extends ConsumerState<StrategyView>
     with WindowListener {
   bool _isClosingWindow = false;
   bool _isInitialLoadPending = false;
+  bool _hasInitialLoadCompleted = false;
 
   @override
   void initState() {
@@ -124,6 +125,7 @@ class _StrategyViewState extends ConsumerState<StrategyView>
       if (loadedStrategy.id != strategyId || loadedStrategy.stratName == null) {
         throw StateError('Strategy "$strategyId" was not found.');
       }
+      _hasInitialLoadCompleted = true;
     } catch (error, stackTrace) {
       developer.log(
         'Error loading strategy: $error',
@@ -180,7 +182,8 @@ class _StrategyViewState extends ConsumerState<StrategyView>
     final strategyState = ref.watch(strategyProvider);
     final initialStrategyId = widget.initialStrategyId;
     final showSkeleton = _isInitialLoadPending ||
-        (initialStrategyId != null &&
+        (!_hasInitialLoadCompleted &&
+            initialStrategyId != null &&
             (strategyState.stratName == null ||
                 strategyState.id != initialStrategyId));
 

--- a/lib/strategy_view.dart
+++ b/lib/strategy_view.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/custom_icons.dart';
+import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/interactive_map.dart';
 import 'package:icarus/providers/agent_filter_provider.dart';
@@ -12,6 +16,7 @@ import 'package:icarus/services/unsaved_strategy_guard.dart';
 import 'package:icarus/sidebar.dart';
 import 'package:icarus/widgets/delete_capture.dart';
 import 'package:icarus/widgets/demo_tag.dart';
+import 'package:icarus/widgets/strategy_view_skeleton.dart';
 import 'package:icarus/widgets/strategy_quick_switcher.dart';
 import 'package:icarus/widgets/map_selector.dart';
 import 'package:icarus/widgets/pages_bar.dart';
@@ -24,7 +29,48 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
 class StrategyView extends ConsumerStatefulWidget {
-  const StrategyView({super.key});
+  const StrategyView({
+    super.key,
+    this.initialStrategyId,
+    this.initialStrategyName,
+    this.initialMapValue,
+    this.initialIsAttack = true,
+  });
+
+  final String? initialStrategyId;
+  final String? initialStrategyName;
+  final MapValue? initialMapValue;
+  final bool initialIsAttack;
+
+  static PageRoute<void> route({
+    String? initialStrategyId,
+    String? initialStrategyName,
+    MapValue? initialMapValue,
+    bool initialIsAttack = true,
+  }) {
+    return PageRouteBuilder<void>(
+      transitionDuration: const Duration(milliseconds: 200),
+      reverseTransitionDuration: const Duration(milliseconds: 200),
+      pageBuilder: (context, animation, _) => StrategyView(
+        initialStrategyId: initialStrategyId,
+        initialStrategyName: initialStrategyName,
+        initialMapValue: initialMapValue,
+        initialIsAttack: initialIsAttack,
+      ),
+      transitionsBuilder: (context, animation, _, child) {
+        return FadeTransition(
+          opacity: animation,
+          child: ScaleTransition(
+            scale: Tween<double>(
+              begin: 0.9,
+              end: 1.0,
+            ).chain(CurveTween(curve: Curves.easeOut)).animate(animation),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _StrategyViewState();
@@ -33,10 +79,17 @@ class StrategyView extends ConsumerStatefulWidget {
 class _StrategyViewState extends ConsumerState<StrategyView>
     with WindowListener {
   bool _isClosingWindow = false;
+  bool _isInitialLoadPending = false;
 
   @override
   void initState() {
     super.initState();
+    if (widget.initialStrategyId != null) {
+      _isInitialLoadPending = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_loadInitialStrategy());
+      });
+    }
     if (!kIsWeb) {
       windowManager.addListener(this);
       _enableWindowCloseGuard();
@@ -54,6 +107,42 @@ class _StrategyViewState extends ConsumerState<StrategyView>
 
   Future<void> _enableWindowCloseGuard() async {
     await windowManager.setPreventClose(true);
+  }
+
+  Future<void> _loadInitialStrategy() async {
+    final strategyId = widget.initialStrategyId;
+    if (strategyId == null) {
+      if (mounted) {
+        setState(() => _isInitialLoadPending = false);
+      }
+      return;
+    }
+
+    try {
+      await ref.read(strategyProvider.notifier).loadFromHive(strategyId);
+      final loadedStrategy = ref.read(strategyProvider);
+      if (loadedStrategy.id != strategyId || loadedStrategy.stratName == null) {
+        throw StateError('Strategy "$strategyId" was not found.');
+      }
+    } catch (error, stackTrace) {
+      developer.log(
+        'Error loading strategy: $error',
+        name: 'strategy_view',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        Settings.showToast(
+          message: 'Could not load strategy.',
+          backgroundColor: Settings.tacticalVioletTheme.destructive,
+        );
+        Navigator.maybePop(context);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isInitialLoadPending = false);
+      }
+    }
   }
 
   Future<void> _leaveToLibrary() async {
@@ -88,12 +177,33 @@ class _StrategyViewState extends ConsumerState<StrategyView>
         );
       }
     });
+    final strategyState = ref.watch(strategyProvider);
+    final initialStrategyId = widget.initialStrategyId;
+    final showSkeleton = _isInitialLoadPending ||
+        (initialStrategyId != null &&
+            (strategyState.stratName == null ||
+                strategyState.id != initialStrategyId));
+
+    if (showSkeleton) {
+      return Scaffold(
+        body: StrategyViewSkeleton(
+          strategyName: widget.initialStrategyName,
+          mapValue: widget.initialMapValue,
+          isAttack: widget.initialIsAttack,
+        ),
+      );
+    }
+
     return Scaffold(
       body: Column(
         children: [
           Padding(
-            padding:
-                const EdgeInsets.only(left: 15, top: 15, bottom: 10, right: 15),
+            padding: const EdgeInsets.only(
+              left: 15,
+              top: 15,
+              bottom: 10,
+              right: 15,
+            ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -110,33 +220,29 @@ class _StrategyViewState extends ConsumerState<StrategyView>
                       const Padding(
                         padding: EdgeInsets.symmetric(horizontal: 8.0),
                         child: DemoTag(),
-                      )
+                      ),
                   ],
                 ),
                 const StrategyQuickSwitcher(),
                 Row(
                   children: [
                     TextButton(
-                        style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
-                        ),
-                        onPressed: () async {
-                          await launchUrl(Settings.dicordLink);
-                        },
-                        child: const Row(
-                          children: [
-                            Text("Have any bugs? Join the Discord"),
-                            SizedBox(
-                              width: 10,
-                            ),
-                            Icon(
-                              CustomIcons.discord,
-                              color: Colors.white,
-                            )
-                          ],
-                        )),
+                      style: TextButton.styleFrom(
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: () async {
+                        await launchUrl(Settings.dicordLink);
+                      },
+                      child: const Row(
+                        children: [
+                          Text("Have any bugs? Join the Discord"),
+                          SizedBox(width: 10),
+                          Icon(CustomIcons.discord, color: Colors.white),
+                        ],
+                      ),
+                    ),
                   ],
-                )
+                ),
               ],
             ),
           ),
@@ -145,14 +251,8 @@ class _StrategyViewState extends ConsumerState<StrategyView>
               clipBehavior: Clip.none,
               children: [
                 Positioned.fill(child: DeleteCapture()),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: InteractiveMap(),
-                ),
-                Align(
-                  alignment: Alignment.topLeft,
-                  child: SaveAndLoadButton(),
-                ),
+                Align(alignment: Alignment.centerLeft, child: InteractiveMap()),
+                Align(alignment: Alignment.topLeft, child: SaveAndLoadButton()),
                 Align(
                   alignment: Alignment.bottomLeft,
                   child: Padding(
@@ -160,10 +260,7 @@ class _StrategyViewState extends ConsumerState<StrategyView>
                     child: PagesBar(),
                   ),
                 ),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: SideBarUI(),
-                ),
+                Align(alignment: Alignment.centerRight, child: SideBarUI()),
               ],
             ),
           ),

--- a/lib/widgets/strategy_tile/strategy_tile.dart
+++ b/lib/widgets/strategy_tile/strategy_tile.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,7 +54,8 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
         onEnter: (_) =>
             setState(() => _highlightColor = Settings.tacticalVioletTheme.ring),
         onExit: (_) => setState(
-            () => _highlightColor = Settings.tacticalVioletTheme.border),
+          () => _highlightColor = Settings.tacticalVioletTheme.border,
+        ),
         child: AbsorbPointer(
           absorbing: _isLoading,
           child: ShadContextMenuRegion(
@@ -99,9 +98,7 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
                           onPressed: () {
                             _menuButtonController.toggle();
                           },
-                          icon: const Icon(
-                            Icons.more_vert_outlined,
-                          ),
+                          icon: const Icon(Icons.more_vert_outlined),
                         ),
                       ),
                     ),
@@ -146,38 +143,18 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
     }
 
     setState(() => _isLoading = true);
-    _showLoadingOverlay();
 
     try {
-      await ref
-          .read(strategyProvider.notifier)
-          .loadFromHive(widget.strategyData.id);
       if (!context.mounted) return;
-      Navigator.pop(context);
       await Navigator.push(
         context,
-        PageRouteBuilder(
-          transitionDuration: const Duration(milliseconds: 200),
-          reverseTransitionDuration: const Duration(milliseconds: 200),
-          pageBuilder: (context, animation, _) => const StrategyView(),
-          transitionsBuilder: (context, animation, _, child) {
-            return FadeTransition(
-              opacity: animation,
-              child: ScaleTransition(
-                scale: Tween<double>(begin: 0.9, end: 1.0)
-                    .chain(CurveTween(curve: Curves.easeOut))
-                    .animate(animation),
-                child: child,
-              ),
-            );
-          },
+        StrategyView.route(
+          initialStrategyId: widget.strategyData.id,
+          initialStrategyName: widget.strategyData.name,
+          initialMapValue: widget.strategyData.mapData,
+          initialIsAttack: _initialIsAttack(widget.strategyData),
         ),
       );
-    } catch (error, stackTrace) {
-      log('Error loading strategy: $error', stackTrace: stackTrace);
-      if (context.mounted) {
-        Navigator.pop(context);
-      }
     } finally {
       if (mounted) {
         setState(() => _isLoading = false);
@@ -185,12 +162,8 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
     }
   }
 
-  void _showLoadingOverlay() {
-    showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
-    );
+  bool _initialIsAttack(StrategyData strategy) {
+    return strategy.pages.isEmpty ? true : strategy.pages.first.isAttack;
   }
 
   Future<void> _duplicateStrategy() async {

--- a/lib/widgets/strategy_view_skeleton.dart
+++ b/lib/widgets/strategy_view_skeleton.dart
@@ -1,0 +1,568 @@
+import 'package:flutter/material.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/custom_icons.dart';
+import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/widgets/dot_painter.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class StrategyViewSkeleton extends StatelessWidget {
+  const StrategyViewSkeleton({
+    super.key,
+    this.strategyName,
+    this.mapValue,
+    this.isAttack = true,
+  });
+
+  final String? strategyName;
+  final MapValue? mapValue;
+  final bool isAttack;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedMap = mapValue ?? MapValue.ascent;
+    return ExcludeSemantics(
+      child: IgnorePointer(
+        child: _SkeletonShimmer(
+          child: Column(
+            children: [
+              _SkeletonTopBar(
+                strategyName: strategyName,
+                mapValue: resolvedMap,
+                isAttack: isAttack,
+              ),
+              Expanded(
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned.fill(
+                      child: _MapCanvasSkeleton(
+                        mapValue: resolvedMap,
+                        isAttack: isAttack,
+                      ),
+                    ),
+                    const Align(
+                      alignment: Alignment.topLeft,
+                      child: Padding(
+                        padding: EdgeInsets.all(8),
+                        child: _FloatingControlSkeleton(),
+                      ),
+                    ),
+                    const Align(
+                      alignment: Alignment.bottomLeft,
+                      child: Padding(
+                        padding: EdgeInsets.all(8),
+                        child: _PagesBarSkeleton(),
+                      ),
+                    ),
+                    const Align(
+                      alignment: Alignment.centerRight,
+                      child: _SidebarSkeleton(),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SkeletonShimmer extends StatefulWidget {
+  const _SkeletonShimmer({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_SkeletonShimmer> createState() => _SkeletonShimmerState();
+}
+
+class _SkeletonShimmerState extends State<_SkeletonShimmer>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1350),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final disableAnimations = MediaQuery.of(context).disableAnimations;
+    if (disableAnimations) {
+      _controller.stop();
+    } else if (!_controller.isAnimating) {
+      _controller.repeat();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.of(context).disableAnimations) {
+      return widget.child;
+    }
+
+    return AnimatedBuilder(
+      animation: _controller,
+      child: widget.child,
+      builder: (context, child) {
+        return ShaderMask(
+          blendMode: BlendMode.srcATop,
+          shaderCallback: (bounds) {
+            final shimmerOffset =
+                -bounds.width + bounds.width * 2 * _controller.value;
+            return LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: [
+                Colors.transparent,
+                Colors.white.withAlpha(34),
+                Colors.transparent,
+              ],
+              stops: const [0.34, 0.5, 0.66],
+            ).createShader(bounds.translate(shimmerOffset, 0));
+          },
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+class _SkeletonTopBar extends StatelessWidget {
+  const _SkeletonTopBar({
+    required this.mapValue,
+    required this.isAttack,
+    this.strategyName,
+  });
+
+  final String? strategyName;
+  final MapValue mapValue;
+  final bool isAttack;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = strategyName?.trim();
+    return Padding(
+      padding: const EdgeInsets.only(left: 15, top: 15, bottom: 10, right: 15),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              const _SkeletonBlock(width: 40, height: 40, radius: 8),
+              const SizedBox(width: 5),
+              _MapSelectorSkeleton(mapValue: mapValue, isAttack: isAttack),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Container(
+              width: 280,
+              height: 40,
+              decoration: BoxDecoration(
+                color: _tone(Settings.tacticalVioletTheme.card, 0.95),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: _tone(Settings.highlightColor, 0.82)),
+              ),
+              child: Center(
+                child: title == null || title.isEmpty
+                    ? const _SkeletonBlock(width: 158, height: 12, radius: 5)
+                    : Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: ShadTheme.of(
+                            context,
+                          ).textTheme.small.copyWith(color: Colors.white70),
+                        ),
+                      ),
+              ),
+            ),
+          ),
+          const _SkeletonBlock(width: 238, height: 40, radius: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapSelectorSkeleton extends StatelessWidget {
+  const _MapSelectorSkeleton({required this.mapValue, required this.isAttack});
+
+  final MapValue mapValue;
+  final bool isAttack;
+
+  @override
+  Widget build(BuildContext context) {
+    final mapName = Maps.mapNames[mapValue] ?? Maps.mapNames[MapValue.ascent]!;
+    return Container(
+      width: 262,
+      height: 65,
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: Settings.tacticalVioletTheme.card,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: Settings.tacticalVioletTheme.border,
+          width: 2,
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: SizedBox(
+              width: 180,
+              height: 57,
+              child: ColorFiltered(
+                colorFilter: _grayscaleFilter,
+                child: Opacity(
+                  opacity: 0.62,
+                  child: Image.asset(
+                    'assets/maps/thumbnails/${mapName}_thumbnail.webp',
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  isAttack ? CustomIcons.sword : Icons.shield,
+                  size: 20,
+                  color: Settings.tacticalVioletTheme.mutedForeground,
+                ),
+                const SizedBox(height: 2),
+                _SkeletonBlock(width: isAttack ? 36 : 44, height: 8, radius: 4),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapCanvasSkeleton extends StatelessWidget {
+  const _MapCanvasSkeleton({required this.mapValue, required this.isAttack});
+
+  final MapValue mapValue;
+  final bool isAttack;
+
+  @override
+  Widget build(BuildContext context) {
+    final mapName = Maps.mapNames[mapValue] ?? Maps.mapNames[MapValue.ascent]!;
+    final assetName =
+        'assets/maps/${mapName}_map${isAttack ? "" : "_defense"}.svg';
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final height = constraints.maxHeight;
+        final worldWidth = height * (16 / 9);
+        final playAreaSize = Size(worldWidth, height);
+        CoordinateSystem(playAreaSize: playAreaSize);
+        final coordinateSystem = CoordinateSystem.instance;
+        final viewportWidth =
+            (constraints.maxWidth - Settings.sideBarReservedWidth)
+                .clamp(0.0, constraints.maxWidth)
+                .toDouble();
+        final mapWidth = height * coordinateSystem.mapAspectRatio;
+        final mapLeft = (worldWidth - mapWidth) / 2;
+        final worldLeft = (viewportWidth - worldWidth) / 2;
+
+        return Row(
+          children: [
+            SizedBox(
+              width: viewportWidth,
+              height: height,
+              child: Container(
+                width: viewportWidth,
+                height: height,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: Alignment.center,
+                    radius: 1.5,
+                    colors: [
+                      const Color(0xff18181b),
+                      ShadTheme.of(context).colorScheme.background,
+                    ],
+                  ),
+                ),
+                child: ClipRect(
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        left: worldLeft,
+                        top: 0,
+                        width: worldWidth,
+                        height: height,
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            const Positioned.fill(
+                              child: Padding(
+                                padding: EdgeInsets.all(4),
+                                child: DotGrid(),
+                              ),
+                            ),
+                            Positioned(
+                              left: mapLeft,
+                              top: 0,
+                              width: mapWidth,
+                              height: height,
+                              child: ColorFiltered(
+                                colorFilter: _grayscaleFilter,
+                                child: Opacity(
+                                  opacity: 0.46,
+                                  child: SvgPicture.asset(
+                                    assetName,
+                                    semanticsLabel: 'Map',
+                                    fit: BoxFit.contain,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(width: Settings.sideBarReservedWidth, height: height),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _FloatingControlSkeleton extends StatelessWidget {
+  const _FloatingControlSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      children: [
+        _SkeletonBlock(width: 40, height: 40, radius: 8),
+        SizedBox(width: 8),
+        _SkeletonBlock(width: 40, height: 40, radius: 8),
+        SizedBox(width: 8),
+        _SkeletonBlock(width: 40, height: 40, radius: 8),
+        SizedBox(width: 8),
+        _SkeletonBlock(width: 40, height: 40, radius: 8),
+      ],
+    );
+  }
+}
+
+class _PagesBarSkeleton extends StatelessWidget {
+  const _PagesBarSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 224,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: _tone(Settings.tacticalVioletTheme.card, 0.9),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: _tone(Settings.highlightColor, 0.88)),
+      ),
+      child: const Row(
+        children: [
+          _SkeletonBlock(width: 34, height: 34, radius: 6),
+          SizedBox(width: 8),
+          Expanded(child: _SkeletonBlock(height: 34, radius: 6)),
+          SizedBox(width: 8),
+          _SkeletonBlock(width: 34, height: 34, radius: 6),
+        ],
+      ),
+    );
+  }
+}
+
+class _SidebarSkeleton extends StatelessWidget {
+  const _SidebarSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: Settings.sideBarReservedWidth,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: Settings.sideBarPanelPaddingLeft,
+          right: Settings.sideBarPanelPaddingRight,
+          bottom: 8,
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            width: Settings.sideBarPanelWidth,
+            decoration: BoxDecoration(
+              color: Settings.tacticalVioletTheme.card,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: const Color.fromRGBO(210, 214, 219, 0.1),
+                width: 2,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: _SkeletonBlock(width: 58, height: 24, radius: 5),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: GridView.count(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    crossAxisCount: 5,
+                    mainAxisSpacing: 5,
+                    crossAxisSpacing: 5,
+                    children: List.generate(
+                      9,
+                      (_) => const _SkeletonBlock(radius: 8),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Align(
+                  alignment: Alignment.centerLeft,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: _SkeletonBlock(width: 72, height: 24, radius: 5),
+                  ),
+                ),
+                const Padding(
+                  padding: EdgeInsets.only(
+                    left: 16,
+                    right: 16,
+                    top: 8,
+                    bottom: 10,
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Row(
+                            children: [
+                              _SkeletonBlock(width: 176, height: 36, radius: 6),
+                              SizedBox(width: 8),
+                              _SkeletonBlock(width: 40, height: 40, radius: 8),
+                            ],
+                          ),
+                          SizedBox(width: 8),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              _SkeletonBlock(width: 42, height: 13, radius: 4),
+                              SizedBox(height: 8),
+                              _SkeletonBlock(width: 50, height: 13, radius: 4),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.topRight,
+                    child: SizedBox(
+                      width: Settings.sideBarContentWidth,
+                      child: GridView.count(
+                        physics: const NeverScrollableScrollPhysics(),
+                        padding: const EdgeInsets.only(bottom: 10, right: 10),
+                        crossAxisCount: 4,
+                        crossAxisSpacing: 8,
+                        mainAxisSpacing: 8,
+                        children: List.generate(
+                          20,
+                          (_) => const _SkeletonBlock(radius: 8),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SkeletonBlock extends StatelessWidget {
+  const _SkeletonBlock({this.width, this.height, this.radius = 8});
+
+  final double? width;
+  final double? height;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: _tone(Settings.tacticalVioletTheme.secondary, 0.74),
+        borderRadius: BorderRadius.circular(radius),
+        border: Border.all(color: _tone(Settings.highlightColor, 0.45)),
+      ),
+    );
+  }
+}
+
+const ColorFilter _grayscaleFilter = ColorFilter.matrix(<double>[
+  0.2126,
+  0.7152,
+  0.0722,
+  0,
+  0,
+  0.2126,
+  0.7152,
+  0.0722,
+  0,
+  0,
+  0.2126,
+  0.7152,
+  0.0722,
+  0,
+  0,
+  0,
+  0,
+  0,
+  1,
+  0,
+]);
+
+Color _tone(Color color, double opacity) {
+  return color.withAlpha((opacity * 255).round().clamp(0, 255));
+}

--- a/lib/widgets/strategy_view_skeleton.dart
+++ b/lib/widgets/strategy_view_skeleton.dart
@@ -280,8 +280,7 @@ class _MapCanvasSkeleton extends StatelessWidget {
         final height = constraints.maxHeight;
         final worldWidth = height * (16 / 9);
         final playAreaSize = Size(worldWidth, height);
-        CoordinateSystem(playAreaSize: playAreaSize);
-        final coordinateSystem = CoordinateSystem.instance;
+        final coordinateSystem = CoordinateSystem(playAreaSize: playAreaSize);
         final viewportWidth =
             (constraints.maxWidth - Settings.sideBarReservedWidth)
                 .clamp(0.0, constraints.maxWidth)

--- a/lib/widgets/strategy_view_skeleton.dart
+++ b/lib/widgets/strategy_view_skeleton.dart
@@ -279,13 +279,11 @@ class _MapCanvasSkeleton extends StatelessWidget {
       builder: (context, constraints) {
         final height = constraints.maxHeight;
         final worldWidth = height * (16 / 9);
-        final playAreaSize = Size(worldWidth, height);
-        final coordinateSystem = CoordinateSystem(playAreaSize: playAreaSize);
         final viewportWidth =
             (constraints.maxWidth - Settings.sideBarReservedWidth)
                 .clamp(0.0, constraints.maxWidth)
                 .toDouble();
-        final mapWidth = height * coordinateSystem.mapAspectRatio;
+        final mapWidth = height * CoordinateSystem.defaultMapAspectRatio;
         final mapLeft = (worldWidth - mapWidth) / 2;
         final worldLeft = (viewportWidth - worldWidth) / 2;
 

--- a/test/agent_dragable_lineup_state_test.dart
+++ b/test/agent_dragable_lineup_state_test.dart
@@ -116,7 +116,10 @@ void main() {
 
     await _pumpHarness(tester, container: container);
 
-    await tester.tap(_tileFinder(AgentType.sova), warnIfMissed: false);
+    final sovaTile = tester.widget<InkWell>(_tileFinder(AgentType.sova));
+    expect(sovaTile.onTap, isNotNull);
+
+    sovaTile.onTap!();
     await tester.pumpAndSettle();
 
     expect(container.read(abilityBarProvider)?.type, AgentType.sova);


### PR DESCRIPTION
## Summary
- Add a full strategy-view skeleton shown while an initially targeted strategy loads.
- Add `StrategyView.route(...)` so strategy tiles can navigate immediately and let the strategy view own loading and error handling.
- Update strategy tiles to pass initial name/map/side metadata instead of blocking behind a modal spinner before navigation.
- Stabilize the agent tile lineup tap test that was failing in CI by asserting and invoking the enabled `InkWell` callback directly.
- Avoid mutating the global `CoordinateSystem` singleton while rendering the skeleton.

## Validation
- `fvm flutter analyze --no-pub lib\const\coordinate_system.dart lib\strategy_view.dart lib\widgets\strategy_tile\strategy_tile.dart lib\widgets\strategy_view_skeleton.dart test\agent_dragable_lineup_state_test.dart`
- `fvm flutter test test\agent_dragable_lineup_state_test.dart`
- `fvm flutter test`

## Risk / Compatibility
- Local-strategy behavior only; no storage format or migration changes.
- Existing `const StrategyView()` callers remain supported.
- The test change is harness-only and keeps the locked-mode blocked-tap coverage intact.