### PR TITLE
Redesign share dialogs: role badges, revoke confirmation, state polish

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,96 @@
+# Cloud UX overhaul — work list
+
+Findings from the 2026-07-06 cloud UX audit. The cloud surfaces work, but they don't
+meet the polish bar set by main (micro-interactions, shadcn consistency, state
+feedback). Each section below is scoped as one PR into
+`codex/reconcile-main-into-cloud`; the branch merges into `icarus-cloud` at the end.
+
+Polish vocabulary to reuse (from main's recent work): 1.03 hover scale @150ms easeOut
+(`folder_pill.dart`), 100–120ms border/background fades (`strategy_tile.dart`),
+180ms rail expansion with delayed detail fade (`folder_navigator.dart`), 250ms search
+expansion (`custom_search_field.dart`), shimmer skeleton (`strategy_view_skeleton.dart`).
+
+## 1. Share dialogs redo — `lib/widgets/dialogs/share_links_dialog.dart`
+
+- [x] Role clarity: two-line role options (what "View only"/"Can edit" grant), role
+      badges (EDIT/VIEW/REVOKED) on each active link row
+- [x] Link rows: code + relative created time instead of triple-wrapped URL; URL in tooltip
+- [x] Copy buttons flash to a check (scale/fade, 120ms) alongside the toast
+- [x] Revoke requires confirmation; spinner while revoking; revoked rows muted + strikethrough
+- [x] Loading/error/empty/list states cross-fade (180ms); inline error card with Retry
+- [x] Add-by-link dialog: inline validation errors + red input border (was: silent no-op),
+      stays open on failed redemption (`redeemToken` now returns success), format shown
+      in placeholder, Enter submits
+
+## 2. Folder navigator side rail — `lib/widgets/folder_navigator_sidebar.dart`
+
+- [ ] Narrow the panel (~288px → ~240px); reduce top-stack chrome
+- [ ] Collapse the two stacked sort selects into one compact row (or move sorting into
+      the content header)
+- [ ] Remove the permanently-disabled "Cloud Tools" buttons in cloud mode
+      (`Import .ica` / `Import Backup` / `Export Library` render disabled, ~120px dead space)
+- [ ] Merge the duplicate Home entries in cloud mode ("Views → Home" vs root "Home" in Folders)
+- [ ] Chevron expand/collapse for nested folders (tree is currently always fully expanded),
+      150–180ms easeOutCubic reveal
+- [ ] Row hover polish per main's vocabulary; drop the 500ms hover-exit timer on the "…" menu
+
+## 3. Sync safety surfacing (trust-critical)
+
+- [ ] Persistent sync-status chip in the editor top strip driven by
+      `strategySaveStateProvider` (synced / syncing / offline / needs-attention),
+      150ms state cross-fades — today pending/failed/offline are invisible until exit
+- [ ] Wire up conflict surfacing: `strategyConflictProvider` is written
+      (`strategy_page_session_provider.dart:718`) but watched by nothing — conflicts
+      resolve silently
+- [ ] Offline feedback ("working offline, will sync") — currently detected
+      (`strategy_op_queue_provider.dart:371`) with zero UI
+- [ ] Persistent indicator for failed media uploads (today: one toast on first failure,
+      then invisible; ops silently dropped after 8 attempts)
+
+## 4. Library loading / empty / error states + workspace transitions
+
+- [ ] Skeleton grid while cloud lists load — `valueOrNull ?? []` currently shows
+      "No cloud strategies yet" *during fetch* (`folder_content.dart:52`)
+- [ ] Real error state with retry (auth/network failures currently yield empty lists
+      that read as "you have no strategies", `remote_library_provider.dart:74-94`)
+- [ ] Cloud-unavailable state to match the community placeholder's polish
+      (icon + composition, `folder_content.dart:351-373`)
+- [ ] 200–250ms cross-fade when switching Local ↔ Cloud workspace (currently instant)
+- [ ] Disabled cloud rail items: opacity decay + transition when cloud becomes available
+
+## 5. Cloud & role visibility in library and editor
+
+- [ ] Cloud badge on cloud strategy tiles (currently identical to local,
+      `folder_content.dart:249-263`)
+- [ ] Owner/editor/viewer role badges on shared items in the library
+- [ ] Role visibility in the editor (e.g. "View only" chip) — today role silently
+      disables buttons with no explanation
+
+## 6. Auth polish + Account settings
+
+- [ ] Replace Material `AlertDialog` auth-incident prompt with ShadDialog
+      (`auth_provider.dart:1137-1163`)
+- [ ] Humanize error copy — no "Convex"/"Supabase"/"session" jargon
+      (`auth_provider.dart:557, 576, 817, 1140`)
+- [ ] Auth dialog: animated error presentation, input error borders, validation before
+      submit-wait (`auth_dialog.dart:140-150`)
+- [ ] OAuth: don't pop the dialog blind — show a pending state during the Discord round-trip
+      (`auth_dialog.dart:179-187`)
+- [ ] Sign-out feedback (toast) + loading affordance on the account rail item
+- [ ] Account section in settings: email, sign out, cloud connection status
+      (none exists today)
+- [ ] Forgot-password / resend-confirmation affordances
+
+## 7. Hardcoded color / theme sweep
+
+- [ ] `strategy_tile_sections.dart:93-97` — `Colors.redAccent`/`lightBlueAccent`/
+      `orangeAccent` for attack/defend labels → tactical palette
+- [ ] `strategy_tile_sections.dart:284` — `Colors.deepPurpleAccent` drag border
+- [ ] `strategy_tile.dart:198-200` — `Colors.redAccent` delete → `destructive`
+- [ ] `folder_content.dart:276` — `Colors.grey` → `mutedForeground`
+- [ ] `folder_navigator.dart:352-371` — `Colors.white` in popover buttons → theme foreground
+
+## Done when
+
+Every box above is checked, each PR has passed greptile review, and
+`codex/reconcile-main-into-cloud` is merged into `icarus-cloud` (PR #78).

--- a/lib/providers/share_link_provider.dart
+++ b/lib/providers/share_link_provider.dart
@@ -29,10 +29,10 @@ class ShareLinkController extends Notifier<String?> {
     return true;
   }
 
-  Future<void> redeemPendingIfPossible({String source = 'pending'}) async {
+  Future<bool> redeemPendingIfPossible({String source = 'pending'}) async {
     final token = state;
     if (token == null || token.isEmpty) {
-      return;
+      return false;
     }
 
     final auth = ref.read(authProvider);
@@ -41,7 +41,7 @@ class ShareLinkController extends Notifier<String?> {
         message: 'Sign in to redeem shared links.',
         backgroundColor: Settings.tacticalVioletTheme.primary,
       );
-      return;
+      return false;
     }
 
     try {
@@ -68,6 +68,7 @@ class ShareLinkController extends Notifier<String?> {
             : 'Shared strategy added to your library.',
         backgroundColor: Settings.tacticalVioletTheme.primary,
       );
+      return true;
     } catch (error, stackTrace) {
       if (isConvexUnauthenticatedError(error)) {
         await ref.read(authProvider.notifier).reportConvexUnauthenticated(
@@ -75,18 +76,19 @@ class ShareLinkController extends Notifier<String?> {
               error: error,
               stackTrace: stackTrace,
             );
-        return;
+        return false;
       }
       Settings.showToast(
         message: 'Failed to redeem share link.',
         backgroundColor: Settings.tacticalVioletTheme.destructive,
       );
+      return false;
     }
   }
 
-  Future<void> redeemToken(String token) async {
+  Future<bool> redeemToken(String token) async {
     state = token;
-    await redeemPendingIfPossible(source: 'manual');
+    return redeemPendingIfPossible(source: 'manual');
   }
 
   @override

--- a/lib/providers/share_link_provider.dart
+++ b/lib/providers/share_link_provider.dart
@@ -29,7 +29,12 @@ class ShareLinkController extends Notifier<String?> {
     return true;
   }
 
-  Future<bool> redeemPendingIfPossible({String source = 'pending'}) async {
+  /// Set [showFailureToasts] to false when the caller (e.g. a dialog)
+  /// presents failures inline itself; success toasts always show.
+  Future<bool> redeemPendingIfPossible({
+    String source = 'pending',
+    bool showFailureToasts = true,
+  }) async {
     final token = state;
     if (token == null || token.isEmpty) {
       return false;
@@ -37,10 +42,12 @@ class ShareLinkController extends Notifier<String?> {
 
     final auth = ref.read(authProvider);
     if (!auth.isAuthenticated || !auth.isConvexUserReady) {
-      Settings.showToast(
-        message: 'Sign in to redeem shared links.',
-        backgroundColor: Settings.tacticalVioletTheme.primary,
-      );
+      if (showFailureToasts) {
+        Settings.showToast(
+          message: 'Sign in to redeem shared links.',
+          backgroundColor: Settings.tacticalVioletTheme.primary,
+        );
+      }
       return false;
     }
 
@@ -78,17 +85,19 @@ class ShareLinkController extends Notifier<String?> {
             );
         return false;
       }
-      Settings.showToast(
-        message: 'Failed to redeem share link.',
-        backgroundColor: Settings.tacticalVioletTheme.destructive,
-      );
+      if (showFailureToasts) {
+        Settings.showToast(
+          message: 'Failed to redeem share link.',
+          backgroundColor: Settings.tacticalVioletTheme.destructive,
+        );
+      }
       return false;
     }
   }
 
   Future<bool> redeemToken(String token) async {
     state = token;
-    return redeemPendingIfPossible(source: 'manual');
+    return redeemPendingIfPossible(source: 'manual', showFailureToasts: false);
   }
 
   @override

--- a/lib/widgets/dialogs/share_links_dialog.dart
+++ b/lib/widgets/dialogs/share_links_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,12 +8,27 @@ import 'package:icarus/collab/convex_strategy_repository.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/share_link_provider.dart';
 import 'package:icarus/share/share_link_format.dart';
+import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 /// Headline like: Share "My Strategy Name" (`"` in [name] become `'`).
 String _shareDialogHeadline(String name) {
   final safe = name.replaceAll('"', "'");
   return 'Share "$safe"';
+}
+
+const _stateSwitchDuration = Duration(milliseconds: 180);
+const _hoverDuration = Duration(milliseconds: 120);
+const _copiedFlashDuration = Duration(milliseconds: 1200);
+
+String _relativeTime(DateTime time) {
+  final diff = DateTime.now().difference(time);
+  if (diff.inMinutes < 1) return 'just now';
+  if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+  if (diff.inDays < 1) return '${diff.inHours}h ago';
+  if (diff.inDays < 30) return '${diff.inDays}d ago';
+  return '${time.year}-${time.month.toString().padLeft(2, '0')}'
+      '-${time.day.toString().padLeft(2, '0')}';
 }
 
 class ShareLinksDialog extends ConsumerStatefulWidget {
@@ -37,20 +54,17 @@ Future<void> showAddSharedItemDialog(BuildContext context) {
   );
 }
 
+enum _LinksStatus { loading, error, ready }
+
 class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
   List<ShareLinkSummary> _links = const [];
-  bool _isLoading = true;
+  _LinksStatus _status = _LinksStatus.loading;
   bool _isCreating = false;
+  String? _revokingToken;
   String _selectedRole = 'viewer';
 
-  @override
-  void initState() {
-    super.initState();
-    _loadLinks();
-  }
-
   Future<void> _loadLinks() async {
-    setState(() => _isLoading = true);
+    setState(() => _status = _LinksStatus.loading);
     try {
       final links =
           await ref.read(convexStrategyRepositoryProvider).listShareLinks(
@@ -60,16 +74,18 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
       if (!mounted) return;
       setState(() {
         _links = links;
-        _isLoading = false;
+        _status = _LinksStatus.ready;
       });
     } catch (_) {
       if (!mounted) return;
-      setState(() => _isLoading = false);
-      Settings.showToast(
-        message: 'Failed to load share links.',
-        backgroundColor: Settings.tacticalVioletTheme.destructive,
-      );
+      setState(() => _status = _LinksStatus.error);
     }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLinks();
   }
 
   Future<void> _createLink() async {
@@ -100,23 +116,19 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
     }
   }
 
-  Future<void> _copyLink(String token) async {
-    await Clipboard.setData(ClipboardData(text: buildIcarusShareLink(token)));
-    Settings.showToast(
-      message: 'Share link copied to clipboard.',
-      backgroundColor: Settings.tacticalVioletTheme.primary,
-    );
-  }
-
-  Future<void> _copyCode(String token) async {
-    await Clipboard.setData(ClipboardData(text: token));
-    Settings.showToast(
-      message: 'Share code copied to clipboard.',
-      backgroundColor: Settings.tacticalVioletTheme.primary,
-    );
-  }
-
   Future<void> _revokeLink(String token) async {
+    final confirmed = await ConfirmAlertDialog.show(
+      context: context,
+      title: 'Revoke this link?',
+      content: 'Anyone who has the link or code loses the ability to join. '
+          'People who already joined keep their access.',
+      confirmText: 'Revoke',
+      isDestructive: true,
+    );
+    if (!confirmed || !mounted) {
+      return;
+    }
+    setState(() => _revokingToken = token);
     try {
       await ref.read(convexStrategyRepositoryProvider).revokeShareLink(
             targetType: widget.targetType,
@@ -129,6 +141,10 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
         message: 'Failed to revoke share link.',
         backgroundColor: Settings.tacticalVioletTheme.destructive,
       );
+    } finally {
+      if (mounted) {
+        setState(() => _revokingToken = null);
+      }
     }
   }
 
@@ -142,7 +158,8 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
         softWrap: true,
       ),
       description: const Text(
-        'Links never expire. Anyone who opens one can join this item in your cloud library with the access you choose.',
+        'Links never expire. Anyone who opens one joins this item with the '
+        'access you choose.',
       ),
       actions: [
         ShadButton.secondary(
@@ -156,61 +173,62 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(
-              'New link',
-              style: theme.textTheme.small.copyWith(
-                color: theme.colorScheme.mutedForeground,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.2,
-              ),
-            ),
+            const _SectionLabel(label: 'New link'),
             const SizedBox(height: 8),
-            ShadSelect<String>(
-              initialValue: _selectedRole,
-              selectedOptionBuilder: (context, value) => Text(
-                value == 'editor' ? 'Can edit' : 'View only',
-              ),
-              options: const [
-                ShadOption(value: 'viewer', child: Text('View only')),
-                ShadOption(value: 'editor', child: Text('Can edit')),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: ShadSelect<String>(
+                    initialValue: _selectedRole,
+                    selectedOptionBuilder: (context, value) => Text(
+                      value == 'editor' ? 'Can edit' : 'View only',
+                    ),
+                    options: const [
+                      ShadOption(
+                        value: 'viewer',
+                        child: _RoleOptionLabel(
+                          label: 'View only',
+                          description: 'Can open and view every page',
+                        ),
+                      ),
+                      ShadOption(
+                        value: 'editor',
+                        child: _RoleOptionLabel(
+                          label: 'Can edit',
+                          description: 'Can change pages, drawings, and media',
+                        ),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() => _selectedRole = value);
+                      }
+                    },
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ShadButton(
+                  onPressed: _isCreating ? null : _createLink,
+                  leading: _isCreating
+                      ? SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: theme.colorScheme.primaryForeground,
+                          ),
+                        )
+                      : const Icon(LucideIcons.link, size: 16),
+                  child: Text(_isCreating ? 'Creating…' : 'Create & copy'),
+                ),
               ],
-              onChanged: (value) {
-                if (value != null) {
-                  setState(() => _selectedRole = value);
-                }
-              },
-            ),
-            const SizedBox(height: 12),
-            ShadButton(
-              onPressed: _isCreating ? null : _createLink,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    LucideIcons.copy,
-                    size: 16,
-                    color: theme.colorScheme.primaryForeground,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    _isCreating ? 'Creating…' : 'Create link & copy',
-                  ),
-                ],
-              ),
             ),
             const SizedBox(height: 20),
             Row(
               children: [
-                Text(
-                  'Active links',
-                  style: theme.textTheme.small.copyWith(
-                    color: theme.colorScheme.mutedForeground,
-                    fontWeight: FontWeight.w600,
-                    letterSpacing: 0.2,
-                  ),
-                ),
-                if (!_isLoading && _links.isNotEmpty) ...[
+                const _SectionLabel(label: 'Active links'),
+                if (_status == _LinksStatus.ready && _links.isNotEmpty) ...[
                   const SizedBox(width: 8),
                   ShadBadge.secondary(
                     child: Text('${_links.length}'),
@@ -219,141 +237,466 @@ class _ShareLinksDialogState extends ConsumerState<ShareLinksDialog> {
               ],
             ),
             const SizedBox(height: 10),
-            if (_isLoading)
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 28),
-                child: Center(child: CircularProgressIndicator()),
-              )
-            else if (_links.isEmpty)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 20),
-                child: Text(
-                  'No links yet. Create one above to invite collaborators.',
-                  style: theme.textTheme.muted,
-                  textAlign: TextAlign.center,
-                ),
-              )
-            else
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 280),
-                child: ListView.separated(
-                  shrinkWrap: true,
-                  itemCount: _links.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 10),
-                  itemBuilder: (context, index) {
-                    final link = _links[index];
-                    final code = link.token;
-                    final url = buildIcarusShareLink(code);
-                    return DecoratedBox(
-                      decoration: BoxDecoration(
-                        border: Border.all(color: theme.colorScheme.border),
-                        borderRadius: theme.radius,
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 10,
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Expanded(
-                              child: Tooltip(
-                                message: url,
-                                child: SelectionArea(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Text(
-                                        url,
-                                        style: theme.textTheme.small.copyWith(
-                                          color:
-                                              theme.colorScheme.mutedForeground,
-                                          fontFamily: 'monospace',
-                                          fontSize: 11,
-                                          height: 1.35,
-                                        ),
-                                        maxLines: 3,
-                                        overflow: TextOverflow.ellipsis,
-                                        softWrap: true,
-                                      ),
-                                      const SizedBox(height: 4),
-                                      Text(
-                                        'Code: $code',
-                                        style: theme.textTheme.small.copyWith(
-                                          color:
-                                              theme.colorScheme.mutedForeground,
-                                          fontFamily: 'monospace',
-                                          fontSize: 11,
-                                          height: 1.35,
-                                        ),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Tooltip(
-                                  message: 'Copy link',
-                                  child: ShadButton.ghost(
-                                    size: ShadButtonSize.sm,
-                                    onPressed: () => _copyLink(link.token),
-                                    child: Icon(
-                                      LucideIcons.copy,
-                                      size: 16,
-                                      color: theme.colorScheme.foreground,
-                                    ),
-                                  ),
-                                ),
-                                Tooltip(
-                                  message: 'Copy code',
-                                  child: ShadButton.ghost(
-                                    size: ShadButtonSize.sm,
-                                    onPressed: () => _copyCode(link.token),
-                                    child: Icon(
-                                      LucideIcons.hash,
-                                      size: 16,
-                                      color: theme.colorScheme.foreground,
-                                    ),
-                                  ),
-                                ),
-                                Tooltip(
-                                  message: link.isRevoked
-                                      ? 'Revoked'
-                                      : 'Revoke link',
-                                  child: ShadButton.ghost(
-                                    size: ShadButtonSize.sm,
-                                    onPressed: link.isRevoked
-                                        ? null
-                                        : () => _revokeLink(link.token),
-                                    child: Icon(
-                                      LucideIcons.trash2,
-                                      size: 16,
-                                      color: link.isRevoked
-                                          ? theme.colorScheme.mutedForeground
-                                          : theme.colorScheme.destructive,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                ),
+            AnimatedSize(
+              duration: _stateSwitchDuration,
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.topCenter,
+              child: AnimatedSwitcher(
+                duration: _stateSwitchDuration,
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeOutCubic,
+                child: _buildLinksBody(theme),
               ),
+            ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildLinksBody(ShadThemeData theme) {
+    switch (_status) {
+      case _LinksStatus.loading:
+        return const _LinkListPlaceholder(key: ValueKey('loading'));
+      case _LinksStatus.error:
+        return _LinkListMessage(
+          key: const ValueKey('error'),
+          icon: LucideIcons.circleAlert,
+          message: "Couldn't load share links.",
+          action: ShadButton.ghost(
+            size: ShadButtonSize.sm,
+            onPressed: _loadLinks,
+            leading: const Icon(LucideIcons.refreshCw, size: 14),
+            child: const Text('Retry'),
+          ),
+        );
+      case _LinksStatus.ready:
+        if (_links.isEmpty) {
+          return const _LinkListMessage(
+            key: ValueKey('empty'),
+            icon: LucideIcons.link2,
+            message: 'No links yet. Create one above to invite collaborators.',
+          );
+        }
+        return ConstrainedBox(
+          key: const ValueKey('links'),
+          constraints: const BoxConstraints(maxHeight: 280),
+          child: ListView.separated(
+            shrinkWrap: true,
+            itemCount: _links.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final link = _links[index];
+              return _ShareLinkTile(
+                link: link,
+                isRevoking: _revokingToken == link.token,
+                onRevoke: () => _revokeLink(link.token),
+              );
+            },
+          ),
+        );
+    }
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Text(
+      label,
+      style: theme.textTheme.small.copyWith(
+        color: theme.colorScheme.mutedForeground,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.2,
+      ),
+    );
+  }
+}
+
+class _RoleOptionLabel extends StatelessWidget {
+  const _RoleOptionLabel({
+    required this.label,
+    required this.description,
+  });
+
+  final String label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(label),
+        const SizedBox(height: 2),
+        Text(
+          description,
+          style: theme.textTheme.small.copyWith(
+            color: theme.colorScheme.mutedForeground,
+            fontSize: 11,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RoleBadge extends StatelessWidget {
+  const _RoleBadge({required this.role, required this.isRevoked});
+
+  final String role;
+  final bool isRevoked;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final Color background;
+    final Color foreground;
+    final String label;
+    if (isRevoked) {
+      background = theme.colorScheme.destructive.withValues(alpha: 0.14);
+      foreground = theme.colorScheme.destructive;
+      label = 'REVOKED';
+    } else if (role == 'editor') {
+      background = theme.colorScheme.primary.withValues(alpha: 0.16);
+      foreground = theme.colorScheme.primary;
+      label = 'EDIT';
+    } else {
+      background = theme.colorScheme.muted;
+      foreground = theme.colorScheme.mutedForeground;
+      label = 'VIEW';
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: foreground,
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+class _ShareLinkTile extends StatefulWidget {
+  const _ShareLinkTile({
+    required this.link,
+    required this.isRevoking,
+    required this.onRevoke,
+  });
+
+  final ShareLinkSummary link;
+  final bool isRevoking;
+  final VoidCallback onRevoke;
+
+  @override
+  State<_ShareLinkTile> createState() => _ShareLinkTileState();
+}
+
+class _ShareLinkTileState extends State<_ShareLinkTile> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final link = widget.link;
+    final url = buildIcarusShareLink(link.token);
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: AnimatedContainer(
+        duration: _hoverDuration,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: _hovered && !link.isRevoked
+                ? theme.colorScheme.ring
+                : theme.colorScheme.border,
+          ),
+          borderRadius: theme.radius,
+        ),
+        child: AnimatedOpacity(
+          duration: _hoverDuration,
+          opacity: link.isRevoked ? 0.6 : 1,
+          child: Row(
+            children: [
+              _RoleBadge(role: link.role, isRevoked: link.isRevoked),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Tooltip(
+                  message: url,
+                  waitDuration: const Duration(milliseconds: 400),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SelectionArea(
+                        child: Text(
+                          link.token,
+                          style: theme.textTheme.small.copyWith(
+                            fontFamily: 'monospace',
+                            fontSize: 12,
+                            height: 1.3,
+                            decoration: link.isRevoked
+                                ? TextDecoration.lineThrough
+                                : null,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Created ${_relativeTime(link.createdAt)}',
+                        style: theme.textTheme.small.copyWith(
+                          color: theme.colorScheme.mutedForeground,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _CopyIconButton(
+                tooltip: 'Copy link',
+                icon: LucideIcons.link,
+                enabled: !link.isRevoked,
+                textToCopy: url,
+                toastMessage: 'Share link copied to clipboard.',
+              ),
+              _CopyIconButton(
+                tooltip: 'Copy code',
+                icon: LucideIcons.hash,
+                enabled: !link.isRevoked,
+                textToCopy: link.token,
+                toastMessage: 'Share code copied to clipboard.',
+              ),
+              Tooltip(
+                message: link.isRevoked ? 'Revoked' : 'Revoke link',
+                child: ShadButton.ghost(
+                  size: ShadButtonSize.sm,
+                  onPressed: link.isRevoked || widget.isRevoking
+                      ? null
+                      : widget.onRevoke,
+                  child: widget.isRevoking
+                      ? SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: theme.colorScheme.mutedForeground,
+                          ),
+                        )
+                      : Icon(
+                          LucideIcons.trash2,
+                          size: 16,
+                          color: link.isRevoked
+                              ? theme.colorScheme.mutedForeground
+                              : theme.colorScheme.destructive,
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CopyIconButton extends StatefulWidget {
+  const _CopyIconButton({
+    required this.tooltip,
+    required this.icon,
+    required this.enabled,
+    required this.textToCopy,
+    required this.toastMessage,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final bool enabled;
+  final String textToCopy;
+  final String toastMessage;
+
+  @override
+  State<_CopyIconButton> createState() => _CopyIconButtonState();
+}
+
+class _CopyIconButtonState extends State<_CopyIconButton> {
+  bool _copied = false;
+  Timer? _resetTimer;
+
+  @override
+  void dispose() {
+    _resetTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _copy() async {
+    await Clipboard.setData(ClipboardData(text: widget.textToCopy));
+    if (!mounted) return;
+    setState(() => _copied = true);
+    _resetTimer?.cancel();
+    _resetTimer = Timer(_copiedFlashDuration, () {
+      if (mounted) {
+        setState(() => _copied = false);
+      }
+    });
+    Settings.showToast(
+      message: widget.toastMessage,
+      backgroundColor: Settings.tacticalVioletTheme.primary,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Tooltip(
+      message: widget.tooltip,
+      child: ShadButton.ghost(
+        size: ShadButtonSize.sm,
+        onPressed: widget.enabled ? _copy : null,
+        child: AnimatedSwitcher(
+          duration: _hoverDuration,
+          switchInCurve: Curves.easeOutCubic,
+          switchOutCurve: Curves.easeOutCubic,
+          transitionBuilder: (child, animation) => ScaleTransition(
+            scale: animation,
+            child: FadeTransition(opacity: animation, child: child),
+          ),
+          child: _copied
+              ? Icon(
+                  LucideIcons.check,
+                  key: const ValueKey('check'),
+                  size: 16,
+                  color: theme.colorScheme.primary,
+                )
+              : Icon(
+                  widget.icon,
+                  key: const ValueKey('idle'),
+                  size: 16,
+                  color: widget.enabled
+                      ? theme.colorScheme.foreground
+                      : theme.colorScheme.mutedForeground,
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LinkListMessage extends StatelessWidget {
+  const _LinkListMessage({
+    super.key,
+    required this.icon,
+    required this.message,
+    this.action,
+  });
+
+  final IconData icon;
+  final String message;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 20, color: theme.colorScheme.mutedForeground),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            style: theme.textTheme.muted,
+            textAlign: TextAlign.center,
+          ),
+          if (action != null) ...[
+            const SizedBox(height: 8),
+            action!,
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _LinkListPlaceholder extends StatefulWidget {
+  const _LinkListPlaceholder({super.key});
+
+  @override
+  State<_LinkListPlaceholder> createState() => _LinkListPlaceholderState();
+}
+
+class _LinkListPlaceholderState extends State<_LinkListPlaceholder>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1100),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (MediaQuery.of(context).disableAnimations) {
+      _controller.stop();
+      _controller.value = 1;
+    } else if (!_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return FadeTransition(
+      opacity: Tween<double>(begin: 0.45, end: 0.9).animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+      ),
+      child: Column(
+        children: [
+          for (var i = 0; i < 2; i++) ...[
+            if (i > 0) const SizedBox(height: 8),
+            Container(
+              height: 54,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.muted.withValues(alpha: 0.4),
+                borderRadius: theme.radius,
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -370,6 +713,7 @@ class AddSharedItemDialog extends ConsumerStatefulWidget {
 class _AddSharedItemDialogState extends ConsumerState<AddSharedItemDialog> {
   final TextEditingController _controller = TextEditingController();
   bool _isSubmitting = false;
+  String? _errorText;
 
   @override
   void dispose() {
@@ -378,23 +722,47 @@ class _AddSharedItemDialogState extends ConsumerState<AddSharedItemDialog> {
   }
 
   Future<void> _submit() async {
-    final token = extractIcarusShareCode(_controller.text);
-    if (token == null || token.isEmpty) {
+    if (_isSubmitting) {
       return;
     }
-    setState(() => _isSubmitting = true);
-    await ref.read(shareLinkControllerProvider.notifier).redeemToken(token);
+    final token = extractIcarusShareCode(_controller.text);
+    if (token == null || token.isEmpty) {
+      setState(() {
+        _errorText = _controller.text.trim().isEmpty
+            ? 'Paste a share link or code first.'
+            : "That doesn't look like an Icarus share link or code.";
+      });
+      return;
+    }
+    setState(() {
+      _isSubmitting = true;
+      _errorText = null;
+    });
+    final succeeded =
+        await ref.read(shareLinkControllerProvider.notifier).redeemToken(token);
     if (!mounted) return;
     setState(() => _isSubmitting = false);
-    Navigator.of(context).pop();
+    if (succeeded) {
+      Navigator.of(context).pop();
+    } else {
+      setState(() {
+        _errorText = "Couldn't add that item. The link may be revoked, "
+            'or you may need to sign in.';
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final hasError = _errorText != null;
+
     return ShadDialog(
       title: const Text('Add Shared Item'),
       description: const Text(
-          'Paste an Icarus share link or enter a share code to add it to Shared with Me.'),
+        'Paste an Icarus share link or enter a share code to add it to '
+        'Shared with Me.',
+      ),
       actions: [
         ShadButton.secondary(
           onPressed: () => Navigator.of(context).pop(),
@@ -402,12 +770,74 @@ class _AddSharedItemDialogState extends ConsumerState<AddSharedItemDialog> {
         ),
         ShadButton(
           onPressed: _isSubmitting ? null : _submit,
-          child: Text(_isSubmitting ? 'Adding...' : 'Add'),
+          leading: _isSubmitting
+              ? SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: theme.colorScheme.primaryForeground,
+                  ),
+                )
+              : null,
+          child: Text(_isSubmitting ? 'Adding…' : 'Add'),
         ),
       ],
-      child: ShadInput(
-        controller: _controller,
-        placeholder: const Text('Paste share link or code'),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ShadInput(
+            controller: _controller,
+            autofocus: true,
+            placeholder: const Text(
+              'https://$icarusShareHost/share/… or ICR-XXXX-XXXX-XXXX-XXXX',
+            ),
+            onSubmitted: (_) => _submit(),
+            onChanged: (_) {
+              if (_errorText != null) {
+                setState(() => _errorText = null);
+              }
+            },
+            decoration: hasError
+                ? ShadDecoration(
+                    border: ShadBorder.all(
+                      color: theme.colorScheme.destructive,
+                    ),
+                  )
+                : null,
+          ),
+          AnimatedSize(
+            duration: _stateSwitchDuration,
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topLeft,
+            child: hasError
+                ? Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          LucideIcons.circleAlert,
+                          size: 13,
+                          color: theme.colorScheme.destructive,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            _errorText!,
+                            style: theme.textTheme.small.copyWith(
+                              color: theme.colorScheme.destructive,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Part 1 of the cloud UX overhaul (see TODO.md, added in this PR).

## Share links dialog
- Role badges on each active link (EDIT / VIEW / REVOKED) — links previously didn't show what access they grant
- Role select options explain what viewer/editor can do
- Link rows show the share code + relative created time; full URL moved to a tooltip (was three wrapped lines of monospace)
- Copy buttons flash to a check (120ms scale/fade) alongside the toast
- Revoke now requires confirmation and shows an in-flight spinner; revoked rows are muted with strikethrough
- Loading / error / empty / list states cross-fade (180ms easeOutCubic); load failure shows an inline retry instead of a toast over a frozen dialog

## Add Shared Item dialog
- Inline validation with red input border — invalid input was previously a **silent no-op**
- Failed redemption keeps the dialog open with an inline error (previously closed as if it succeeded); `redeemToken`/`redeemPendingIfPossible` now return success
- Placeholder shows the actual link/code formats; Enter submits; autofocus

## Also
- Adds `TODO.md` — the full audited work list for the cloud UX overhaul

🤖 Generated with [Claude Code](https://claude.com/claude-code)