### PR TITLE
Collect lineup-item images in server asset reference checks

### DIFF
--- a/convex/lib/imageAssets.ts
+++ b/convex/lib/imageAssets.ts
@@ -56,20 +56,36 @@ export function collectAssetIdsFromLineupPayload(
   payload: Doc<"lineups">["payload"],
 ): Set<string> {
   const assetIds = new Set<string>();
-  const rawImages = payload.data.images;
-  if (!Array.isArray(rawImages)) {
-    return assetIds;
-  }
 
-  for (const image of rawImages) {
-    if (
-      typeof image === "object" &&
-      image !== null &&
-      typeof image.id === "string"
-    ) {
-      assetIds.add(image.id);
+  const addImages = (rawImages: unknown) => {
+    if (!Array.isArray(rawImages)) {
+      return;
+    }
+    for (const image of rawImages) {
+      if (
+        typeof image === "object" &&
+        image !== null &&
+        typeof (image as { id?: unknown }).id === "string"
+      ) {
+        assetIds.add((image as { id: string }).id);
+      }
+    }
+  };
+
+  // Legacy lineup payloads stored images at the top level.
+  addImages(payload.data.images);
+
+  // Grouped lineup payloads (LineUpGroup) nest them per item:
+  // data.items[*].images[*].id
+  const rawItems = payload.data.items;
+  if (Array.isArray(rawItems)) {
+    for (const item of rawItems) {
+      if (typeof item === "object" && item !== null) {
+        addImages((item as { images?: unknown }).images);
+      }
     }
   }
+
   return assetIds;
 }
 


### PR DESCRIPTION
Fixes the P1 greptile flagged on #78: `collectAssetIdsFromLineupPayload` only read the legacy top-level `data.images`, but grouped lineup payloads (`LineUpGroup.toJson()`) nest images at `data.items[*].images[*].id` — matching the client-side collector in `lib/collab/cloud_media_models.dart` (`collectStrategyImageAssetIds`). Lineup-only images were therefore missing from server reference checks, so asset listing could omit them and stale-asset checks could flag them.

The collector now reads both shapes (legacy top-level list kept for old records). `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)