### PR TITLE
Include lineup agents in strategy and folder previews

### DIFF
--- a/lib/widgets/folder_card.dart
+++ b/lib/widgets/folder_card.dart
@@ -77,6 +77,11 @@ class FolderCardViewData {
         for (final agent in page.agentData) {
           seenInStrategy.add(agent.type);
         }
+        // Lineup agents live in lineUpGroups, not agentData, so collect them
+        // too or agents added via the lineup tool never show in previews.
+        for (final group in page.lineUpGroups) {
+          seenInStrategy.add(group.agent.type);
+        }
       }
       for (final type in seenInStrategy) {
         counts[type] = (counts[type] ?? 0) + 1;

--- a/lib/widgets/strategy_tile/strategy_tile_sections.dart
+++ b/lib/widgets/strategy_tile/strategy_tile_sections.dart
@@ -71,6 +71,11 @@ class StrategyTileViewData {
       for (final agent in page.agentData) {
         result.add(agent.type);
       }
+      // Lineup agents live in lineUpGroups, not agentData, so collect them
+      // too or agents added via the lineup tool never show in previews.
+      for (final group in page.lineUpGroups) {
+        result.add(group.agent.type);
+      }
     }
 
     return [


### PR DESCRIPTION
## Summary
Fixes the bug reported on Discord: agents included in lineups weren't shown in the strategy's agent list, nor in the folder agent list.

Both preview collectors (`StrategyTileViewData._collectAgentTypes` and `FolderCardViewData._collectAgents`) only read `page.agentData`. Agents created through the **Add Lineup** toolbar tool live only inside `page.lineUpGroups`, so they never appeared in previews. (The right-click → Create Lineup path looked fine only because the agent was already placed in `agentData`.)

Now both collectors also gather `group.agent.type` from every lineup group on every page.

## Testing
- `dart analyze` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)