### PR TITLE
Auth polish: humanized errors, ShadDialog incident prompt, Account settings

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -5,7 +5,9 @@ import 'package:convex_flutter/convex_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/app_navigator.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/services/app_error_reporter.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final authProvider =
@@ -554,7 +556,7 @@ class AuthProvider extends Notifier<AppAuthState> {
       );
 
       if (response.session == null) {
-        const message = 'Sign in did not return a session.';
+        const message = "Sign in didn't complete. Please try again.";
         state = state.copyWith(
           isLoading: false,
           isConvexUserReady: false,
@@ -573,7 +575,7 @@ class AuthProvider extends Notifier<AppAuthState> {
         error: error,
         stackTrace: stackTrace,
       );
-      final message = 'Email/password sign-in failed: $error';
+      final message = _friendlySignInError(error);
       state = state.copyWith(
         isLoading: false,
         isConvexUserReady: false,
@@ -582,6 +584,47 @@ class AuthProvider extends Notifier<AppAuthState> {
       );
       return message;
     }
+  }
+
+  static String _friendlySignInError(Object error) {
+    final message = error.toString().toLowerCase();
+    if (message.contains('invalid login credentials') ||
+        message.contains('invalid_credentials')) {
+      return 'Incorrect email or password.';
+    }
+    if (message.contains('email not confirmed')) {
+      return 'Confirm your email first — check your inbox for the '
+          'confirmation link.';
+    }
+    if (message.contains('rate limit') || message.contains('too many')) {
+      return 'Too many attempts. Wait a moment and try again.';
+    }
+    if (message.contains('socket') ||
+        message.contains('network') ||
+        message.contains('timed out') ||
+        message.contains('failed host lookup')) {
+      return "Couldn't reach the server. Check your connection and try again.";
+    }
+    return 'Sign in failed. Please try again.';
+  }
+
+  static String _friendlySignUpError(Object error) {
+    final message = error.toString().toLowerCase();
+    if (message.contains('already registered') ||
+        message.contains('already exists')) {
+      return 'An account with this email already exists. Try signing in '
+          'instead.';
+    }
+    if (message.contains('rate limit') || message.contains('too many')) {
+      return 'Too many attempts. Wait a moment and try again.';
+    }
+    if (message.contains('socket') ||
+        message.contains('network') ||
+        message.contains('timed out') ||
+        message.contains('failed host lookup')) {
+      return "Couldn't reach the server. Check your connection and try again.";
+    }
+    return 'Sign up failed. Please try again.';
   }
 
   Future<String?> signUpWithEmailPassword({
@@ -603,7 +646,8 @@ class AuthProvider extends Notifier<AppAuthState> {
 
       if (response.session == null) {
         const message =
-            'Account created, but email confirmation is required before sign in.';
+            'Account created! Check your inbox for the confirmation link, '
+            'then sign in.';
         state = state.copyWith(
           isLoading: false,
           isConvexUserReady: false,
@@ -622,7 +666,7 @@ class AuthProvider extends Notifier<AppAuthState> {
         error: error,
         stackTrace: stackTrace,
       );
-      final message = 'Email/password sign-up failed: $error';
+      final message = _friendlySignUpError(error);
       state = state.copyWith(
         isLoading: false,
         isConvexUserReady: false,
@@ -655,6 +699,10 @@ class AuthProvider extends Notifier<AppAuthState> {
         isConvexUserReady: false,
         convexAuthStatus: ConvexAuthStatus.signedOut,
       );
+      Settings.showToast(
+        message: 'Signed out. Your local strategies stay on this device.',
+        backgroundColor: Settings.tacticalVioletTheme.primary,
+      );
     } catch (error, stackTrace) {
       log(
         'Sign out failed: $error',
@@ -666,7 +714,7 @@ class AuthProvider extends Notifier<AppAuthState> {
         isLoading: false,
         isConvexUserReady: false,
         convexAuthStatus: ConvexAuthStatus.incident,
-        errorMessage: 'Sign out failed: $error',
+        errorMessage: 'Sign out failed. Please try again.',
       );
     }
   }
@@ -814,7 +862,8 @@ class AuthProvider extends Notifier<AppAuthState> {
       activeAuthIncidentId: incidentId,
       lastAuthIncidentSource: source,
       errorMessage:
-          'Cloud authentication expired. Retry Convex auth or sign out.',
+          'Your cloud session expired. Reconnect to resume syncing, or '
+          'sign out.',
     );
 
     log(
@@ -1098,7 +1147,7 @@ class AuthProvider extends Notifier<AppAuthState> {
       state = state.copyWith(
         isConvexUserReady: false,
         convexAuthStatus: ConvexAuthStatus.incident,
-        errorMessage: 'Failed to configure Convex auth: $error',
+        errorMessage: "Couldn't connect to cloud sync. Please retry.",
       );
     }
   }
@@ -1130,34 +1179,38 @@ class AuthProvider extends Notifier<AppAuthState> {
     state = state.copyWith(isAuthIncidentPromptOpen: true);
 
     try {
-      final action = await showDialog<_AuthIncidentAction>(
+      final action = await showShadDialog<_AuthIncidentAction>(
         context: navCtx,
         barrierDismissible: false,
         builder: (context) {
-          return AlertDialog(
-            title: const Text('Cloud Session Needs Attention'),
-            content: const Text(
-              'Convex reported your session as unauthenticated while Supabase is signed in. '
-              'Retry Convex auth, sign out, or dismiss to keep cloud features paused.',
+          return ShadDialog.alert(
+            title: const Text('Cloud connection lost'),
+            description: const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'Your cloud session is no longer valid, so syncing is '
+                'paused. Reconnect to keep your cloud strategies up to '
+                'date, or sign out. Local strategies are unaffected.',
+              ),
             ),
             actions: [
-              TextButton(
+              ShadButton.ghost(
                 onPressed: () {
                   Navigator.of(context).pop(_AuthIncidentAction.dismiss);
                 },
-                child: const Text('Dismiss'),
+                child: const Text('Not Now'),
               ),
-              TextButton(
+              ShadButton.secondary(
                 onPressed: () {
                   Navigator.of(context).pop(_AuthIncidentAction.signOut);
                 },
                 child: const Text('Sign Out'),
               ),
-              FilledButton(
+              ShadButton(
                 onPressed: () {
                   Navigator.of(context).pop(_AuthIncidentAction.retry);
                 },
-                child: const Text('Retry Convex Auth'),
+                child: const Text('Reconnect'),
               ),
             ],
           );

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -153,16 +153,24 @@ class AppAuthState {
 
   String get displayName {
     final metadata = user?.userMetadata ?? const <String, dynamic>{};
-    final String? name = metadata['full_name'] as String? ??
-        metadata['name'] as String? ??
-        metadata['user_name'] as String? ??
+    // Metadata values are user/provider controlled — tolerate non-string
+    // entries instead of crashing the widget build.
+    String? stringEntry(String key) {
+      final value = metadata[key];
+      return value is String && value.isNotEmpty ? value : null;
+    }
+
+    final name = stringEntry('full_name') ??
+        stringEntry('name') ??
+        stringEntry('user_name') ??
         user?.email;
     return (name?.isNotEmpty ?? false) ? name! : 'Discord user';
   }
 
   String? get avatarUrl {
     final metadata = user?.userMetadata ?? const <String, dynamic>{};
-    return metadata['avatar_url'] as String?;
+    final value = metadata['avatar_url'];
+    return value is String && value.isNotEmpty ? value : null;
   }
 
   AppAuthState copyWith({

--- a/lib/widgets/custom_text_field.dart
+++ b/lib/widgets/custom_text_field.dart
@@ -16,6 +16,7 @@ class CustomTextField extends ConsumerWidget {
     this.autofillHints,
     this.obscureText = false,
     this.textInputAction,
+    this.hasError = false,
   });
   final TextEditingController? controller;
   final String? hintText;
@@ -28,10 +29,20 @@ class CustomTextField extends ConsumerWidget {
   final bool obscureText;
   final TextInputAction? textInputAction;
 
+  /// Draws a destructive border when true (e.g. failed validation).
+  final bool hasError;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return TextEditingShortcutScope(
       child: ShadInput(
+        decoration: hasError
+            ? ShadDecoration(
+                border: ShadBorder.all(
+                  color: ShadTheme.of(context).colorScheme.destructive,
+                ),
+              )
+            : null,
         controller: controller,
         textAlign: textAlign ?? TextAlign.start,
         minLines: minLines,

--- a/lib/widgets/dialogs/auth/auth_dialog.dart
+++ b/lib/widgets/dialogs/auth/auth_dialog.dart
@@ -8,6 +8,10 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 
 enum AuthDialogMode { signIn, signUp }
 
+enum _AuthField { email, password, confirm }
+
+const _bannerDuration = Duration(milliseconds: 180);
+
 class AuthDialog extends ConsumerStatefulWidget {
   const AuthDialog({
     super.key,
@@ -26,7 +30,10 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
   final TextEditingController _confirmController = TextEditingController();
   bool _submitting = false;
   bool _isSignUp = false;
-  String? _errorMessage;
+  bool _waitingForDiscord = false;
+  String? _message;
+  bool _messageIsInfo = false;
+  _AuthField? _errorField;
 
   @override
   void initState() {
@@ -42,47 +49,59 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
     super.dispose();
   }
 
+  void _setValidationError(String message, _AuthField field) {
+    setState(() {
+      _message = message;
+      _messageIsInfo = false;
+      _errorField = field;
+    });
+  }
+
   Future<void> _submit() async {
     final email = _emailController.text.trim();
     final password = _passwordController.text;
     final confirm = _confirmController.text;
 
     if (email.isEmpty || !email.contains('@')) {
-      setState(() {
-        _errorMessage = 'Enter a valid email address.';
-      });
+      _setValidationError('Enter a valid email address.', _AuthField.email);
       return;
     }
 
     if (password.length < 6) {
-      setState(() {
-        _errorMessage = 'Password must be at least 6 characters.';
-      });
+      _setValidationError(
+        'Password must be at least 6 characters.',
+        _AuthField.password,
+      );
       return;
     }
 
     if (_isSignUp && password != confirm) {
-      setState(() {
-        _errorMessage = 'Passwords do not match.';
-      });
+      _setValidationError('Passwords do not match.', _AuthField.confirm);
       return;
     }
 
     setState(() {
       _submitting = true;
-      _errorMessage = null;
+      _message = null;
+      _messageIsInfo = false;
+      _errorField = null;
     });
 
     final notifier = ref.read(authProvider.notifier);
     final error = _isSignUp
-        ? await notifier.signUpWithEmailPassword(email: email, password: password)
-        : await notifier.signInWithEmailPassword(email: email, password: password);
+        ? await notifier.signUpWithEmailPassword(
+            email: email, password: password)
+        : await notifier.signInWithEmailPassword(
+            email: email, password: password);
 
     if (!mounted) return;
 
     setState(() {
       _submitting = false;
-      _errorMessage = error;
+      _message = error;
+      // The "account created" outcome comes back through the error channel
+      // but is good news — present it as info, not failure.
+      _messageIsInfo = error != null && error.startsWith('Account created');
     });
 
     if (error == null) {
@@ -90,10 +109,30 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
     }
   }
 
+  void _startDiscordSignIn() {
+    setState(() {
+      _waitingForDiscord = true;
+      _message = null;
+      _messageIsInfo = false;
+      _errorField = null;
+    });
+    unawaited(ref.read(authProvider.notifier).signInWithDiscord());
+  }
+
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(authProvider);
     final busy = _submitting || authState.isLoading;
+
+    // The Discord flow completes via a browser round-trip and deep link:
+    // close the dialog once the session actually lands.
+    ref.listen(authProvider, (previous, next) {
+      if (_waitingForDiscord &&
+          next.isAuthenticated &&
+          previous?.isAuthenticated != true) {
+        Navigator.of(context).pop(true);
+      }
+    });
 
     return ShadDialog(
       title: Text(_isSignUp ? 'Create account' : 'Sign in'),
@@ -114,6 +153,7 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
               autofillHints: const [AutofillHints.email],
               hintText: 'Email',
               textInputAction: TextInputAction.next,
+              hasError: _errorField == _AuthField.email,
             ),
             const SizedBox(height: 10),
             CustomTextField(
@@ -124,6 +164,7 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
               textInputAction:
                   _isSignUp ? TextInputAction.next : TextInputAction.done,
               onSubmitted: _isSignUp ? null : (_) => _submit(),
+              hasError: _errorField == _AuthField.password,
             ),
             if (_isSignUp) ...[
               const SizedBox(height: 10),
@@ -134,20 +175,35 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
                 hintText: 'Confirm password',
                 textInputAction: TextInputAction.done,
                 onSubmitted: (_) => _submit(),
+                hasError: _errorField == _AuthField.confirm,
               ),
             ],
             const SizedBox(height: 12),
-            if (_errorMessage != null)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: Text(
-                  _errorMessage!,
-                  style: TextStyle(
-                    color: ShadTheme.of(context).colorScheme.destructive,
-                    fontSize: 12,
-                  ),
-                ),
-              ),
+            AnimatedSize(
+              duration: _bannerDuration,
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.topCenter,
+              child: _message != null
+                  ? Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: _AuthMessageBanner(
+                        message: _message!,
+                        isInfo: _messageIsInfo,
+                      ),
+                    )
+                  : const SizedBox(width: double.infinity),
+            ),
+            AnimatedSize(
+              duration: _bannerDuration,
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.topCenter,
+              child: _waitingForDiscord
+                  ? const Padding(
+                      padding: EdgeInsets.only(bottom: 10),
+                      child: _DiscordPendingBanner(),
+                    )
+                  : const SizedBox(width: double.infinity),
+            ),
             Row(
               children: [
                 Expanded(
@@ -157,7 +213,9 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
                         : () {
                             setState(() {
                               _isSignUp = !_isSignUp;
-                              _errorMessage = null;
+                              _message = null;
+                              _messageIsInfo = false;
+                              _errorField = null;
                             });
                           },
                     child: Text(
@@ -174,14 +232,8 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
               children: [
                 Expanded(
                   child: ShadButton.secondary(
-                    onPressed: busy
-                        ? null
-                        : () {
-                            Navigator.of(context).pop();
-                            unawaited(
-                              ref.read(authProvider.notifier).signInWithDiscord(),
-                            );
-                          },
+                    onPressed:
+                        busy || _waitingForDiscord ? null : _startDiscordSignIn,
                     child: const Text('Continue with Discord'),
                   ),
                 ),
@@ -189,19 +241,113 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
                 Expanded(
                   child: ShadButton(
                     onPressed: busy ? null : _submit,
-                    child: busy
+                    leading: busy
                         ? const SizedBox(
-                            width: 16,
-                            height: 16,
+                            width: 14,
+                            height: 14,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Text(_isSignUp ? 'Create account' : 'Sign in'),
+                        : null,
+                    child: Text(
+                      busy
+                          ? (_isSignUp ? 'Creating…' : 'Signing in…')
+                          : (_isSignUp ? 'Create account' : 'Sign in'),
+                    ),
                   ),
                 ),
               ],
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _AuthMessageBanner extends StatelessWidget {
+  const _AuthMessageBanner({
+    required this.message,
+    required this.isInfo,
+  });
+
+  final String message;
+  final bool isInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final color =
+        isInfo ? theme.colorScheme.primary : theme.colorScheme.destructive;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            isInfo ? Icons.mark_email_read_outlined : Icons.error_outline,
+            size: 15,
+            color: color,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.small.copyWith(
+                color: color,
+                fontSize: 12,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiscordPendingBanner extends StatelessWidget {
+  const _DiscordPendingBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.muted.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 13,
+            height: 13,
+            child: CircularProgressIndicator(
+              strokeWidth: 1.8,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                theme.colorScheme.mutedForeground,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Finish signing in with Discord in your browser — this dialog '
+              'will close automatically.',
+              style: theme.textTheme.small.copyWith(
+                color: theme.colorScheme.mutedForeground,
+                fontSize: 12,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/dialogs/auth/auth_dialog.dart
+++ b/lib/widgets/dialogs/auth/auth_dialog.dart
@@ -125,12 +125,23 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
     final busy = _submitting || authState.isLoading;
 
     // The Discord flow completes via a browser round-trip and deep link:
-    // close the dialog once the session actually lands.
+    // close the dialog once the session actually lands, and drop the pending
+    // state if the provider reports a failure instead.
     ref.listen(authProvider, (previous, next) {
-      if (_waitingForDiscord &&
-          next.isAuthenticated &&
-          previous?.isAuthenticated != true) {
+      if (!_waitingForDiscord) {
+        return;
+      }
+      if (next.isAuthenticated && previous?.isAuthenticated != true) {
         Navigator.of(context).pop(true);
+        return;
+      }
+      if (next.errorMessage != null &&
+          next.errorMessage != previous?.errorMessage) {
+        setState(() {
+          _waitingForDiscord = false;
+          _message = next.errorMessage;
+          _messageIsInfo = false;
+        });
       }
     });
 
@@ -198,9 +209,13 @@ class _AuthDialogState extends ConsumerState<AuthDialog> {
               curve: Curves.easeOutCubic,
               alignment: Alignment.topCenter,
               child: _waitingForDiscord
-                  ? const Padding(
-                      padding: EdgeInsets.only(bottom: 10),
-                      child: _DiscordPendingBanner(),
+                  ? Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: _DiscordPendingBanner(
+                        onCancel: () {
+                          setState(() => _waitingForDiscord = false);
+                        },
+                      ),
                     )
                   : const SizedBox(width: double.infinity),
             ),
@@ -311,7 +326,9 @@ class _AuthMessageBanner extends StatelessWidget {
 }
 
 class _DiscordPendingBanner extends StatelessWidget {
-  const _DiscordPendingBanner();
+  const _DiscordPendingBanner({required this.onCancel});
+
+  final VoidCallback onCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -346,6 +363,12 @@ class _DiscordPendingBanner extends StatelessWidget {
                 height: 1.35,
               ),
             ),
+          ),
+          const SizedBox(width: 8),
+          ShadButton.ghost(
+            size: ShadButtonSize.sm,
+            onPressed: onCancel,
+            child: const Text('Cancel'),
           ),
         ],
       ),

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -5,6 +5,8 @@ import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/shortcut_info.dart';
+import 'package:icarus/providers/auth_provider.dart';
+import 'package:icarus/widgets/dialogs/auth/auth_dialog.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
 import 'package:icarus/providers/marker_sizes_sync.dart';
@@ -26,6 +28,7 @@ enum _SettingsMode {
 enum _SettingsSection {
   strategyObjects,
   strategyMapTheme,
+  globalAccount,
   globalDefaults,
   globalSaving,
   globalMapVisibility,
@@ -187,6 +190,7 @@ class _SettingsTabState extends ConsumerState<SettingsTab> {
       case _SettingsSection.strategyObjects:
       case _SettingsSection.strategyMapTheme:
         return _SettingsMode.strategy;
+      case _SettingsSection.globalAccount:
       case _SettingsSection.globalDefaults:
       case _SettingsSection.globalSaving:
       case _SettingsSection.globalMapVisibility:
@@ -369,6 +373,12 @@ class _GlobalSettingsSections extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        _AccountSettingsSection(
+          key: sectionKeys[_SettingsSection.globalAccount],
+        ),
+        const SizedBox(height: 20),
+        const _SectionDivider(),
+        const SizedBox(height: 20),
         SettingsScopeCard(
           key: sectionKeys[_SettingsSection.globalDefaults],
           title: "New strategy defaults",
@@ -1072,6 +1082,186 @@ class _ShortcutEmptySearch extends StatelessWidget {
   }
 }
 
+class _AccountSettingsSection extends ConsumerWidget {
+  const _AccountSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authProvider);
+
+    return SettingsScopeCard(
+      title: 'Account',
+      description: authState.isAuthenticated
+          ? 'Your cloud identity and sync connection.'
+          : 'Sign in to sync strategies to the cloud and share them.',
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 180),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeOutCubic,
+        child: authState.isAuthenticated
+            ? _SignedInAccountRow(
+                key: const ValueKey('account-signed-in'),
+                authState: authState,
+              )
+            : Padding(
+                key: const ValueKey('account-signed-out'),
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.cloud_off_outlined,
+                      size: 18,
+                      color: Settings.tacticalVioletTheme.mutedForeground,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        'Not signed in',
+                        style: TextStyle(
+                          color: Settings.tacticalVioletTheme.mutedForeground,
+                        ),
+                      ),
+                    ),
+                    ShadButton(
+                      size: ShadButtonSize.sm,
+                      onPressed: authState.isLoading
+                          ? null
+                          : () {
+                              showDialog<void>(
+                                context: context,
+                                builder: (_) => const AuthDialog(),
+                              );
+                            },
+                      child: const Text('Log In'),
+                    ),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class _SignedInAccountRow extends ConsumerWidget {
+  const _SignedInAccountRow({super.key, required this.authState});
+
+  final AppAuthState authState;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    const theme = Settings.tacticalVioletTheme;
+    final email = authState.user?.email;
+    final avatarUrl = authState.avatarUrl;
+
+    final (String statusLabel, IconData statusIcon, Color statusColor) =
+        switch (authState.convexAuthStatus) {
+      ConvexAuthStatus.ready => (
+          'Cloud sync active',
+          Icons.cloud_done_outlined,
+          theme.mutedForeground,
+        ),
+      ConvexAuthStatus.configuring => (
+          'Connecting to cloud…',
+          Icons.cloud_sync_outlined,
+          theme.mutedForeground,
+        ),
+      ConvexAuthStatus.incident => (
+          'Cloud connection needs attention',
+          Icons.error_outline,
+          theme.destructive,
+        ),
+      ConvexAuthStatus.signedOut => (
+          'Cloud sync inactive',
+          Icons.cloud_off_outlined,
+          theme.mutedForeground,
+        ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 16,
+            backgroundColor: theme.muted,
+            foregroundImage:
+                avatarUrl != null ? NetworkImage(avatarUrl) : null,
+            child: Text(
+              authState.displayName.characters.first.toUpperCase(),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: theme.foreground,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  authState.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                if (email != null && email != authState.displayName)
+                  Text(
+                    email,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: theme.mutedForeground,
+                      fontSize: 12,
+                    ),
+                  ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Icon(statusIcon, size: 13, color: statusColor),
+                    const SizedBox(width: 5),
+                    Flexible(
+                      child: Text(
+                        statusLabel,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: statusColor,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          if (authState.convexAuthStatus == ConvexAuthStatus.incident) ...[
+            ShadButton(
+              size: ShadButtonSize.sm,
+              onPressed: () {
+                ref
+                    .read(authProvider.notifier)
+                    .reinitializeConvexAuth(source: 'settings_account');
+              },
+              child: const Text('Reconnect'),
+            ),
+            const SizedBox(width: 8),
+          ],
+          ShadButton.outline(
+            size: ShadButtonSize.sm,
+            onPressed: authState.isLoading
+                ? null
+                : () {
+                    ref.read(authProvider.notifier).signOut();
+                  },
+            child: const Text('Sign Out'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SettingsNavigationRail extends StatelessWidget {
   const _SettingsNavigationRail({
     required this.mode,
@@ -1125,6 +1315,12 @@ class _SettingsNavigationRail extends StatelessWidget {
             onTap: () => onSectionSelected(_SettingsSection.globalDefaults),
           ),
           const SizedBox(height: 4),
+          _SettingsNavItem(
+            icon: Icons.person_outline,
+            label: "Account",
+            isSelected: selectedSection == _SettingsSection.globalAccount,
+            onTap: () => onSectionSelected(_SettingsSection.globalAccount),
+          ),
           _SettingsNavItem(
             icon: Icons.auto_fix_high_outlined,
             label: "Defaults",


### PR DESCRIPTION
Part 6 of the cloud UX overhaul (TODO.md §6).

## Problem
- The auth-incident prompt was a raw Material `AlertDialog` telling users "Convex reported your session as unauthenticated while Supabase is signed in" with a "Retry Convex Auth" button
- Backend exception text leaked into the UI; errors appeared as bare red text with no animation or field highlighting
- Discord OAuth popped the dialog before the browser round-trip started, leaving no visible pending state
- Sign-out was silent; there was no Account section in settings at all

## Change
- **Incident prompt** → `ShadDialog.alert` "Cloud connection lost" with Reconnect / Sign Out / Not Now and plain-language copy
- **Humanized errors** via `_friendlySignInError`/`_friendlySignUpError` (incorrect credentials, unconfirmed email, rate limit, network); raw errors stay in logs only
- **Auth dialog**: animated (180ms) inline banner — destructive for errors, info-styled with a mail icon for the "Account created! Check your inbox" outcome — plus per-field error borders (`CustomTextField.hasError`) and a labeled spinner on submit
- **Discord OAuth pending state**: banner ("finish signing in in your browser — this dialog will close automatically") and auto-close via an auth listener instead of a blind pop
- **Sign-out toast**: "Signed out. Your local strategies stay on this device."
- **Account settings section** (App-wide → Account): avatar/name/email, live cloud status (active / connecting / needs attention with a Reconnect button / inactive), Sign Out, or a Log In row when signed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)