### PR TITLE
Persist library sort and drawing defaults

### DIFF
--- a/lib/const/settings.dart
+++ b/lib/const/settings.dart
@@ -47,11 +47,13 @@ class Settings {
 
   static const Color abilityBGColor = Color(0xFF1B1B1B);
   static const double feedbackOpacity = 0.7;
+  static const double strokeThicknessThin = 2;
   static const double strokeThicknessSmall = 3;
   static const double strokeThicknessMedium = 5;
   static const double strokeThicknessLarge = 8;
   static const double defaultStrokeThickness = strokeThicknessMedium;
   static const List<double> strokeThicknessOptions = [
+    strokeThicknessThin,
     strokeThicknessSmall,
     strokeThicknessMedium,
     strokeThicknessLarge,

--- a/lib/const/shortcut_info.dart
+++ b/lib/const/shortcut_info.dart
@@ -337,7 +337,8 @@ class ShortcutInfo {
   static final Map<ShortcutActivator, Intent> globalShortcuts =
       globalShortcutsFor(const {});
 
-  // New map to disable global shortcuts when typing
+  // Fallback blockers for app shortcuts that native text editing does not own.
+  // TextEditingShortcutScope places DefaultTextEditingShortcuts inside these.
   static Map<ShortcutActivator, Intent> textEditingOverridesFor(
     Map<String, String> customBindings, {
     TargetPlatform? platform,

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -1312,13 +1312,22 @@ class AppPreferencesAdapter extends TypeAdapter<AppPreferences> {
       pagesBarWidth: fields[7] == null ? 224.0 : (fields[7] as num).toDouble(),
       customColorValues: (fields[3] as List?)?.cast<int>(),
       customShortcutBindings: (fields[8] as Map?)?.cast<String, String>(),
+      librarySortByName:
+          fields[12] == null ? 'dateCreated' : fields[12] as String,
+      librarySortOrderName:
+          fields[13] == null ? 'ascending' : fields[13] as String,
+      drawingColorValue:
+          fields[14] == null ? 0xFFFFFFFF : (fields[14] as num).toInt(),
+      drawingThickness: fields[15] == null
+          ? Settings.defaultStrokeThickness
+          : (fields[15] as num).toDouble(),
     );
   }
 
   @override
   void write(BinaryWriter writer, AppPreferences obj) {
     writer
-      ..writeByte(12)
+      ..writeByte(16)
       ..writeByte(0)
       ..write(obj.defaultThemeProfileIdForNewStrategies)
       ..writeByte(1)
@@ -1342,7 +1351,15 @@ class AppPreferencesAdapter extends TypeAdapter<AppPreferences> {
       ..writeByte(10)
       ..write(obj.showUltOrbs)
       ..writeByte(11)
-      ..write(obj.showRegionNames);
+      ..write(obj.showRegionNames)
+      ..writeByte(12)
+      ..write(obj.librarySortByName)
+      ..writeByte(13)
+      ..write(obj.librarySortOrderName)
+      ..writeByte(14)
+      ..write(obj.drawingColorValue)
+      ..writeByte(15)
+      ..write(obj.drawingThickness);
   }
 
   @override

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -441,7 +441,7 @@ types:
         index: 4
   AppPreferences:
     typeId: 28
-    nextIndex: 12
+    nextIndex: 16
     fields:
       defaultThemeProfileIdForNewStrategies:
         index: 0
@@ -467,6 +467,14 @@ types:
         index: 10
       showRegionNames:
         index: 11
+      librarySortByName:
+        index: 12
+      librarySortOrderName:
+        index: 13
+      drawingColorValue:
+        index: 14
+      drawingThickness:
+        index: 15
   PlacedViewConeAgent:
     typeId: 29
     nextIndex: 9

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:toastification/toastification.dart';
 import 'package:window_manager/window_manager.dart';
 
-late CustomMouseCursor staticDrawingCursor;
+CustomMouseCursor? staticDrawingCursor;
 WebViewEnvironment? webViewEnvironment;
 bool isWebViewInitialized = false;
 Future<void> main(List<String> args) async {

--- a/lib/providers/pen_provider.dart
+++ b/lib/providers/pen_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:custom_mouse_cursor/custom_mouse_cursor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +9,7 @@ import 'package:icarus/const/custom_icons.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/traversal_speed.dart';
 import 'package:icarus/main.dart';
+import 'package:icarus/providers/user_preferences_provider.dart';
 
 enum PenMode { line, freeDraw, square, ellipse }
 
@@ -74,14 +77,19 @@ final penProvider = NotifierProvider<PenProvider, PenState>(PenProvider.new);
 class PenProvider extends Notifier<PenState> {
   @override
   PenState build() {
+    final preferences = ref.read(appPreferencesProvider);
     return PenState(
       listOfColors: Settings.penColors,
       penMode: PenMode.freeDraw,
-      color: Colors.white,
+      color: Color(preferences.drawingColorValue),
       hasArrow: false,
       isDotted: false,
       opacity: 1,
-      thickness: Settings.defaultStrokeThickness,
+      thickness: Settings.strokeThicknessOptions.contains(
+        preferences.drawingThickness,
+      )
+          ? preferences.drawingThickness
+          : Settings.defaultStrokeThickness,
       traversalTimeEnabled: false,
       activeTraversalSpeedProfile: TraversalSpeed.defaultProfile,
       drawingCursor: staticDrawingCursor,
@@ -135,6 +143,14 @@ class PenProvider extends Notifier<PenState> {
       traversalTimeEnabled: traversalTimeEnabled,
       activeTraversalSpeedProfile: activeTraversalSpeedProfile,
     );
+    if (color != null || thickness != null) {
+      unawaited(
+        ref.read(appPreferencesProvider.notifier).setDrawingDefaults(
+              colorValue: color?.toARGB32(),
+              thickness: thickness,
+            ),
+      );
+    }
   }
 
   void setColor(int index) async {
@@ -150,6 +166,11 @@ class PenProvider extends Notifier<PenState> {
     }
 
     state = state.copyWith(listOfColors: newColors, color: selectedColor);
+    unawaited(
+      ref
+          .read(appPreferencesProvider.notifier)
+          .setDrawingDefaults(colorValue: selectedColor.toARGB32()),
+    );
     await buildCursors();
   }
 

--- a/lib/providers/strategy_filter_provider.dart
+++ b/lib/providers/strategy_filter_provider.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/providers/user_preferences_provider.dart';
 
 enum SortBy {
   alphabetical,
@@ -50,18 +53,35 @@ class StrategyFilterProvider extends Notifier<StrategyFilterState> {
 
   @override
   StrategyFilterState build() {
+    final preferences = ref.read(appPreferencesProvider);
     return StrategyFilterState(
-      sortBy: SortBy.dateCreated,
-      sortOrder: SortOrder.ascending,
+      sortBy: SortBy.values.firstWhere(
+        (value) => value.name == preferences.librarySortByName,
+        orElse: () => SortBy.dateCreated,
+      ),
+      sortOrder: SortOrder.values.firstWhere(
+        (value) => value.name == preferences.librarySortOrderName,
+        orElse: () => SortOrder.ascending,
+      ),
     );
   }
 
   void setSortBy(SortBy sortBy) {
     state = state.copyWith(sortBy: sortBy);
+    unawaited(
+      ref
+          .read(appPreferencesProvider.notifier)
+          .setLibrarySort(sortByName: sortBy.name),
+    );
   }
 
   void setSortOrder(SortOrder sortOrder) {
     state = state.copyWith(sortOrder: sortOrder);
+    unawaited(
+      ref
+          .read(appPreferencesProvider.notifier)
+          .setLibrarySort(sortOrderName: sortOrder.name),
+    );
   }
 
   ({IconData icon, String label}) getCurrentSortBy() {

--- a/lib/providers/user_preferences_provider.dart
+++ b/lib/providers/user_preferences_provider.dart
@@ -535,179 +535,159 @@ class MapThemeProfilesProvider extends Notifier<MapThemeProfilesState> {
 }
 
 class AppPreferencesNotifier extends Notifier<AppPreferences> {
+  Future<void> _writeQueue = Future<void>.value();
+
   @override
   AppPreferences build() {
     return _readFromHive();
   }
 
   Future<void> refreshFromHive() async {
+    await _writeQueue;
     state = _readFromHive();
   }
 
-  Future<void> setAutosaveEnabled(bool enabled) async {
-    final updated = _readFromHive().copyWith(autosaveEnabled: enabled);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setAutosaveEnabled(bool enabled) {
+    return _updatePreferences(
+      (current) => current.copyWith(autosaveEnabled: enabled),
     );
-    state = updated;
   }
 
-  Future<void> setShowSpawnBarrier(bool visible) async {
-    final updated = _readFromHive().copyWith(showSpawnBarrier: visible);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setShowSpawnBarrier(bool visible) {
+    return _updatePreferences(
+      (current) => current.copyWith(showSpawnBarrier: visible),
     );
-    state = updated;
   }
 
-  Future<void> setShowUltOrbs(bool visible) async {
-    final updated = _readFromHive().copyWith(showUltOrbs: visible);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setShowUltOrbs(bool visible) {
+    return _updatePreferences(
+      (current) => current.copyWith(showUltOrbs: visible),
     );
-    state = updated;
   }
 
-  Future<void> setShowRegionNames(bool visible) async {
-    final updated = _readFromHive().copyWith(showRegionNames: visible);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setShowRegionNames(bool visible) {
+    return _updatePreferences(
+      (current) => current.copyWith(showRegionNames: visible),
     );
-    state = updated;
   }
 
-  Future<void> setDefaultNeutralTeamColorsForNewStrategies(bool enabled) async {
-    final updated = _readFromHive().copyWith(
-      defaultNeutralTeamColorsForNewStrategies: enabled,
+  Future<void> setDefaultNeutralTeamColorsForNewStrategies(bool enabled) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        defaultNeutralTeamColorsForNewStrategies: enabled,
+      ),
     );
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
-    );
-    state = updated;
   }
 
-  Future<void> setDefaultAgentSizeForNewStrategies(double size) async {
-    final updated =
-        _readFromHive().copyWith(defaultAgentSizeForNewStrategies: size);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setDefaultAgentSizeForNewStrategies(double size) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        defaultAgentSizeForNewStrategies: size,
+      ),
     );
-    state = updated;
   }
 
-  Future<void> setDefaultAbilitySizeForNewStrategies(double size) async {
-    final updated =
-        _readFromHive().copyWith(defaultAbilitySizeForNewStrategies: size);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setDefaultAbilitySizeForNewStrategies(double size) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        defaultAbilitySizeForNewStrategies: size,
+      ),
     );
-    state = updated;
   }
 
-  Future<void> setPagesBarExpandedHeight(double height) async {
-    final updated = _readFromHive().copyWith(pagesBarExpandedHeight: height);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setPagesBarExpandedHeight(double height) {
+    return _updatePreferences(
+      (current) => current.copyWith(pagesBarExpandedHeight: height),
     );
-    state = updated;
   }
 
-  Future<void> setPagesBarWidth(double width) async {
-    final updated = _readFromHive().copyWith(pagesBarWidth: width);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> setPagesBarWidth(double width) {
+    return _updatePreferences(
+      (current) => current.copyWith(pagesBarWidth: width),
     );
-    state = updated;
   }
 
-  Future<void> setCustomColorValues(List<int> colorValues) async {
-    final updated = _readFromHive().copyWith(
-      customColorValues: colorValues.take(15).toList(growable: false),
+  Future<void> setCustomColorValues(List<int> colorValues) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        customColorValues: colorValues.take(15).toList(growable: false),
+      ),
     );
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
-    );
-    state = updated;
   }
 
   Future<void> setLibrarySort({
     String? sortByName,
     String? sortOrderName,
-  }) async {
-    final updated = state.copyWith(
-      librarySortByName: sortByName,
-      librarySortOrderName: sortOrderName,
-    );
-    state = updated;
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  }) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        librarySortByName: sortByName,
+        librarySortOrderName: sortOrderName,
+      ),
     );
   }
 
   Future<void> setDrawingDefaults({
     int? colorValue,
     double? thickness,
-  }) async {
-    final updated = state.copyWith(
-      drawingColorValue: colorValue,
-      drawingThickness: thickness,
-    );
-    state = updated;
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  }) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        drawingColorValue: colorValue,
+        drawingThickness: thickness,
+      ),
     );
   }
 
   Future<void> setCustomShortcutBinding(
     String shortcutId,
     String serializedBinding,
-  ) async {
-    final current = _readFromHive();
-    final updatedBindings = {
-      ...current.customShortcutBindings,
-      shortcutId: serializedBinding,
-    };
-    final updated = current.copyWith(customShortcutBindings: updatedBindings);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  ) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        customShortcutBindings: {
+          ...current.customShortcutBindings,
+          shortcutId: serializedBinding,
+        },
+      ),
     );
-    state = updated;
   }
 
-  Future<void> resetCustomShortcutBinding(String shortcutId) async {
-    final current = _readFromHive();
-    final updatedBindings = {...current.customShortcutBindings}
-      ..remove(shortcutId);
-    final updated = current.copyWith(customShortcutBindings: updatedBindings);
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
+  Future<void> resetCustomShortcutBinding(String shortcutId) {
+    return _updatePreferences(
+      (current) => current.copyWith(
+        customShortcutBindings: {...current.customShortcutBindings}
+          ..remove(shortcutId),
+      ),
     );
-    state = updated;
   }
 
-  Future<void> resetAllCustomShortcutBindings() async {
-    final updated = _readFromHive().copyWith(
-      customShortcutBindings: const {},
+  Future<void> resetAllCustomShortcutBindings() {
+    return _updatePreferences(
+      (current) => current.copyWith(customShortcutBindings: const {}),
     );
-    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
-      MapThemeProfilesProvider.appPreferencesSingletonKey,
-      updated,
-    );
+  }
+
+  Future<void> flushPendingWrites() => _writeQueue;
+
+  Future<void> _updatePreferences(
+    AppPreferences Function(AppPreferences current) update,
+  ) {
+    final updated = update(state);
     state = updated;
+
+    final write = _writeQueue.then<void>(
+      (_) => Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
+        MapThemeProfilesProvider.appPreferencesSingletonKey,
+        updated,
+      ),
+    );
+    // Keep later writes moving if this caller observes and handles a failure.
+    _writeQueue = write.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return write;
   }
 
   AppPreferences _readFromHive() {

--- a/lib/providers/user_preferences_provider.dart
+++ b/lib/providers/user_preferences_provider.dart
@@ -122,6 +122,10 @@ class AppPreferences extends HiveObject {
   final double pagesBarWidth;
   final List<int> customColorValues;
   final Map<String, String> customShortcutBindings;
+  final String librarySortByName;
+  final String librarySortOrderName;
+  final int drawingColorValue;
+  final double drawingThickness;
 
   AppPreferences({
     required this.defaultThemeProfileIdForNewStrategies,
@@ -136,6 +140,10 @@ class AppPreferences extends HiveObject {
     this.pagesBarWidth = 224.0,
     List<int>? customColorValues,
     Map<String, String>? customShortcutBindings,
+    this.librarySortByName = 'dateCreated',
+    this.librarySortOrderName = 'ascending',
+    this.drawingColorValue = 0xFFFFFFFF,
+    this.drawingThickness = Settings.defaultStrokeThickness,
   })  : customColorValues = List.unmodifiable(customColorValues ?? const []),
         customShortcutBindings =
             Map.unmodifiable(customShortcutBindings ?? const {});
@@ -153,6 +161,10 @@ class AppPreferences extends HiveObject {
     double? pagesBarWidth,
     List<int>? customColorValues,
     Map<String, String>? customShortcutBindings,
+    String? librarySortByName,
+    String? librarySortOrderName,
+    int? drawingColorValue,
+    double? drawingThickness,
   }) {
     return AppPreferences(
       defaultThemeProfileIdForNewStrategies:
@@ -175,6 +187,10 @@ class AppPreferences extends HiveObject {
       customColorValues: customColorValues ?? this.customColorValues,
       customShortcutBindings:
           customShortcutBindings ?? this.customShortcutBindings,
+      librarySortByName: librarySortByName ?? this.librarySortByName,
+      librarySortOrderName: librarySortOrderName ?? this.librarySortOrderName,
+      drawingColorValue: drawingColorValue ?? this.drawingColorValue,
+      drawingThickness: drawingThickness ?? this.drawingThickness,
     );
   }
 }
@@ -622,6 +638,36 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
       updated,
     );
     state = updated;
+  }
+
+  Future<void> setLibrarySort({
+    String? sortByName,
+    String? sortOrderName,
+  }) async {
+    final updated = state.copyWith(
+      librarySortByName: sortByName,
+      librarySortOrderName: sortOrderName,
+    );
+    state = updated;
+    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
+      MapThemeProfilesProvider.appPreferencesSingletonKey,
+      updated,
+    );
+  }
+
+  Future<void> setDrawingDefaults({
+    int? colorValue,
+    double? thickness,
+  }) async {
+    final updated = state.copyWith(
+      drawingColorValue: colorValue,
+      drawingThickness: thickness,
+    );
+    state = updated;
+    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).put(
+      MapThemeProfilesProvider.appPreferencesSingletonKey,
+      updated,
+    );
   }
 
   Future<void> setCustomShortcutBinding(

--- a/lib/widgets/folder_card.dart
+++ b/lib/widgets/folder_card.dart
@@ -54,7 +54,7 @@ class FolderCardViewData {
   /// Distinct map thumbnail assets, most used first, capped at 2.
   final List<String> mapPeeks;
 
-  /// Agents across all strategies, most frequent first (role breaks ties).
+  /// Agents across all strategies in tactical role order, then frequency.
   final List<AgentType> agentTypes;
 
   static List<String> _collectMapPeeks(List<StrategyData> strategies) {
@@ -97,9 +97,13 @@ class FolderCardViewData {
 
     final ordered = counts.keys.toList()
       ..sort((a, b) {
+        final byRole = roleRank(a).compareTo(roleRank(b));
+        if (byRole != 0) return byRole;
         final byCount = counts[b]!.compareTo(counts[a]!);
         if (byCount != 0) return byCount;
-        return roleRank(a).compareTo(roleRank(b));
+        return AgentData.agents[a]!.name
+            .toLowerCase()
+            .compareTo(AgentData.agents[b]!.name.toLowerCase());
       });
     return ordered;
   }

--- a/lib/widgets/strategy_quick_switcher.dart
+++ b/lib/widgets/strategy_quick_switcher.dart
@@ -10,10 +10,10 @@ import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/shortcut_info.dart';
 import 'package:icarus/providers/agent_filter_provider.dart';
 import 'package:icarus/providers/interaction_state_provider.dart';
-import 'package:icarus/providers/user_preferences_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/services/unsaved_strategy_guard.dart';
 import 'package:icarus/widgets/overflow_tooltip_text.dart';
+import 'package:icarus/widgets/text_editing_shortcut_scope.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 /// Displays the current strategy name with a recent-strategies dropdown.
@@ -367,16 +367,15 @@ class _StrategyQuickSwitcherState extends ConsumerState<StrategyQuickSwitcher> {
                               padding:
                                   const EdgeInsets.symmetric(horizontal: 12),
                               child: Center(
-                                child: Shortcuts(
-                                  shortcuts: <ShortcutActivator, Intent>{
-                                    ...ShortcutInfo.textEditingOverridesFor(
-                                      ref
-                                          .watch(appPreferencesProvider)
-                                          .customShortcutBindings,
-                                    ),
-                                    const SingleActivator(
+                                child: TextEditingShortcutScope(
+                                  extraShortcuts: const <ShortcutActivator,
+                                      Intent>{
+                                    SingleActivator(
+                                      LogicalKeyboardKey.enter,
+                                    ): EnterTextIntent(),
+                                    SingleActivator(
                                       LogicalKeyboardKey.escape,
-                                    ): const DismissIntent(),
+                                    ): DismissIntent(),
                                   },
                                   child: Actions(
                                     actions: <Type, Action<Intent>>{

--- a/lib/widgets/text_editing_shortcut_scope.dart
+++ b/lib/widgets/text_editing_shortcut_scope.dart
@@ -22,14 +22,24 @@ class TextEditingShortcutScope extends ConsumerWidget {
             ? ref.watch(appPreferencesProvider).customShortcutBindings
             : const <String, String>{};
 
+    // Shortcut priority follows widget nesting from the focused field out:
+    // field-specific commands, native text editing, then app shortcut blockers.
+    final textField = DefaultTextEditingShortcuts(
+      child: extraShortcuts.isEmpty
+          ? child
+          : Shortcuts(
+              shortcuts: extraShortcuts,
+              child: child,
+            ),
+    );
+
     return Shortcuts(
       shortcuts: {
         ...ShortcutInfo.textEditingOverridesFor(
           customShortcutBindings,
         ),
-        ...extraShortcuts,
       },
-      child: child,
+      child: textField,
     );
   }
 }

--- a/test/drawing_provider_test.dart
+++ b/test/drawing_provider_test.dart
@@ -52,6 +52,7 @@ void main() {
         lineStart: const Offset(10, 20),
         lineEnd: const Offset(30, 40),
         color: Colors.red,
+        thickness: Settings.strokeThicknessThin,
         boundingBox: BoundingBox(
           min: const Offset(10, 20),
           max: const Offset(30, 40),
@@ -72,6 +73,10 @@ void main() {
       );
       expect(decodedJson.single, containsPair('isDotted', true));
       expect(decodedJson.single, containsPair('hasArrow', true));
+      expect(
+        decodedJson.single,
+        containsPair('thickness', Settings.strokeThicknessThin),
+      );
       expect(decodedJson.single, containsPair('showTraversalTime', true));
       expect(
         decodedJson.single,
@@ -82,6 +87,7 @@ void main() {
       expect(decoded.lineStart, const Offset(10, 20));
       expect(decoded.lineEnd, const Offset(30, 40));
       expect(decoded.colorValue, Colors.red.toARGB32());
+      expect(decoded.thickness, Settings.strokeThicknessThin);
       expect(decoded.boundingBox!.min, const Offset(10, 20));
       expect(decoded.boundingBox!.max, const Offset(30, 40));
       expect(decoded.isDotted, isTrue);

--- a/test/folder_content_visibility_test.dart
+++ b/test/folder_content_visibility_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/providers/folder_provider.dart';
 import 'package:icarus/providers/strategy_filter_provider.dart';
+import 'package:icarus/providers/strategy_page.dart';
 import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/folder_card.dart';
 import 'package:icarus/widgets/folder_content.dart';
 
@@ -258,6 +262,71 @@ void main() {
       'deep',
     ]);
     expect(viewData.strategyCount, 3);
+  });
+
+  test('folder card agents follow tactical role order', () {
+    final previewFolder = folder(
+      id: 'preview',
+      name: 'Preview',
+      dateCreated: DateTime.utc(2026, 1, 1),
+    );
+    final previewStrategy = StrategyData(
+      id: 'preview-strategy',
+      name: 'Preview Strategy',
+      mapData: MapValue.ascent,
+      versionNumber: 1,
+      lastEdited: DateTime.utc(2026, 1, 2),
+      folderID: previewFolder.id,
+      pages: [
+        StrategyPage(
+          id: 'page',
+          name: 'Page',
+          drawingData: const [],
+          agentData: [
+            PlacedAgent(
+              type: AgentType.killjoy,
+              position: Offset.zero,
+              id: 'sentinel',
+            ),
+            PlacedAgent(
+              type: AgentType.omen,
+              position: Offset.zero,
+              id: 'controller',
+            ),
+            PlacedAgent(
+              type: AgentType.sova,
+              position: Offset.zero,
+              id: 'initiator',
+            ),
+            PlacedAgent(
+              type: AgentType.jett,
+              position: Offset.zero,
+              id: 'duelist',
+            ),
+          ],
+          abilityData: const [],
+          textData: const [],
+          imageData: const [],
+          utilityData: const [],
+          sortIndex: 0,
+          isAttack: true,
+          settings: StrategySettings(),
+        ),
+      ],
+    );
+
+    final viewData = FolderCardViewData(
+      folder: previewFolder,
+      strategies: [previewStrategy],
+      folderCount: 0,
+    );
+
+    expect(viewData.agentTypes, [
+      AgentType.jett,
+      AgentType.sova,
+      AgentType.omen,
+      AgentType.killjoy,
+    ]);
   });
 
   test('empty folder last updated falls back to creation date', () {

--- a/test/text_editing_shortcut_scope_test.dart
+++ b/test/text_editing_shortcut_scope_test.dart
@@ -1,9 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/shortcut_info.dart';
 import 'package:icarus/widgets/text_editing_shortcut_scope.dart';
 
 void main() {
+  late String clipboardText;
+
+  setUp(() {
+    clipboardText = '';
+    TestWidgetsFlutterBinding.ensureInitialized()
+        .defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      switch (call.method) {
+        case 'Clipboard.getData':
+          return <String, dynamic>{'text': clipboardText};
+        case 'Clipboard.setData':
+          final arguments = call.arguments as Map<dynamic, dynamic>;
+          clipboardText = arguments['text'] as String? ?? '';
+        case 'Clipboard.hasStrings':
+          return <String, bool>{'value': clipboardText.isNotEmpty};
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestWidgetsFlutterBinding.ensureInitialized()
+        .defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
   testWidgets('renders without an opened app preferences Hive box',
       (tester) async {
     await tester.pumpWidget(
@@ -20,5 +48,117 @@ void main() {
 
     expect(find.byType(TextField), findsOneWidget);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Ctrl+V pastes text instead of invoking the app shortcut',
+      (tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    var pasteImageInvocations = 0;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Shortcuts(
+            shortcuts: const <ShortcutActivator, Intent>{
+              SingleActivator(LogicalKeyboardKey.keyV, control: true):
+                  PasteImageIntent(),
+            },
+            child: Actions(
+              actions: <Type, Action<Intent>>{
+                PasteImageIntent: CallbackAction<PasteImageIntent>(
+                  onInvoke: (_) {
+                    pasteImageInvocations++;
+                    return null;
+                  },
+                ),
+              },
+              child: Scaffold(
+                body: TextEditingShortcutScope(
+                  child: TextField(controller: controller),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    clipboardText = 'https://youtu.be/example';
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(controller.text, 'https://youtu.be/example');
+    expect(pasteImageInvocations, 0);
+  });
+
+  testWidgets('Ctrl+Z uses the text field undo history', (tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: TextEditingShortcutScope(
+              child: TextField(controller: controller, autofocus: true),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.enterText(find.byType(TextField), 'draft text');
+    await tester.pump(const Duration(milliseconds: 500));
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyZ);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(controller.text, isEmpty);
+  });
+
+  testWidgets('field-specific shortcuts take priority over text defaults',
+      (tester) async {
+    var submitInvocations = 0;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: TextEditingShortcutScope(
+              extraShortcuts: const <ShortcutActivator, Intent>{
+                SingleActivator(LogicalKeyboardKey.enter): EnterTextIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  EnterTextIntent: CallbackAction<EnterTextIntent>(
+                    onInvoke: (_) {
+                      submitInvocations++;
+                      return null;
+                    },
+                  ),
+                },
+                child: const TextField(autofocus: true),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(submitInvocations, 1);
   });
 }

--- a/test/tool_preference_persistence_test.dart
+++ b/test/tool_preference_persistence_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:icarus/const/hive_boxes.dart';
+import 'package:icarus/hive/hive_registration.dart';
+import 'package:icarus/providers/pen_provider.dart';
+import 'package:icarus/providers/strategy_filter_provider.dart';
+import 'package:icarus/providers/user_preferences_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('icarus-tool-prefs-');
+    Hive.init(tempDir.path);
+    registerIcarusAdapters(Hive);
+    await Hive.openBox<AppPreferences>(HiveBoxNames.appPreferencesBox);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('library sort and drawing defaults survive a provider restart',
+      () async {
+    var container = ProviderContainer();
+
+    container
+        .read(strategyFilterProvider.notifier)
+        .setSortBy(SortBy.alphabetical);
+    container
+        .read(strategyFilterProvider.notifier)
+        .setSortOrder(SortOrder.descending);
+    container.read(penProvider.notifier).updateValue(
+          color: const Color(0xFF44AA77),
+          thickness: 8,
+        );
+
+    await Future<void>.delayed(Duration.zero);
+    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).flush();
+    container.dispose();
+
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(strategyFilterProvider).sortBy, SortBy.alphabetical);
+    expect(
+        container.read(strategyFilterProvider).sortOrder, SortOrder.descending);
+    expect(container.read(penProvider).color, const Color(0xFF44AA77));
+    expect(container.read(penProvider).thickness, 8);
+  });
+}

--- a/test/tool_preference_persistence_test.dart
+++ b/test/tool_preference_persistence_test.dart
@@ -15,10 +15,13 @@ void main() {
 
   late Directory tempDir;
 
+  setUpAll(() {
+    registerIcarusAdapters(Hive);
+  });
+
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('icarus-tool-prefs-');
     Hive.init(tempDir.path);
-    registerIcarusAdapters(Hive);
     await Hive.openBox<AppPreferences>(HiveBoxNames.appPreferencesBox);
   });
 
@@ -44,7 +47,7 @@ void main() {
           thickness: 8,
         );
 
-    await Future<void>.delayed(Duration.zero);
+    await container.read(appPreferencesProvider.notifier).flushPendingWrites();
     await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).flush();
     container.dispose();
 
@@ -56,5 +59,32 @@ void main() {
         container.read(strategyFilterProvider).sortOrder, SortOrder.descending);
     expect(container.read(penProvider).color, const Color(0xFF44AA77));
     expect(container.read(penProvider).thickness, 8);
+  });
+
+  test('overlapping preference writes preserve every changed field', () async {
+    var container = ProviderContainer();
+    final preferences = container.read(appPreferencesProvider.notifier);
+
+    await Future.wait([
+      preferences.setLibrarySort(sortByName: SortBy.alphabetical.name),
+      preferences.setLibrarySort(sortOrderName: SortOrder.descending.name),
+      preferences.setDrawingDefaults(
+        colorValue: const Color(0xFFAA4477).toARGB32(),
+      ),
+      preferences.setDrawingDefaults(thickness: 3),
+      preferences.setAutosaveEnabled(false),
+    ]);
+    await Hive.box<AppPreferences>(HiveBoxNames.appPreferencesBox).flush();
+    container.dispose();
+
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final restoredPreferences = container.read(appPreferencesProvider);
+    expect(restoredPreferences.librarySortByName, SortBy.alphabetical.name);
+    expect(restoredPreferences.librarySortOrderName, SortOrder.descending.name);
+    expect(restoredPreferences.drawingColorValue, 0xFFAA4477);
+    expect(restoredPreferences.drawingThickness, 3);
+    expect(restoredPreferences.autosaveEnabled, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- Prioritize native text editing shortcuts inside text fields so app-level bindings no longer intercept common editing actions like paste, undo, and enter.
- Persist library sort preferences and drawing defaults in app preferences, then restore them on startup.
- Add support for a thinner pen stroke option and update drawing serialization/persistence accordingly.
- Refine folder card agent ordering to follow tactical role order before frequency.
- Extend coverage with tests for shortcut precedence, preference persistence, drawing serialization, and folder card ordering.

## Testing
- `flutter test test/text_editing_shortcut_scope_test.dart`
- `flutter test test/tool_preference_persistence_test.dart`
- `flutter test test/drawing_provider_test.dart`
- `flutter test test/folder_content_visibility_test.dart`
- Not run: full app integration / manual Windows Flutter smoke test