### PR TITLE
Show cloud and role badges in library and editor

### DIFF
--- a/lib/providers/collab/strategy_capabilities_provider.dart
+++ b/lib/providers/collab/strategy_capabilities_provider.dart
@@ -87,3 +87,34 @@ final currentStrategyCapabilitiesProvider =
       ref.watch(remoteStrategySnapshotProvider).valueOrNull?.header.role;
   return StrategyCapabilities.fromCloudRole(role);
 });
+
+/// Last non-null cloud role reported for the currently open strategy.
+///
+/// [remoteStrategySnapshotProvider] transiently loses its value during
+/// reloads, refresh errors, and auth incidents, so role-dependent UI (like
+/// the editor's "View only" chip) must not read `valueOrNull` directly or it
+/// flickers off mid-session. This provider remembers the last role seen for
+/// the open strategy and only resets when a different strategy is opened.
+/// It is null only before the role has ever been known.
+final lastKnownCloudRoleProvider =
+    NotifierProvider<LastKnownCloudRoleNotifier, String?>(
+  LastKnownCloudRoleNotifier.new,
+);
+
+class LastKnownCloudRoleNotifier extends Notifier<String?> {
+  @override
+  String? build() {
+    // Rebuild (and therefore reset the cached role) whenever a different
+    // strategy is opened.
+    ref.watch(strategyProvider.select((value) => value.strategyId));
+
+    ref.listen(remoteStrategySnapshotProvider, (previous, next) {
+      final role = next.valueOrNull?.header.role;
+      if (role != null) {
+        state = role;
+      }
+    });
+
+    return ref.read(remoteStrategySnapshotProvider).valueOrNull?.header.role;
+  }
+}

--- a/lib/widgets/role_badge.dart
+++ b/lib/widgets/role_badge.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:icarus/const/settings.dart';
+
+/// Small uppercase micro badges used to mark cloud ownership and share role.
+///
+/// Styling follows the Icarus design system: 10px, w600, 0.5 letter spacing,
+/// uppercase text on a tinted pill. Colors come only from the tactical theme
+/// tokens (no hardcoded Material colors).
+enum CloudBadgeKind { owned, editor, viewer }
+
+CloudBadgeKind? cloudBadgeKindForRole(String? role) {
+  switch (role) {
+    case 'owner':
+      return CloudBadgeKind.owned;
+    case 'editor':
+      return CloudBadgeKind.editor;
+    case 'viewer':
+      return CloudBadgeKind.viewer;
+    default:
+      // Unknown role: treat as viewer so shared items are never mistaken for
+      // owned ones.
+      return role == null ? null : CloudBadgeKind.viewer;
+  }
+}
+
+class CloudRoleBadge extends StatelessWidget {
+  const CloudRoleBadge({super.key, required this.kind});
+
+  final CloudBadgeKind kind;
+
+  @override
+  Widget build(BuildContext context) {
+    const theme = Settings.tacticalVioletTheme;
+
+    switch (kind) {
+      case CloudBadgeKind.owned:
+        // Owned cloud strategies: a muted cloud glyph pill, deliberately quiet.
+        return _BadgePill(
+          background: theme.muted,
+          border: theme.border,
+          child: Icon(
+            Icons.cloud_outlined,
+            size: 12,
+            color: theme.mutedForeground,
+          ),
+        );
+      case CloudBadgeKind.editor:
+        // Shared with edit access: violet tint to echo the "action" accent.
+        return _BadgePill(
+          background: theme.primary.withValues(alpha: 0.16),
+          border: theme.primary.withValues(alpha: 0.32),
+          child: _BadgeLabel(text: 'EDIT', color: theme.primary),
+        );
+      case CloudBadgeKind.viewer:
+        // Shared read-only: muted, no command color.
+        return _BadgePill(
+          background: theme.muted,
+          border: theme.border,
+          child: _BadgeLabel(text: 'VIEW', color: theme.mutedForeground),
+        );
+    }
+  }
+}
+
+class _BadgePill extends StatelessWidget {
+  const _BadgePill({
+    required this.background,
+    required this.border,
+    required this.child,
+  });
+
+  final Color background;
+  final Color border;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: border),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _BadgeLabel extends StatelessWidget {
+  const _BadgeLabel({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        color: color,
+        fontSize: 10,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.5,
+        height: 1.2,
+      ),
+    );
+  }
+}

--- a/lib/widgets/role_badge.dart
+++ b/lib/widgets/role_badge.dart
@@ -17,8 +17,11 @@ CloudBadgeKind? cloudBadgeKindForRole(String? role) {
     case 'viewer':
       return CloudBadgeKind.viewer;
     default:
-      // Unknown role: treat as viewer so shared items are never mistaken for
-      // owned ones.
+      // Unknown non-null roles fall back to the viewer badge. This mirrors
+      // StrategyCapabilities.fromCloudRole (strategy_capabilities_provider),
+      // which grants viewer capabilities to any role that is not exactly
+      // 'owner' or 'editor' — so the badge matches what the user can actually
+      // do, and shared items are never mistaken for owned ones.
       return role == null ? null : CloudBadgeKind.viewer;
   }
 }

--- a/lib/widgets/save_and_load_button.dart
+++ b/lib/widgets/save_and_load_button.dart
@@ -9,6 +9,8 @@ import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/providers/collab/cloud_collab_provider.dart';
+import 'package:icarus/providers/collab/remote_strategy_snapshot_provider.dart';
 import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/screenshot_provider.dart';
@@ -16,6 +18,7 @@ import 'package:icarus/providers/strategy_page_session_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/strategy/strategy_import_export.dart';
 import 'package:icarus/strategy/strategy_models.dart';
+import 'package:icarus/strategy/strategy_page_models.dart';
 import 'package:icarus/screenshot/screenshot_view.dart';
 import 'package:icarus/widgets/settings_tab.dart';
 import 'package:icarus/widgets/strategy_save_icon_button.dart';
@@ -201,7 +204,68 @@ class _SaveAndLoadButtonState extends ConsumerState<SaveAndLoadButton> {
                   : const Icon(Icons.camera_alt_outlined),
             ),
           ),
+          if (_isViewOnly()) ...[
+            const SizedBox(width: 4),
+            const _ViewOnlyChip(),
+          ],
         ],
+      ),
+    );
+  }
+
+  bool _isViewOnly() {
+    final source = ref.watch(strategyProvider.select((value) => value.source));
+    if (source != StrategySource.cloud ||
+        !ref.watch(isCloudCollabEnabledProvider)) {
+      return false;
+    }
+    final role =
+        ref.watch(remoteStrategySnapshotProvider).valueOrNull?.header.role;
+    return role == 'viewer';
+  }
+}
+
+/// Non-interactive chip shown in the editor top strip when the open cloud
+/// strategy is shared with view-only access.
+class _ViewOnlyChip extends StatelessWidget {
+  const _ViewOnlyChip();
+
+  @override
+  Widget build(BuildContext context) {
+    const theme = Settings.tacticalVioletTheme;
+
+    return ShadTooltip(
+      builder: (context) => const Text(
+        'You have view access. Ask the owner for edit access to make changes.',
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: theme.muted,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: theme.border),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.visibility_outlined,
+              size: 14,
+              color: theme.mutedForeground,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              'View only',
+              style: TextStyle(
+                color: theme.mutedForeground,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.3,
+                height: 1.2,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/save_and_load_button.dart
+++ b/lib/widgets/save_and_load_button.dart
@@ -10,7 +10,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
-import 'package:icarus/providers/collab/remote_strategy_snapshot_provider.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/screenshot_provider.dart';
@@ -219,8 +219,10 @@ class _SaveAndLoadButtonState extends ConsumerState<SaveAndLoadButton> {
         !ref.watch(isCloudCollabEnabledProvider)) {
       return false;
     }
-    final role =
-        ref.watch(remoteStrategySnapshotProvider).valueOrNull?.header.role;
+    // Read the cached role rather than the raw snapshot so the chip does not
+    // flicker off while the snapshot is reloading or transiently errored; it
+    // is absent only before the role has ever been known.
+    final role = ref.watch(lastKnownCloudRoleProvider);
     return role == 'viewer';
   }
 }

--- a/lib/widgets/strategy_tile/strategy_tile_sections.dart
+++ b/lib/widgets/strategy_tile/strategy_tile_sections.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/strategy_page.dart';
 import 'package:icarus/strategy/strategy_models.dart';
+import 'package:icarus/widgets/role_badge.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 const double _agentIconSize = 27;
@@ -25,6 +26,7 @@ class StrategyTileViewData {
     required this.thumbnailAsset,
     required this.lastEditedLabel,
     required this.agentTypes,
+    this.cloudBadge,
   });
 
   factory StrategyTileViewData.fromStrategy(StrategyData strategy) {
@@ -58,6 +60,7 @@ class StrategyTileViewData {
           'assets/maps/thumbnails/${strategy.mapData}_thumbnail.webp',
       lastEditedLabel: _timeAgo(strategy.updatedAt),
       agentTypes: const [],
+      cloudBadge: cloudBadgeKindForRole(strategy.role),
     );
   }
 
@@ -68,6 +71,10 @@ class StrategyTileViewData {
   final String thumbnailAsset;
   final String lastEditedLabel;
   final List<AgentType> agentTypes;
+
+  /// Non-null only for cloud strategies. Local tiles leave this null so they
+  /// render exactly as before.
+  final CloudBadgeKind? cloudBadge;
 
   static String _mapName(MapValue? map) {
     final raw = map == null ? null : Maps.mapNames[map];
@@ -193,15 +200,26 @@ class StrategyTileDetails extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 130),
-                      child: Text(
-                        data.name,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.w500,
-                          overflow: TextOverflow.ellipsis,
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Flexible(
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 130),
+                            child: Text(
+                              data.name,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w500,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ),
                         ),
-                      ),
+                        if (data.cloudBadge != null) ...[
+                          const SizedBox(width: 6),
+                          CloudRoleBadge(kind: data.cloudBadge!),
+                        ],
+                      ],
                     ),
                     const SizedBox(height: 5),
                     Text(data.mapName),


### PR DESCRIPTION
## Problem

Part 5 of the cloud UX overhaul (TODO.md §5). Cloud strategies and shared items were visually indistinguishable from local ones in the library, and a user's share role (owner / editor / viewer) was never displayed anywhere — so viewers had no signal about why editing was blocked.

## Change

- **Shared badge widget** (`lib/widgets/role_badge.dart`): micro badges (10px, w600, 0.5 letter spacing, uppercase) on tinted pills, all colors from `Settings.tacticalVioletTheme`:
  - Owned cloud strategy → muted `Icons.cloud_outlined` pill (quiet, informational).
  - Editor share → `EDIT` badge, violet tint (primary @ 0.16 bg, primary fg).
  - Viewer share → `VIEW` badge, muted bg / mutedForeground fg.
- **Cloud strategy tiles**: badge renders inline beside the name/metadata in the tile detail block, keeping it clear of the map thumbnail focal area. Local tiles leave `cloudBadge` null and are visually unchanged.
- **Editor top strip** (`save_and_load_button.dart`): when the open strategy is a cloud viewer share, a non-interactive "View only" chip appears after the existing buttons, styled like nearby chips, with a tooltip: "You have view access. Ask the owner for edit access to make changes." Editors and owners see nothing.

## Notes

- No hardcoded Material colors; theme tokens only.
- `dart analyze lib/widgets lib/providers` reports zero issues on the changed/new files (4 remaining infos are pre-existing in untouched folder widgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)