### PR TITLE
[codex] Add tilted drag feedback

### DIFF
--- a/lib/widgets/drag_tilt_feedback.dart
+++ b/lib/widgets/drag_tilt_feedback.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// Feeds pointer movement from a [Draggable.onDragUpdate] callback into the
+/// drag preview so it can react to the drag direction.
+///
+/// The owning widget keeps one controller and calls [addDelta] on every drag
+/// update; the [TiltDragFeedback] ticker drains it once per frame.
+class DragTiltController {
+  double _pendingDx = 0;
+
+  void addDelta(double dx) => _pendingDx += dx;
+
+  double takePendingDx() {
+    final dx = _pendingDx;
+    _pendingDx = 0;
+    return dx;
+  }
+}
+
+/// Shared drag-preview wrapper for library items (strategy tiles, folder
+/// cards, folder pills).
+///
+/// Makes the drag feel physical in two ways:
+/// - The preview hangs from the pointer by its top-center edge (the pointer
+///   is the grip point) instead of sitting at its top-left corner.
+/// - It swings a few degrees away from the direction of travel, pivoting
+///   around the grip point, and settles back with an exponential ease when
+///   movement stops. No bounce, no overshoot.
+class TiltDragFeedback extends StatefulWidget {
+  const TiltDragFeedback({
+    super.key,
+    required this.controller,
+    required this.child,
+    this.opacity = 0.95,
+  });
+
+  final DragTiltController controller;
+  final Widget child;
+  final double opacity;
+
+  @override
+  State<TiltDragFeedback> createState() => _TiltDragFeedbackState();
+}
+
+class _TiltDragFeedbackState extends State<TiltDragFeedback>
+    with SingleTickerProviderStateMixin {
+  // ~3.4 degrees: readable as physical swing without looking cartoonish.
+  static const double _maxTilt = 0.06;
+  static const double _velocityToTilt = 0.006;
+
+  late final Ticker _ticker;
+  double _velocity = 0;
+  double _angle = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    // Discard movement buffered before this drag's preview mounted.
+    widget.controller.takePendingDx();
+    _ticker = createTicker(_onTick)..start();
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  void _onTick(Duration elapsed) {
+    // Low-pass the per-frame movement, then chase the resulting tilt target.
+    // Both steps decay exponentially, so the card settles without bouncing.
+    _velocity = _velocity * 0.78 + widget.controller.takePendingDx() * 0.22;
+    final target = (_velocity * _velocityToTilt).clamp(-_maxTilt, _maxTilt);
+    final next = _angle + (target - _angle) * 0.24;
+
+    if ((next - _angle).abs() < 0.0002 && target.abs() < 0.0002) {
+      if (_angle != 0) setState(() => _angle = 0);
+      return;
+    }
+    setState(() => _angle = next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+
+    Widget preview = Material(
+      color: Colors.transparent,
+      child: widget.child,
+    );
+
+    if (!reduceMotion) {
+      preview = Transform.rotate(
+        angle: _angle,
+        alignment: Alignment.topCenter,
+        child: preview,
+      );
+    }
+
+    // The Draggable pins the feedback's top-left to the pointer
+    // (pointerDragAnchorStrategy); shifting by half the preview's own width
+    // moves the grip point to top-center regardless of preview size.
+    return IgnorePointer(
+      child: Opacity(
+        opacity: widget.opacity,
+        child: FractionalTranslation(
+          translation: const Offset(-0.5, 0),
+          child: preview,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/drag_tilt_feedback.dart
+++ b/lib/widgets/drag_tilt_feedback.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -47,11 +49,13 @@ class _TiltDragFeedbackState extends State<TiltDragFeedback>
     with SingleTickerProviderStateMixin {
   // ~3.4 degrees: readable as physical swing without looking cartoonish.
   static const double _maxTilt = 0.06;
-  static const double _velocityToTilt = 0.006;
+  static const double _velocityToTilt = 0.0001;
+  static const double _baselineFrameSeconds = 1 / 60;
 
   late final Ticker _ticker;
   double _velocity = 0;
   double _angle = 0;
+  Duration? _lastElapsed;
 
   @override
   void initState() {
@@ -68,11 +72,26 @@ class _TiltDragFeedbackState extends State<TiltDragFeedback>
   }
 
   void _onTick(Duration elapsed) {
-    // Low-pass the per-frame movement, then chase the resulting tilt target.
-    // Both steps decay exponentially, so the card settles without bouncing.
-    _velocity = _velocity * 0.78 + widget.controller.takePendingDx() * 0.22;
+    final previousElapsed = _lastElapsed;
+    _lastElapsed = elapsed;
+
+    final rawDt = previousElapsed == null
+        ? _baselineFrameSeconds
+        : (elapsed - previousElapsed).inMicroseconds /
+            Duration.microsecondsPerSecond;
+    final dt = rawDt.clamp(1 / 240, 1 / 15).toDouble();
+    final frameScale = dt / _baselineFrameSeconds;
+
+    // Low-pass pointer velocity, then chase the tilt target. Converting the
+    // 60 Hz tuning constants to wall-time keeps the feel stable across refresh
+    // rates while preserving the original baseline.
+    final velocityAlpha = 1 - math.pow(0.78, frameScale).toDouble();
+    final angleAlpha = 1 - math.pow(0.76, frameScale).toDouble();
+    final movementVelocity = widget.controller.takePendingDx() / dt;
+
+    _velocity += (movementVelocity - _velocity) * velocityAlpha;
     final target = (_velocity * _velocityToTilt).clamp(-_maxTilt, _maxTilt);
-    final next = _angle + (target - _angle) * 0.24;
+    final next = _angle + (target - _angle) * angleAlpha;
 
     if ((next - _angle).abs() < 0.0002 && target.abs() < 0.0002) {
       if (_angle != 0) setState(() => _angle = 0);

--- a/lib/widgets/folder_card.dart
+++ b/lib/widgets/folder_card.dart
@@ -9,6 +9,7 @@ import 'package:icarus/providers/library_context_menu_provider.dart';
 import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
+import 'package:icarus/widgets/drag_tilt_feedback.dart';
 import 'package:icarus/widgets/drop_insertion_indicator.dart';
 import 'package:icarus/widgets/folder_edit_dialog.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
@@ -124,6 +125,7 @@ class _FolderCardState extends ConsumerState<FolderCard>
       ShadContextMenuController();
   final ShadContextMenuController _rightClickMenuController =
       ShadContextMenuController();
+  final DragTiltController _dragTiltController = DragTiltController();
 
   Folder get _folder => widget.data.folder;
 
@@ -292,8 +294,14 @@ class _FolderCardState extends ConsumerState<FolderCard>
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: folderCardGutterOutset),
         child: Draggable<GridItem>(
-          feedback: _buildDragFeedback(),
+          feedback: TiltDragFeedback(
+            controller: _dragTiltController,
+            opacity: 0.9,
+            child: _buildDragFeedback(),
+          ),
           dragAnchorStrategy: pointerDragAnchorStrategy,
+          onDragUpdate: (details) =>
+              _dragTiltController.addDelta(details.delta.dx),
           data: FolderItem(_folder),
           child: MouseRegion(
             onEnter: (_) {
@@ -675,38 +683,32 @@ class _FolderCardState extends ConsumerState<FolderCard>
   }
 
   Widget _buildDragFeedback() {
-    return Opacity(
-      opacity: 0.9,
-      child: Material(
-        color: Colors.transparent,
-        child: Container(
-          height: 44,
-          padding: const EdgeInsets.symmetric(horizontal: 14),
-          decoration: BoxDecoration(
-            color: _frontTone,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: Colors.white, width: 2),
+    return Container(
+      height: 44,
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      decoration: BoxDecoration(
+        color: _frontTone,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white, width: 2),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FolderIconView(
+            iconId: _folder.iconId,
+            color: Colors.white,
+            size: 20,
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              FolderIconView(
-                iconId: _folder.iconId,
-                color: Colors.white,
-                size: 20,
-              ),
-              const SizedBox(width: 10),
-              Text(
-                _folder.name,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
+          const SizedBox(width: 10),
+          Text(
+            _folder.name,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -341,13 +341,13 @@ class FolderContent extends ConsumerWidget {
                                   // Calculate how many columns can fit with minimum width
                                   const double minTileWidth =
                                       250; // Your minimum width
-                                  const double spacing = 20;
                                   const double padding = 32; // 16 * 2
 
                                   int crossAxisCount = ((constraints.maxWidth -
                                               padding +
-                                              spacing) /
-                                          (minTileWidth + spacing))
+                                              strategyTileGridSpacing) /
+                                          (minTileWidth +
+                                              strategyTileGridSpacing))
                                       .floor();
                                   crossAxisCount = crossAxisCount
                                       .clamp(1, double.infinity)
@@ -404,14 +404,17 @@ class FolderContent extends ConsumerWidget {
                                       // Strategies grid
                                       if (strategies.isNotEmpty)
                                         SliverPadding(
-                                          padding: const EdgeInsets.all(16),
+                                          padding: const EdgeInsets.all(
+                                            16 - strategyTileGutterOutset,
+                                          ),
                                           sliver: SliverGrid(
                                             gridDelegate:
                                                 SliverGridDelegateWithFixedCrossAxisCount(
                                               crossAxisCount: crossAxisCount,
-                                              mainAxisExtent: 250,
-                                              crossAxisSpacing: 20,
-                                              mainAxisSpacing: 20,
+                                              mainAxisExtent:
+                                                  strategyTileGridMainAxisExtent,
+                                              crossAxisSpacing: 0,
+                                              mainAxisSpacing: 0,
                                             ),
                                             delegate:
                                                 SliverChildBuilderDelegate(

--- a/lib/widgets/folder_pill.dart
+++ b/lib/widgets/folder_pill.dart
@@ -6,6 +6,7 @@ import 'package:icarus/providers/library_context_menu_provider.dart';
 import 'package:icarus/providers/pinned_items_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
+import 'package:icarus/widgets/drag_tilt_feedback.dart';
 import 'package:icarus/widgets/drop_insertion_indicator.dart';
 import 'package:icarus/widgets/folder_edit_dialog.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
@@ -44,6 +45,7 @@ class _FolderPillState extends ConsumerState<FolderPill>
       ShadContextMenuController();
   final ShadContextMenuController _rightClickMenuController =
       ShadContextMenuController();
+  final DragTiltController _dragTiltController = DragTiltController();
   @override
   void initState() {
     super.initState();
@@ -114,8 +116,13 @@ class _FolderPillState extends ConsumerState<FolderPill>
     final isPinned = pinned.containsKey(id);
 
     return Draggable<GridItem>(
-      feedback: _buildDragFeedback(),
+      feedback: TiltDragFeedback(
+        controller: _dragTiltController,
+        opacity: 0.9,
+        child: _buildDragFeedback(),
+      ),
       dragAnchorStrategy: pointerDragAnchorStrategy,
+      onDragUpdate: (details) => _dragTiltController.addDelta(details.delta.dx),
       data: FolderItem(widget.folder),
       child: DragTarget<GridItem>(
         onWillAcceptWithDetails: (details) {
@@ -407,38 +414,32 @@ class _FolderPillState extends ConsumerState<FolderPill>
   }
 
   Widget _buildDragFeedback() {
-    return Opacity(
-      opacity: 0.9,
-      child: Material(
-        color: Colors.transparent,
-        child: Container(
-          height: 44,
-          padding: const EdgeInsets.symmetric(horizontal: 14),
-          decoration: BoxDecoration(
-            color: _folderColor,
-            borderRadius: BorderRadius.circular(_folderPillCornerRadius),
-            border: Border.all(color: Colors.white, width: 2),
+    return Container(
+      height: 44,
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      decoration: BoxDecoration(
+        color: _folderColor,
+        borderRadius: BorderRadius.circular(_folderPillCornerRadius),
+        border: Border.all(color: Colors.white, width: 2),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FolderIconView(
+            iconId: widget.folder.iconId,
+            color: Colors.white,
+            size: 20,
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              FolderIconView(
-                iconId: widget.folder.iconId,
-                color: Colors.white,
-                size: 20,
-              ),
-              const SizedBox(width: 10),
-              Text(
-                widget.folder.name,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
+          const SizedBox(width: 10),
+          Text(
+            widget.folder.name,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/strategy_tile/strategy_tile.dart
+++ b/lib/widgets/strategy_tile/strategy_tile.dart
@@ -8,10 +8,17 @@ import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/strategy_view.dart';
 import 'package:icarus/widgets/dialogs/strategy/delete_strategy_alert_dialog.dart';
 import 'package:icarus/widgets/dialogs/strategy/rename_strategy_dialog.dart';
+import 'package:icarus/widgets/drag_tilt_feedback.dart';
 import 'package:icarus/widgets/drop_insertion_indicator.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
 import 'package:icarus/widgets/strategy_tile/strategy_tile_sections.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+
+const double strategyTileGridSpacing = 20;
+const double strategyTileGutterOutset = strategyTileGridSpacing / 2;
+const double strategyTileMainAxisExtent = 250;
+const double strategyTileGridMainAxisExtent =
+    strategyTileMainAxisExtent + strategyTileGridSpacing;
 
 class StrategyTile extends ConsumerStatefulWidget {
   const StrategyTile({super.key, required this.strategyData});
@@ -32,6 +39,7 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
       ShadContextMenuController();
   final ShadContextMenuController _rightClickMenuController =
       ShadContextMenuController();
+  final DragTiltController _dragTiltController = DragTiltController();
 
   @override
   void dispose() {
@@ -128,129 +136,133 @@ class _StrategyTileState extends ConsumerState<StrategyTile> {
               pinned.containsKey(item.strategy.id),
         );
 
-        return Draggable<GridItem>(
-          data: StrategyItem(widget.strategyData),
-          dragAnchorStrategy: pointerDragAnchorStrategy,
-          feedback: Opacity(
-            opacity: 0.95,
-            child: Material(
-              color: Colors.transparent,
+        return Padding(
+          padding: const EdgeInsets.all(strategyTileGutterOutset),
+          child: Draggable<GridItem>(
+            data: StrategyItem(widget.strategyData),
+            dragAnchorStrategy: pointerDragAnchorStrategy,
+            onDragUpdate: (details) =>
+                _dragTiltController.addDelta(details.delta.dx),
+            feedback: TiltDragFeedback(
+              controller: _dragTiltController,
               child: StrategyTileDragPreview(data: viewData),
             ),
-          ),
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            onEnter: (_) => setState(
-                () => _highlightColor = Settings.tacticalVioletTheme.ring),
-            onExit: (_) => setState(
-                () => _highlightColor = Settings.tacticalVioletTheme.border),
-            child: AbsorbPointer(
-              absorbing: _isLoading,
-              child: ShadContextMenuRegion(
-                controller: _rightClickMenuController,
-                items: _buildMenuItems(),
-                child: GestureDetector(
-                  onTap: () => _openStrategy(context),
-                  child: Builder(
-                    builder: (context) {
-                      final dropSide = _pinnedDropSide;
-                      final slotKey = dropSide == null
-                          ? null
-                          : dropInsertionSlotKey(
-                              itemId: id,
-                              side: dropSide,
-                              pinnedOrder: pinnedIdsInManualOrder(pinned),
-                            );
-                      return Stack(
-                        clipBehavior: Clip.none,
-                        children: [
-                          AnimatedContainer(
-                            duration: const Duration(milliseconds: 100),
-                            decoration: BoxDecoration(
-                              color: ShadTheme.of(context).colorScheme.card,
-                              borderRadius: BorderRadius.circular(16),
-                              border: Border.all(
-                                color: isPinDropTarget
-                                    ? Settings.tacticalVioletTheme.border
-                                    : _highlightColor,
-                                width: 2,
-                              ),
-                            ),
-                            padding: const EdgeInsets.all(8),
-                            child: Column(
-                              children: [
-                                Expanded(
-                                  child: StrategyTileThumbnail(
-                                    assetPath: viewData.thumbnailAsset,
-                                  ),
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              onEnter: (_) => setState(
+                  () => _highlightColor = Settings.tacticalVioletTheme.ring),
+              onExit: (_) => setState(
+                  () => _highlightColor = Settings.tacticalVioletTheme.border),
+              child: AbsorbPointer(
+                absorbing: _isLoading,
+                child: ShadContextMenuRegion(
+                  controller: _rightClickMenuController,
+                  items: _buildMenuItems(),
+                  child: GestureDetector(
+                    onTap: () => _openStrategy(context),
+                    child: Builder(
+                      builder: (context) {
+                        final dropSide = _pinnedDropSide;
+                        final slotKey = dropSide == null
+                            ? null
+                            : dropInsertionSlotKey(
+                                itemId: id,
+                                side: dropSide,
+                                pinnedOrder: pinnedIdsInManualOrder(pinned),
+                              );
+                        return Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            AnimatedContainer(
+                              duration: const Duration(milliseconds: 100),
+                              decoration: BoxDecoration(
+                                color: ShadTheme.of(context).colorScheme.card,
+                                borderRadius: BorderRadius.circular(16),
+                                border: Border.all(
+                                  color: isPinDropTarget
+                                      ? Settings.tacticalVioletTheme.border
+                                      : _highlightColor,
+                                  width: 2,
                                 ),
-                                const SizedBox(height: 10),
-                                Expanded(
-                                    child: StrategyTileDetails(data: viewData)),
-                              ],
-                            ),
-                          ),
-                          if (isPinned)
-                            Align(
-                              alignment: Alignment.topLeft,
-                              child: Padding(
-                                padding: const EdgeInsets.all(16),
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color: Settings
-                                        .tacticalVioletTheme.background
-                                        .withValues(alpha: 0.78),
-                                    borderRadius: BorderRadius.circular(999),
-                                    border: Border.all(
-                                      color:
-                                          Settings.tacticalVioletTheme.border,
+                              ),
+                              padding: const EdgeInsets.all(8),
+                              child: Column(
+                                children: [
+                                  Expanded(
+                                    child: StrategyTileThumbnail(
+                                      assetPath: viewData.thumbnailAsset,
                                     ),
                                   ),
-                                  child: const Padding(
-                                    padding: EdgeInsets.all(5),
-                                    child: Icon(Icons.push_pin, size: 15),
+                                  const SizedBox(height: 10),
+                                  Expanded(
+                                      child:
+                                          StrategyTileDetails(data: viewData)),
+                                ],
+                              ),
+                            ),
+                            if (isPinned)
+                              Align(
+                                alignment: Alignment.topLeft,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(16),
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Settings
+                                          .tacticalVioletTheme.background
+                                          .withValues(alpha: 0.78),
+                                      borderRadius: BorderRadius.circular(999),
+                                      border: Border.all(
+                                        color:
+                                            Settings.tacticalVioletTheme.border,
+                                      ),
+                                    ),
+                                    child: const Padding(
+                                      padding: EdgeInsets.all(5),
+                                      child: Icon(Icons.push_pin, size: 15),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            Align(
+                              alignment: Alignment.topRight,
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: ShadContextMenuRegion(
+                                  controller: _menuButtonController,
+                                  items: _buildMenuItems(),
+                                  child: Listener(
+                                    onPointerDown: (_) {
+                                      _menuButtonWasOpenOnPointerDown =
+                                          _menuButtonController.isOpen;
+                                    },
+                                    child: ShadIconButton.secondary(
+                                      width: 28,
+                                      height: 28,
+                                      onPressed: _handleMenuButtonPressed,
+                                      icon:
+                                          const Icon(Icons.more_vert_outlined),
+                                    ),
                                   ),
                                 ),
                               ),
                             ),
-                          Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: const EdgeInsets.all(16),
-                              child: ShadContextMenuRegion(
-                                controller: _menuButtonController,
-                                items: _buildMenuItems(),
-                                child: Listener(
-                                  onPointerDown: (_) {
-                                    _menuButtonWasOpenOnPointerDown =
-                                        _menuButtonController.isOpen;
-                                  },
-                                  child: ShadIconButton.secondary(
-                                    width: 28,
-                                    height: 28,
-                                    onPressed: _handleMenuButtonPressed,
-                                    icon: const Icon(Icons.more_vert_outlined),
-                                  ),
+                            if (dropSide != null && slotKey != null)
+                              Positioned.fill(
+                                child: DropInsertionIndicator(
+                                  key: ValueKey(slotKey),
+                                  slotKey: slotKey,
+                                  side: dropSide,
+                                  // Matches the grid spacing in FolderContent
+                                  // so the caret sits centered in the gutter.
+                                  gap: strategyTileGridSpacing,
+                                  topInset: 6,
+                                  bottomInset: 6,
                                 ),
                               ),
-                            ),
-                          ),
-                          if (dropSide != null && slotKey != null)
-                            Positioned.fill(
-                              child: DropInsertionIndicator(
-                                key: ValueKey(slotKey),
-                                slotKey: slotKey,
-                                side: dropSide,
-                                // Matches the grid crossAxisSpacing so the
-                                // caret sits centered in the gutter.
-                                gap: 20,
-                                topInset: 6,
-                                bottomInset: 6,
-                              ),
-                            ),
-                        ],
-                      );
-                    },
+                          ],
+                        );
+                      },
+                    ),
                   ),
                 ),
               ),

--- a/test/square_icon_counter_rotation_test.dart
+++ b/test/square_icon_counter_rotation_test.dart
@@ -23,7 +23,7 @@ void main() {
 
       await _pumpWidget(
         tester,
-        CustomSquareWidget(
+        const CustomSquareWidget(
           color: Colors.green,
           width: 120,
           height: 60,
@@ -51,7 +51,7 @@ void main() {
 
       await _pumpWidget(
         tester,
-        CenterSquareWidget(
+        const CenterSquareWidget(
           width: 80,
           height: 80,
           iconPath: 'assets/agents/Cypher/1.webp',
@@ -74,7 +74,7 @@ void main() {
 
       await _pumpWidget(
         tester,
-        ResizableSquareWidget(
+        const ResizableSquareWidget(
           color: Colors.red,
           width: 100,
           maxLength: 180,
@@ -102,7 +102,7 @@ void main() {
         (tester) async {
       await _pumpWidget(
         tester,
-        CustomSquareWidget(
+        const CustomSquareWidget(
           color: Colors.orange,
           width: 100,
           height: 50,


### PR DESCRIPTION
## Summary

Adds a shared tilted drag feedback wrapper for library drag previews and wires it into strategy tiles, folder cards, and folder pills. The feedback now pivots around the pointer grip point and eases back toward neutral as horizontal drag movement settles.

Also adjusts strategy tile grid spacing so the drop insertion indicator sits centered in the gutter, and cleans up existing const-constructor analyzer findings in the square icon counter-rotation test.

## Validation

- `dart format lib/widgets/folder_card.dart lib/widgets/folder_content.dart lib/widgets/folder_pill.dart lib/widgets/strategy_tile/strategy_tile.dart lib/widgets/drag_tilt_feedback.dart`
- `dart format test/square_icon_counter_rotation_test.dart`
- `flutter analyze`
- `flutter test test/square_icon_counter_rotation_test.dart`

Note: the repo FVM symlink points at a missing `C:\Users\shawn\fvm\versions\3.44.4`; the global Flutter install is also `3.44.4`, so these checks used that matching global SDK.