### PR TITLE
Cloud library loading/error states and workspace transitions

### DIFF
--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -45,44 +47,13 @@ class FolderContent extends ConsumerWidget {
 
     final isCloud = workspace == LibraryWorkspace.cloud;
     if (isCloud) {
-      final cloudSection = ref.watch(cloudLibrarySectionProvider);
-      final cloudAvailable = ref.watch(isCloudWorkspaceAvailableProvider);
-      if (!cloudAvailable) {
-        return _buildCloudUnavailableState(context, ref);
-      }
-      final foldersAsync = ref.watch(cloudFoldersProvider);
-      final strategiesAsync = ref.watch(cloudStrategiesProvider);
-      if (foldersAsync.hasError || strategiesAsync.hasError) {
-        return _buildCloudErrorState(context, ref);
-      }
-      // Only the very first fetch shows the skeleton; dependency changes keep
-      // the previous value, so navigating folders doesn't flash it.
-      final isInitialLoading =
-          (foldersAsync.isLoading && !foldersAsync.hasValue) ||
-              (strategiesAsync.isLoading && !strategiesAsync.hasValue);
-      if (isInitialLoading) {
-        return const _LibraryLoadingSkeleton();
-      }
-      final folders = (foldersAsync.valueOrNull ?? const [])
-          .map(FolderProvider.cloudSummaryToFolder)
-          .toList(growable: false);
-      final strategies = strategiesAsync.valueOrNull ?? const [];
-      final isSharedWithMe = cloudSection == CloudLibrarySection.sharedWithMe;
-      return _buildScaffold(
-        context,
-        ref,
-        folders: _filterFolders(ref, folders),
-        localStrategies: const [],
-        cloudStrategies: _filterCloudStrategies(ref, strategies),
-        isCloud: true,
-        showAddSharedItemAction: isSharedWithMe,
-        emptyStateIcon:
-            isSharedWithMe ? Icons.people_outline : Icons.cloud_outlined,
-        emptyStateTitle:
-            isSharedWithMe ? 'No shared items yet' : 'No cloud strategies yet',
-        emptyStateSubtitle: isSharedWithMe
-            ? 'Shared folders and strategies will appear here'
-            : 'Create a cloud strategy to start your online workspace',
+      // Wrapped in a switcher so skeleton -> content (and error transitions)
+      // cross-fade instead of hard-snapping.
+      return AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeOutCubic,
+        child: _buildCloudBody(context, ref),
       );
     }
 
@@ -114,6 +85,59 @@ class FolderContent extends ConsumerWidget {
           },
         );
       },
+    );
+  }
+
+  Widget _buildCloudBody(BuildContext context, WidgetRef ref) {
+    final cloudSection = ref.watch(cloudLibrarySectionProvider);
+    final cloudAvailable = ref.watch(isCloudWorkspaceAvailableProvider);
+    if (!cloudAvailable) {
+      return KeyedSubtree(
+        key: const ValueKey('cloud-unavailable'),
+        child: _buildCloudUnavailableState(context, ref),
+      );
+    }
+    final foldersAsync = ref.watch(cloudFoldersProvider);
+    final strategiesAsync = ref.watch(cloudStrategiesProvider);
+    if (foldersAsync.hasError || strategiesAsync.hasError) {
+      return KeyedSubtree(
+        key: const ValueKey('cloud-error'),
+        child: _buildCloudErrorState(context, ref),
+      );
+    }
+    // Only the very first fetch shows the skeleton; dependency changes keep
+    // the previous value, so navigating folders doesn't flash it.
+    final isInitialLoading =
+        (foldersAsync.isLoading && !foldersAsync.hasValue) ||
+            (strategiesAsync.isLoading && !strategiesAsync.hasValue);
+    if (isInitialLoading) {
+      return const _LibraryLoadingSkeleton(
+        key: ValueKey('cloud-loading'),
+      );
+    }
+    final folders = (foldersAsync.valueOrNull ?? const [])
+        .map(FolderProvider.cloudSummaryToFolder)
+        .toList(growable: false);
+    final strategies = strategiesAsync.valueOrNull ?? const [];
+    final isSharedWithMe = cloudSection == CloudLibrarySection.sharedWithMe;
+    return KeyedSubtree(
+      key: const ValueKey('cloud-content'),
+      child: _buildScaffold(
+        context,
+        ref,
+        folders: _filterFolders(ref, folders),
+        localStrategies: const [],
+        cloudStrategies: _filterCloudStrategies(ref, strategies),
+        isCloud: true,
+        showAddSharedItemAction: isSharedWithMe,
+        emptyStateIcon:
+            isSharedWithMe ? Icons.people_outline : Icons.cloud_outlined,
+        emptyStateTitle:
+            isSharedWithMe ? 'No shared items yet' : 'No cloud strategies yet',
+        emptyStateSubtitle: isSharedWithMe
+            ? 'Shared folders and strategies will appear here'
+            : 'Create a cloud strategy to start your online workspace',
+      ),
     );
   }
 
@@ -237,10 +261,12 @@ class FolderContent extends ConsumerWidget {
         const double minTileWidth = 250;
         const double spacing = 20;
         const double padding = 32;
-        int crossAxisCount = ((constraints.maxWidth - padding + spacing) /
-                (minTileWidth + spacing))
-            .floor();
-        crossAxisCount = crossAxisCount.clamp(1, double.infinity).toInt();
+        final crossAxisCount = math.max(
+          1,
+          ((constraints.maxWidth - padding + spacing) /
+                  (minTileWidth + spacing))
+              .floor(),
+        );
 
         return CustomScrollView(
           slivers: [
@@ -536,7 +562,7 @@ class _LibraryMessageState extends StatelessWidget {
 /// Pulsing placeholder shown while the cloud library streams its first
 /// snapshot — previously the grid rendered the empty state during fetch.
 class _LibraryLoadingSkeleton extends StatefulWidget {
-  const _LibraryLoadingSkeleton();
+  const _LibraryLoadingSkeleton({super.key});
 
   @override
   State<_LibraryLoadingSkeleton> createState() =>
@@ -595,12 +621,12 @@ class _LibraryLoadingSkeletonState extends State<_LibraryLoadingSkeleton>
                 const double minTileWidth = 250;
                 const double spacing = 20;
                 const double padding = 32;
-                int crossAxisCount =
-                    ((constraints.maxWidth - padding + spacing) /
-                            (minTileWidth + spacing))
-                        .floor();
-                crossAxisCount =
-                    crossAxisCount.clamp(1, double.infinity).toInt();
+                final crossAxisCount = math.max(
+                  1,
+                  ((constraints.maxWidth - padding + spacing) /
+                          (minTileWidth + spacing))
+                      .floor(),
+                );
                 final tileCount = crossAxisCount * 2;
 
                 return Padding(

--- a/lib/widgets/folder_content.dart
+++ b/lib/widgets/folder_content.dart
@@ -12,6 +12,7 @@ import 'package:icarus/providers/library_workspace_provider.dart';
 import 'package:icarus/providers/strategy_filter_provider.dart';
 import 'package:icarus/strategy/strategy_models.dart';
 import 'package:icarus/widgets/custom_search_field.dart';
+import 'package:icarus/widgets/dialogs/auth/auth_dialog.dart';
 import 'package:icarus/widgets/dialogs/share_links_dialog.dart';
 import 'package:icarus/widgets/dot_painter.dart';
 import 'package:icarus/widgets/folder_pill.dart';
@@ -49,11 +50,23 @@ class FolderContent extends ConsumerWidget {
       if (!cloudAvailable) {
         return _buildCloudUnavailableState(context, ref);
       }
-      final folders = (ref.watch(cloudFoldersProvider).valueOrNull ?? const [])
+      final foldersAsync = ref.watch(cloudFoldersProvider);
+      final strategiesAsync = ref.watch(cloudStrategiesProvider);
+      if (foldersAsync.hasError || strategiesAsync.hasError) {
+        return _buildCloudErrorState(context, ref);
+      }
+      // Only the very first fetch shows the skeleton; dependency changes keep
+      // the previous value, so navigating folders doesn't flash it.
+      final isInitialLoading =
+          (foldersAsync.isLoading && !foldersAsync.hasValue) ||
+              (strategiesAsync.isLoading && !strategiesAsync.hasValue);
+      if (isInitialLoading) {
+        return const _LibraryLoadingSkeleton();
+      }
+      final folders = (foldersAsync.valueOrNull ?? const [])
           .map(FolderProvider.cloudSummaryToFolder)
           .toList(growable: false);
-      final strategies =
-          ref.watch(cloudStrategiesProvider).valueOrNull ?? const [];
+      final strategies = strategiesAsync.valueOrNull ?? const [];
       final isSharedWithMe = cloudSection == CloudLibrarySection.sharedWithMe;
       return _buildScaffold(
         context,
@@ -63,6 +76,8 @@ class FolderContent extends ConsumerWidget {
         cloudStrategies: _filterCloudStrategies(ref, strategies),
         isCloud: true,
         showAddSharedItemAction: isSharedWithMe,
+        emptyStateIcon:
+            isSharedWithMe ? Icons.people_outline : Icons.cloud_outlined,
         emptyStateTitle:
             isSharedWithMe ? 'No shared items yet' : 'No cloud strategies yet',
         emptyStateSubtitle: isSharedWithMe
@@ -172,6 +187,7 @@ class FolderContent extends ConsumerWidget {
     required List<CloudStrategySummary> cloudStrategies,
     required bool isCloud,
     bool showAddSharedItemAction = false,
+    IconData? emptyStateIcon,
     required String emptyStateTitle,
     required String emptyStateSubtitle,
   }) {
@@ -183,6 +199,14 @@ class FolderContent extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            if (emptyStateIcon != null) ...[
+              Icon(
+                emptyStateIcon,
+                size: 38,
+                color: Settings.tacticalVioletTheme.mutedForeground,
+              ),
+              const SizedBox(height: 16),
+            ],
             Text(
               emptyStateTitle,
               textAlign: TextAlign.center,
@@ -337,9 +361,22 @@ class FolderContent extends ConsumerWidget {
                 ),
               ),
               Expanded(
-                child: (folders.isEmpty && !hasStrategies)
-                    ? (isCloud ? emptyState : IcaDropTarget(child: emptyState))
-                    : wrappedContent,
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 200),
+                  switchInCurve: Curves.easeOutCubic,
+                  switchOutCurve: Curves.easeOutCubic,
+                  child: (folders.isEmpty && !hasStrategies)
+                      ? KeyedSubtree(
+                          key: const ValueKey('library-empty'),
+                          child: isCloud
+                              ? emptyState
+                              : IcaDropTarget(child: emptyState),
+                        )
+                      : KeyedSubtree(
+                          key: const ValueKey('library-content'),
+                          child: wrappedContent,
+                        ),
+                ),
               ),
             ],
           ),
@@ -349,30 +386,102 @@ class FolderContent extends ConsumerWidget {
   }
 
   Widget _buildCloudUnavailableState(BuildContext context, WidgetRef ref) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Text('Cloud workspace unavailable'),
-          const SizedBox(height: 8),
-          const Text(
-            'Sign in again or switch back to Local to keep working.',
-          ),
-          const SizedBox(height: 16),
-          ShadButton.secondary(
-            onPressed: () {
-              ref
-                  .read(libraryWorkspaceProvider.notifier)
-                  .select(LibraryWorkspace.local);
-            },
-            child: const Text('Back to Local'),
-          ),
-        ],
-      ),
+    return _LibraryMessageState(
+      icon: Icons.cloud_off_outlined,
+      iconColor: Settings.tacticalVioletTheme.mutedForeground,
+      title: 'Cloud workspace unavailable',
+      subtitle: 'Sign in again to reach your online strategies, or switch '
+          'back to Local to keep working.',
+      actions: [
+        ShadButton(
+          onPressed: () {
+            showDialog<void>(
+              context: context,
+              builder: (_) => const AuthDialog(),
+            );
+          },
+          child: const Text('Log In'),
+        ),
+        ShadButton.secondary(
+          onPressed: () {
+            ref
+                .read(libraryWorkspaceProvider.notifier)
+                .select(LibraryWorkspace.local);
+          },
+          child: const Text('Back to Local'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCloudErrorState(BuildContext context, WidgetRef ref) {
+    return _LibraryMessageState(
+      icon: Icons.cloud_off_outlined,
+      iconColor: Settings.tacticalVioletTheme.destructive,
+      title: "Couldn't load your cloud library",
+      subtitle: 'Check your connection and try again.',
+      actions: [
+        ShadButton(
+          leading: const Icon(LucideIcons.refreshCw, size: 14),
+          onPressed: () {
+            ref.invalidate(cloudFoldersProvider);
+            ref.invalidate(cloudStrategiesProvider);
+          },
+          child: const Text('Retry'),
+        ),
+        ShadButton.secondary(
+          onPressed: () {
+            ref
+                .read(libraryWorkspaceProvider.notifier)
+                .select(LibraryWorkspace.local);
+          },
+          child: const Text('Back to Local'),
+        ),
+      ],
     );
   }
 
   Widget _buildCommunityPlaceholder(BuildContext context, WidgetRef ref) {
+    return _LibraryMessageState(
+      icon: Icons.public,
+      iconColor: Settings.tacticalVioletTheme.primary,
+      title: 'Community strats are coming soon',
+      subtitle:
+          'This space is reserved for public lineups, team executes, and discoverable strategy packs.',
+      actions: [
+        ShadButton.secondary(
+          onPressed: () {
+            ref
+                .read(libraryWorkspaceProvider.notifier)
+                .select(LibraryWorkspace.local);
+          },
+          child: const Text('Back to Local'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shared full-pane message layout (dot-grid backdrop, icon, title, subtitle,
+/// action row) used by the community placeholder and cloud
+/// unavailable/error states so they carry the same visual weight.
+class _LibraryMessageState extends StatelessWidget {
+  const _LibraryMessageState({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.actions,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
     return Stack(
       children: [
         const Positioned.fill(
@@ -387,35 +496,157 @@ class FolderContent extends ConsumerWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(
-                  Icons.public,
-                  size: 38,
-                  color: Settings.tacticalVioletTheme.primary,
-                ),
+                Icon(icon, size: 38, color: iconColor),
                 const SizedBox(height: 16),
-                const Text(
-                  'Community strats are coming soon',
+                Text(
+                  title,
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'This space is reserved for public lineups, team executes, and discoverable strategy packs.',
+                  subtitle,
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: Settings.tacticalVioletTheme.mutedForeground,
                   ),
                 ),
                 const SizedBox(height: 18),
-                ShadButton.secondary(
-                  onPressed: () {
-                    ref
-                        .read(libraryWorkspaceProvider.notifier)
-                        .select(LibraryWorkspace.local);
-                  },
-                  child: const Text('Back to Local'),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    for (var i = 0; i < actions.length; i++) ...[
+                      if (i > 0) const SizedBox(width: 8),
+                      actions[i],
+                    ],
+                  ],
                 ),
               ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Pulsing placeholder shown while the cloud library streams its first
+/// snapshot — previously the grid rendered the empty state during fetch.
+class _LibraryLoadingSkeleton extends StatefulWidget {
+  const _LibraryLoadingSkeleton();
+
+  @override
+  State<_LibraryLoadingSkeleton> createState() =>
+      _LibraryLoadingSkeletonState();
+}
+
+class _LibraryLoadingSkeletonState extends State<_LibraryLoadingSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1100),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (MediaQuery.of(context).disableAnimations) {
+      _controller.stop();
+      _controller.value = 1;
+    } else if (!_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholderColor =
+        Settings.tacticalVioletTheme.muted.withValues(alpha: 0.35);
+    return Stack(
+      children: [
+        const Positioned.fill(
+          child: Padding(
+            padding: EdgeInsets.all(4.0),
+            child: DotGrid(),
+          ),
+        ),
+        Positioned.fill(
+          child: FadeTransition(
+            opacity: Tween<double>(begin: 0.45, end: 0.9).animate(
+              CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+            ),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                const double minTileWidth = 250;
+                const double spacing = 20;
+                const double padding = 32;
+                int crossAxisCount =
+                    ((constraints.maxWidth - padding + spacing) /
+                            (minTileWidth + spacing))
+                        .floor();
+                crossAxisCount =
+                    crossAxisCount.clamp(1, double.infinity).toInt();
+                final tileCount = crossAxisCount * 2;
+
+                return Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Wrap(
+                        spacing: 10,
+                        runSpacing: 10,
+                        children: [
+                          for (var i = 0; i < 3; i++)
+                            Container(
+                              width: 128,
+                              height: 44,
+                              decoration: BoxDecoration(
+                                color: placeholderColor,
+                                borderRadius: BorderRadius.circular(22),
+                              ),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 20),
+                      Expanded(
+                        child: GridView.builder(
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate:
+                              SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: crossAxisCount,
+                            mainAxisExtent: 250,
+                            crossAxisSpacing: 20,
+                            mainAxisSpacing: 20,
+                          ),
+                          itemCount: tileCount,
+                          itemBuilder: (context, index) => DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: placeholderColor,
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
             ),
           ),
         ),

--- a/lib/widgets/folder_navigator.dart
+++ b/lib/widgets/folder_navigator.dart
@@ -415,7 +415,15 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
           ),
           body: Padding(
             padding: const EdgeInsets.only(left: railReservedWidth),
-            child: FolderContent(folder: currentFolder),
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 220),
+              switchInCurve: Curves.easeOutCubic,
+              switchOutCurve: Curves.easeOutCubic,
+              child: KeyedSubtree(
+                key: ValueKey('$workspace/$cloudSection'),
+                child: FolderContent(folder: currentFolder),
+              ),
+            ),
           ),
         ),
         const Positioned(
@@ -764,77 +772,81 @@ class _LibraryRailItem extends StatelessWidget {
             ? SystemMouseCursors.basic
             : SystemMouseCursors.click,
         onTap: data.onTap,
-        child: AnimatedContainer(
+        child: AnimatedOpacity(
           duration: const Duration(milliseconds: 140),
-          height: 48,
-          padding: const EdgeInsets.symmetric(horizontal: 9),
-          decoration: BoxDecoration(
-            color: data.selected ? selectedColor : Colors.transparent,
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(
-              color: data.selected
-                  ? Settings.tacticalVioletTheme.primary
-                  : Colors.transparent,
+          opacity: data.onTap == null ? 0.55 : 1,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 140),
+            height: 48,
+            padding: const EdgeInsets.symmetric(horizontal: 9),
+            decoration: BoxDecoration(
+              color: data.selected ? selectedColor : Colors.transparent,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: data.selected
+                    ? Settings.tacticalVioletTheme.primary
+                    : Colors.transparent,
+              ),
             ),
-          ),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final showLabel = showDetails && constraints.maxWidth >= 96;
-              return Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  Positioned(
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    width: 26,
-                    child: Align(
-                      alignment: Alignment.center,
-                      child: Icon(
-                        data.icon,
-                        size: 21,
-                        color: data.onTap == null
-                            ? Settings.tacticalVioletTheme.mutedForeground
-                            : null,
-                      ),
-                    ),
-                  ),
-                  Positioned.fill(
-                    left: 33,
-                    child: IgnorePointer(
-                      ignoring: !showLabel,
-                      child: AnimatedOpacity(
-                        duration: const Duration(milliseconds: 120),
-                        opacity: expanded && showLabel ? 1 : 0,
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              data.label,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            const SizedBox(height: 1),
-                            Text(
-                              data.description,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                color: Settings
-                                    .tacticalVioletTheme.mutedForeground,
-                                fontSize: 10,
-                              ),
-                            ),
-                          ],
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final showLabel = showDetails && constraints.maxWidth >= 96;
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned(
+                      left: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: 26,
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: Icon(
+                          data.icon,
+                          size: 21,
+                          color: data.onTap == null
+                              ? Settings.tacticalVioletTheme.mutedForeground
+                              : null,
                         ),
                       ),
                     ),
-                  ),
-                ],
-              );
-            },
+                    Positioned.fill(
+                      left: 33,
+                      child: IgnorePointer(
+                        ignoring: !showLabel,
+                        child: AnimatedOpacity(
+                          duration: const Duration(milliseconds: 120),
+                          opacity: expanded && showLabel ? 1 : 0,
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                data.label,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              const SizedBox(height: 1),
+                              Text(
+                                data.description,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: Settings
+                                      .tacticalVioletTheme.mutedForeground,
+                                  fontSize: 10,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Part 4 of the cloud UX overhaul (TODO.md §4).

## Problem
- `valueOrNull ?? []` meant the cloud grid showed **"No cloud strategies yet" while the first fetch was still loading**
- Provider errors surfaced as empty lists that read as "you have no strategies"
- Local ↔ Cloud workspace switches snapped instantly; the cloud-unavailable state was plain text next to a polished community placeholder

## Change
- Pulsing skeleton (folder-pill + tile placeholders, 1100ms ease, respects `disableAnimations`) for the initial cloud fetch only — folder navigation retains previous data, so no skeleton flashing
- Dedicated error state with **Retry** (invalidates `cloudFoldersProvider`/`cloudStrategiesProvider`) and Back to Local
- Cloud-unavailable rebuilt on a shared `_LibraryMessageState` layout (icon/title/subtitle/actions) with a **Log In** action; the community placeholder now reuses the same layout
- 220ms easeOutCubic cross-fade on workspace/section switches and empty ↔ content swaps
- Cloud empty states get icons; disabled cloud rail items decay to 55% opacity (140ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)