### PR TITLE
Scale ability widgets around widget anchors

### DIFF
--- a/lib/const/placed_classes.dart
+++ b/lib/const/placed_classes.dart
@@ -8,6 +8,7 @@ import 'package:icarus/const/abilities.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/json_converters.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -897,8 +898,14 @@ class PlacedAbility extends PlacedWidget {
   }
 
   void switchSides({required double mapScale, required double abilitySize}) {
+    // Serialized positions are defined at the historical default marker size.
+    // Side switching must use that same geometry so the result is independent
+    // of whichever runtime size happens to be selected when the switch occurs.
     final fullAbilityWidgetSize =
-        data.abilityData!.getSize(mapScale: mapScale, abilitySize: abilitySize);
+        data.abilityData!.getSize(
+      mapScale: mapScale,
+      abilitySize: Settings.abilitySize,
+    );
     final abilityData = data.abilityData!;
     final shouldRotate = isRotatable(abilityData);
     final shouldUseRotatableFlipCompensation =

--- a/lib/const/placed_classes.dart
+++ b/lib/const/placed_classes.dart
@@ -392,7 +392,10 @@ sealed class PlacedAgentNode extends PlacedWidget {
 
   void switchSides(double agentSize) {
     final coordinateSystem = CoordinateSystem.instance;
-    final agentScreenPx = coordinateSystem.scale(agentSize);
+    // Serialized positions use the historical default marker footprint.
+    // Runtime size changes are render-only, so side switching must not depend
+    // on the size selected when the command runs.
+    final agentScreenPx = coordinateSystem.scale(Settings.agentSize);
     final scaledSize = Offset(agentScreenPx, agentScreenPx);
 
     position = getFlippedPosition(position: position, scaledSize: scaledSize);
@@ -901,8 +904,7 @@ class PlacedAbility extends PlacedWidget {
     // Serialized positions are defined at the historical default marker size.
     // Side switching must use that same geometry so the result is independent
     // of whichever runtime size happens to be selected when the switch occurs.
-    final fullAbilityWidgetSize =
-        data.abilityData!.getSize(
+    final fullAbilityWidgetSize = data.abilityData!.getSize(
       mapScale: mapScale,
       abilitySize: Settings.abilitySize,
     );
@@ -1192,8 +1194,8 @@ class PlacedUtility extends PlacedWidget {
   }) {
     final size = _getEffectiveUtilitySize(
       mapScale: mapScale,
-      agentSize: agentSize,
-      abilitySize: abilitySize,
+      agentSize: Settings.agentSize,
+      abilitySize: Settings.abilitySize,
     );
     final scaledSize = size.scale(CoordinateSystem.instance.scaleFactor,
         CoordinateSystem.instance.scaleFactor);

--- a/lib/const/transition_data.dart
+++ b/lib/const/transition_data.dart
@@ -92,15 +92,34 @@ Offset screenPositionForWidget({
   required CoordinateSystem coordinateSystem,
   Offset? coordinatePosition,
   double? mapScale,
+  double? agentSize,
   double? abilitySize,
 }) {
   final position = coordinatePosition ?? widget.position;
   var screen = coordinateSystem.coordinateToScreen(position);
+  if (widget is PlacedAgentNode && agentSize != null) {
+    screen += agentScreenPositionAdjustment(
+      coordinateSystem: coordinateSystem,
+      agentSize: agentSize,
+    );
+  }
   if (widget is PlacedAbility && mapScale != null && abilitySize != null) {
     screen += abilityScreenPositionAdjustment(
       ability: widget.data.abilityData!,
       coordinateSystem: coordinateSystem,
       mapScale: mapScale,
+      abilitySize: abilitySize,
+    );
+  }
+  if (widget is PlacedUtility &&
+      mapScale != null &&
+      agentSize != null &&
+      abilitySize != null) {
+    screen += utilityScreenPositionAdjustment(
+      utility: widget,
+      coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+      agentSize: agentSize,
       abilitySize: abilitySize,
     );
   }
@@ -110,6 +129,54 @@ Offset screenPositionForWidget({
     return Offset(screen.dx.roundToDouble(), screen.dy.roundToDouble());
   }
   return screen;
+}
+
+/// The stored position of an agent-backed icon is its top-left at the
+/// historical default marker size. Runtime scaling moves that top-left so the
+/// icon center remains fixed without rewriting serialized strategy data.
+Offset get storedAgentAnchor =>
+    const Offset(Settings.agentSize / 2, Settings.agentSize / 2);
+
+Offset agentScreenPositionAdjustment({
+  required CoordinateSystem coordinateSystem,
+  required double agentSize,
+}) {
+  final renderedAnchor = Offset(agentSize / 2, agentSize / 2);
+  return (storedAgentAnchor - renderedAnchor).scale(
+    coordinateSystem.scaleFactor,
+    coordinateSystem.scaleFactor,
+  );
+}
+
+Offset storedAgentPositionForRenderedScreenPosition({
+  required CoordinateSystem coordinateSystem,
+  required Offset renderedScreenPosition,
+  required double agentSize,
+}) {
+  final adjustment = agentScreenPositionAdjustment(
+    coordinateSystem: coordinateSystem,
+    agentSize: agentSize,
+  );
+  return coordinateSystem.screenToCoordinate(
+    renderedScreenPosition - adjustment,
+  );
+}
+
+Offset screenAnchorForAgent({
+  required PlacedAgentNode agent,
+  required CoordinateSystem coordinateSystem,
+  Offset? coordinatePosition,
+}) {
+  return screenPositionForWidget(
+        widget: agent,
+        coordinateSystem: coordinateSystem,
+        coordinatePosition: coordinatePosition,
+        agentSize: Settings.agentSize,
+      ) +
+      storedAgentAnchor.scale(
+        coordinateSystem.scaleFactor,
+        coordinateSystem.scaleFactor,
+      );
 }
 
 /// The stored position of a placed ability is the top-left position it had at
@@ -189,6 +256,80 @@ Offset screenAnchorForAbility({
         coordinateSystem.scaleFactor,
         coordinateSystem.scaleFactor,
       );
+}
+
+Offset utilityAnchorForScale({
+  required PlacedUtility utility,
+  required double mapScale,
+  required double agentSize,
+  required double abilitySize,
+}) {
+  return UtilityData.utilityWidgets[utility.type]!.getAnchorPoint(
+    id: utility.id,
+    length: utility.length,
+    rotation: utility.rotation,
+    mapScale: mapScale,
+    agentSize: agentSize,
+    abilitySize: abilitySize,
+    diameterMeters: utility.customDiameter,
+    widthMeters: utility.customWidth,
+    rectLengthMeters: utility.customLength,
+  );
+}
+
+Offset storedUtilityAnchor({
+  required PlacedUtility utility,
+  required double mapScale,
+}) {
+  return utilityAnchorForScale(
+    utility: utility,
+    mapScale: mapScale,
+    agentSize: Settings.agentSize,
+    abilitySize: Settings.abilitySize,
+  );
+}
+
+Offset utilityScreenPositionAdjustment({
+  required PlacedUtility utility,
+  required CoordinateSystem coordinateSystem,
+  required double mapScale,
+  required double agentSize,
+  required double abilitySize,
+}) {
+  final storedAnchor = storedUtilityAnchor(
+    utility: utility,
+    mapScale: mapScale,
+  );
+  final renderedAnchor = utilityAnchorForScale(
+    utility: utility,
+    mapScale: mapScale,
+    agentSize: agentSize,
+    abilitySize: abilitySize,
+  );
+  return (storedAnchor - renderedAnchor).scale(
+    coordinateSystem.scaleFactor,
+    coordinateSystem.scaleFactor,
+  );
+}
+
+Offset storedUtilityPositionForRenderedScreenPosition({
+  required PlacedUtility utility,
+  required CoordinateSystem coordinateSystem,
+  required Offset renderedScreenPosition,
+  required double mapScale,
+  required double agentSize,
+  required double abilitySize,
+}) {
+  final adjustment = utilityScreenPositionAdjustment(
+    utility: utility,
+    coordinateSystem: coordinateSystem,
+    mapScale: mapScale,
+    agentSize: agentSize,
+    abilitySize: abilitySize,
+  );
+  return coordinateSystem.screenToCoordinate(
+    renderedScreenPosition - adjustment,
+  );
 }
 
 /// One entry describing how a single PlacedWidget should animate.
@@ -280,7 +421,8 @@ class PageTransitionEntry {
 
   double? get startLength => from != null ? lengthOf(from!) : null;
   double? get endLength => to != null ? lengthOf(to!) : null;
-  List<double>? get startArmLengths => from != null ? armLengthsOf(from!) : null;
+  List<double>? get startArmLengths =>
+      from != null ? armLengthsOf(from!) : null;
   List<double>? get endArmLengths => to != null ? armLengthsOf(to!) : null;
 
   double? get startScale => from != null ? scaleOf(from!) : null;

--- a/lib/const/transition_data.dart
+++ b/lib/const/transition_data.dart
@@ -4,6 +4,7 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/abilities.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
 
 enum TransitionKind { move, appear, disappear, none }
@@ -90,15 +91,104 @@ Offset screenPositionForWidget({
   required PlacedWidget widget,
   required CoordinateSystem coordinateSystem,
   Offset? coordinatePosition,
+  double? mapScale,
+  double? abilitySize,
 }) {
   final position = coordinatePosition ?? widget.position;
-  final screen = coordinateSystem.coordinateToScreen(position);
+  var screen = coordinateSystem.coordinateToScreen(position);
+  if (widget is PlacedAbility && mapScale != null && abilitySize != null) {
+    screen += abilityScreenPositionAdjustment(
+      ability: widget.data.abilityData!,
+      coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+      abilitySize: abilitySize,
+    );
+  }
   if (widget is PlacedAbility && widget.data.abilityData is CircleAbility) {
     // Pixel snapping keeps circles from visually drifting between static and
     // overlay renderers due to sub-pixel interpolation differences.
     return Offset(screen.dx.roundToDouble(), screen.dy.roundToDouble());
   }
   return screen;
+}
+
+/// The stored position of a placed ability is the top-left position it had at
+/// the historical default marker size. Keeping that serialized contract means
+/// old and new strategies remain visually identical without a migration.
+Offset storedAbilityAnchor({
+  required Ability ability,
+  required double mapScale,
+}) {
+  return ability.getAnchorPoint(
+    mapScale: mapScale,
+    abilitySize: Settings.abilitySize,
+  );
+}
+
+/// Runtime-only top-left adjustment that keeps [Ability.getAnchorPoint]
+/// visually fixed while a strategy's ability marker size changes.
+Offset abilityScreenPositionAdjustment({
+  required Ability ability,
+  required CoordinateSystem coordinateSystem,
+  required double mapScale,
+  required double abilitySize,
+}) {
+  final storedAnchor = storedAbilityAnchor(
+    ability: ability,
+    mapScale: mapScale,
+  );
+  final renderedAnchor = ability.getAnchorPoint(
+    mapScale: mapScale,
+    abilitySize: abilitySize,
+  );
+  return (storedAnchor - renderedAnchor).scale(
+    coordinateSystem.scaleFactor,
+    coordinateSystem.scaleFactor,
+  );
+}
+
+/// Converts the rendered top-left from a drag/drop back to the stable position
+/// persisted in strategy files.
+Offset storedAbilityPositionForRenderedScreenPosition({
+  required Ability ability,
+  required CoordinateSystem coordinateSystem,
+  required Offset renderedScreenPosition,
+  required double mapScale,
+  required double abilitySize,
+}) {
+  final adjustment = abilityScreenPositionAdjustment(
+    ability: ability,
+    coordinateSystem: coordinateSystem,
+    mapScale: mapScale,
+    abilitySize: abilitySize,
+  );
+  return coordinateSystem.screenToCoordinate(
+    renderedScreenPosition - adjustment,
+  );
+}
+
+/// Screen-space position of the semantic widget anchor. It intentionally does
+/// not depend on the current marker size.
+Offset screenAnchorForAbility({
+  required PlacedAbility ability,
+  required CoordinateSystem coordinateSystem,
+  required double mapScale,
+  Offset? coordinatePosition,
+}) {
+  return screenPositionForWidget(
+        widget: ability,
+        coordinateSystem: coordinateSystem,
+        coordinatePosition: coordinatePosition,
+        mapScale: mapScale,
+        abilitySize: Settings.abilitySize,
+      ) +
+      storedAbilityAnchor(
+        ability: ability.data.abilityData!,
+        mapScale: mapScale,
+      ).scale(
+        coordinateSystem.scaleFactor,
+        coordinateSystem.scaleFactor,
+      );
 }
 
 /// One entry describing how a single PlacedWidget should animate.

--- a/lib/providers/ability_provider.dart
+++ b/lib/providers/ability_provider.dart
@@ -6,9 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
-import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:uuid/uuid.dart';
 
 final abilityProvider =
@@ -77,10 +78,10 @@ class AbilityProvider extends Notifier<List<PlacedAbility>> {
     final mapState = ref.read(mapProvider);
     final mapScale = Maps.mapScale[mapState.currentMap] ?? 1.0;
 
-    final abilitySize = ref.read(strategySettingsProvider).abilitySize;
-
-    final centerOffset = ability.data.abilityData!
-        .getAnchorPoint(mapScale: mapScale, abilitySize: abilitySize);
+    final centerOffset = storedAbilityAnchor(
+      ability: ability.data.abilityData!,
+      mapScale: mapScale,
+    );
 
     final centerPosition =
         Offset(position.dx + centerOffset.dx, position.dy + centerOffset.dy);
@@ -112,9 +113,10 @@ class AbilityProvider extends Notifier<List<PlacedAbility>> {
     final coordinateSystem = CoordinateSystem.instance;
     final mapState = ref.read(mapProvider);
     final mapScale = Maps.mapScale[mapState.currentMap] ?? 1.0;
-    final abilitySize = ref.read(strategySettingsProvider).abilitySize;
-    final centerOffset = sourceAbility.data.abilityData!
-        .getAnchorPoint(mapScale: mapScale, abilitySize: abilitySize);
+    final centerOffset = storedAbilityAnchor(
+      ability: sourceAbility.data.abilityData!,
+      mapScale: mapScale,
+    );
     final centerPosition =
         Offset(position.dx + centerOffset.dx, position.dy + centerOffset.dy);
 
@@ -134,14 +136,18 @@ class AbilityProvider extends Notifier<List<PlacedAbility>> {
     final newState = <PlacedAbility>[...state];
     final mapState = ref.read(mapProvider);
     final mapScale = Maps.mapScale[mapState.currentMap] ?? 1.0;
-    final abilitySizeSetting = ref.read(strategySettingsProvider).abilitySize;
-
     for (final ability in state) {
-      ability.switchSides(mapScale: mapScale, abilitySize: abilitySizeSetting);
+      ability.switchSides(
+        mapScale: mapScale,
+        abilitySize: Settings.abilitySize,
+      );
     }
 
     for (final ability in poppedAbility) {
-      ability.switchSides(mapScale: mapScale, abilitySize: abilitySizeSetting);
+      ability.switchSides(
+        mapScale: mapScale,
+        abilitySize: Settings.abilitySize,
+      );
     }
 
     state = newState;

--- a/lib/providers/action_provider.dart
+++ b/lib/providers/action_provider.dart
@@ -9,6 +9,7 @@ import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/image_provider.dart';
 import 'package:icarus/providers/image_widget_size_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/providers/text_provider.dart';
 import 'package:icarus/providers/text_widget_height_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
@@ -22,6 +23,7 @@ enum ActionGroup {
   image,
   utility,
   lineUp,
+  strategySettings,
   bulk,
 }
 
@@ -56,6 +58,7 @@ class BulkActionSnapshot {
   final PlacedImageProviderSnapshot? imageSnapshot;
   final UtilityProviderSnapshot? utilitySnapshot;
   final LineUpProviderSnapshot? lineUpSnapshot;
+  final StrategySettings? strategySettingsSnapshot;
   final Map<String, Offset> imageSizeSnapshot;
   final Map<String, Offset> textHeightSnapshot;
 
@@ -70,6 +73,7 @@ class BulkActionSnapshot {
     this.imageSnapshot,
     this.utilitySnapshot,
     this.lineUpSnapshot,
+    this.strategySettingsSnapshot,
     this.imageSizeSnapshot = const {},
     this.textHeightSnapshot = const {},
   });
@@ -104,7 +108,7 @@ final actionProvider =
     NotifierProvider<ActionProvider, List<UserAction>>(ActionProvider.new);
 
 class ActionProvider extends Notifier<List<UserAction>> {
-  static const List<ActionGroup> _undoableGroups = [
+  static const List<ActionGroup> _clearableGroups = [
     ActionGroup.agent,
     ActionGroup.ability,
     ActionGroup.drawing,
@@ -112,6 +116,10 @@ class ActionProvider extends Notifier<List<UserAction>> {
     ActionGroup.image,
     ActionGroup.utility,
     ActionGroup.lineUp,
+  ];
+  static const List<ActionGroup> _transactionGroups = [
+    ..._clearableGroups,
+    ActionGroup.strategySettings,
   ];
   static const _uuid = Uuid();
   List<UserAction> poppedItems = [];
@@ -169,6 +177,8 @@ class ActionProvider extends Notifier<List<UserAction>> {
         ref.read(utilityProvider.notifier).redoAction(poppedAction);
       case ActionGroup.lineUp:
         ref.read(lineUpProvider.notifier).redoAction(poppedAction);
+      case ActionGroup.strategySettings:
+        return;
       case ActionGroup.bulk:
         return;
     }
@@ -211,6 +221,8 @@ class ActionProvider extends Notifier<List<UserAction>> {
         ref.read(utilityProvider.notifier).undoAction(currentAction);
       case ActionGroup.lineUp:
         ref.read(lineUpProvider.notifier).undoAction(currentAction);
+      case ActionGroup.strategySettings:
+        return;
       case ActionGroup.bulk:
         return;
     }
@@ -244,11 +256,11 @@ class ActionProvider extends Notifier<List<UserAction>> {
   }
 
   void clearAllAsAction() {
-    _performBulkClear(_undoableGroups);
+    _performBulkClear(_clearableGroups);
   }
 
   void clearGroupAsAction(ActionGroup group) {
-    if (group == ActionGroup.bulk) return;
+    if (!_clearableGroups.contains(group)) return;
     _performBulkClear([group]);
   }
 
@@ -258,7 +270,7 @@ class ActionProvider extends Notifier<List<UserAction>> {
   }) {
     final targetGroups = <ActionGroup>[];
     for (final group in groups) {
-      if (_undoableGroups.contains(group) && !targetGroups.contains(group)) {
+      if (_transactionGroups.contains(group) && !targetGroups.contains(group)) {
         targetGroups.add(group);
       }
     }
@@ -294,7 +306,7 @@ class ActionProvider extends Notifier<List<UserAction>> {
   void _performBulkClear(List<ActionGroup> groups) {
     final targetGroups = <ActionGroup>[];
     for (final group in groups) {
-      if (_undoableGroups.contains(group) && !targetGroups.contains(group)) {
+      if (_clearableGroups.contains(group) && !targetGroups.contains(group)) {
         targetGroups.add(group);
       }
     }
@@ -340,6 +352,8 @@ class ActionProvider extends Notifier<List<UserAction>> {
           if (ref.read(utilityProvider).isNotEmpty) return true;
         case ActionGroup.lineUp:
           if (ref.read(lineUpProvider).lineUps.isNotEmpty) return true;
+        case ActionGroup.strategySettings:
+          break;
         case ActionGroup.bulk:
           break;
       }
@@ -379,6 +393,9 @@ class ActionProvider extends Notifier<List<UserAction>> {
           : null,
       lineUpSnapshot: groups.contains(ActionGroup.lineUp)
           ? ref.read(lineUpProvider.notifier).takeSnapshot()
+          : null,
+      strategySettingsSnapshot: groups.contains(ActionGroup.strategySettings)
+          ? ref.read(strategySettingsProvider)
           : null,
       imageSizeSnapshot: ref
           .read(imageWidgetSizeProvider.notifier)
@@ -434,6 +451,8 @@ class ActionProvider extends Notifier<List<UserAction>> {
           ref.read(utilityProvider.notifier).clearAll();
         case ActionGroup.lineUp:
           ref.read(lineUpProvider.notifier).clearAll();
+        case ActionGroup.strategySettings:
+          break;
         case ActionGroup.bulk:
           break;
       }
@@ -484,6 +503,11 @@ class ActionProvider extends Notifier<List<UserAction>> {
       ref
           .read(lineUpProvider.notifier)
           .restoreSnapshot(snapshot.lineUpSnapshot!);
+    }
+    if (snapshot.strategySettingsSnapshot != null) {
+      ref
+          .read(strategySettingsProvider.notifier)
+          .fromHive(snapshot.strategySettingsSnapshot!);
     }
 
     if (snapshot.imageSizeSnapshot.isNotEmpty) {

--- a/lib/providers/agent_provider.dart
+++ b/lib/providers/agent_provider.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/const/utilities.dart';
@@ -88,10 +89,7 @@ class AgentProvider extends Notifier<List<PlacedAgentNode>> {
 
     final index = PlacedWidget.getIndexByID(id, newState);
 
-    final agentSize = ref.read(strategySettingsProvider).agentSize;
-
-    final centerPosition =
-        Offset(position.dx + agentSize / 2, position.dy + agentSize / 2);
+    final centerPosition = position + storedAgentAnchor;
     final coordinateSystem = CoordinateSystem.instance;
 
     if (coordinateSystem.isOutOfBounds(centerPosition)) {
@@ -114,9 +112,7 @@ class AgentProvider extends Notifier<List<PlacedAgentNode>> {
     required String sourceId,
     required Offset position,
   }) {
-    final agentSize = ref.read(strategySettingsProvider).agentSize;
-    final centerPosition =
-        Offset(position.dx + agentSize / 2, position.dy + agentSize / 2);
+    final centerPosition = position + storedAgentAnchor;
     final coordinateSystem = CoordinateSystem.instance;
     if (coordinateSystem.isOutOfBounds(centerPosition)) return null;
 

--- a/lib/widgets/current_line_up_painter.dart
+++ b/lib/widgets/current_line_up_painter.dart
@@ -21,7 +21,8 @@ class CurrentLineUpPainter extends ConsumerWidget {
     final double abilitySize = ref.watch(strategySettingsProvider).abilitySize;
     final double agentSize =
         coordinateSystem.scale(ref.watch(strategySettingsProvider).agentSize);
-    final currentMap = ref.watch(mapProvider.select((state) => state.currentMap));
+    final currentMap =
+        ref.watch(mapProvider.select((state) => state.currentMap));
     final double mapScale = Maps.mapScale[currentMap] ?? 1.0;
     final lineUpState = ref.watch(lineUpProvider);
     final PlacedAgent? currentAgent = lineUpState.currentAgent ??
@@ -77,9 +78,10 @@ class _CurrentLinePainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..isAntiAlias = true;
 
-    final startPosition =
-        coordinateSystem.coordinateToScreen(currentAgent!.position) +
-            Offset((agentSize / 2), (agentSize / 2));
+    final startPosition = screenAnchorForAgent(
+      agent: currentAgent!,
+      coordinateSystem: coordinateSystem,
+    );
 
     final endPosition = screenAnchorForAbility(
       ability: currentAbility!,

--- a/lib/widgets/current_line_up_painter.dart
+++ b/lib/widgets/current_line_up_painter.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/line_up_line_painter.dart';
@@ -80,11 +81,11 @@ class _CurrentLinePainter extends CustomPainter {
         coordinateSystem.coordinateToScreen(currentAgent!.position) +
             Offset((agentSize / 2), (agentSize / 2));
 
-    final endPosition = coordinateSystem
-            .coordinateToScreen(currentAbility!.position) +
-        currentAbility!.data.abilityData!
-            .getAnchorPoint(mapScale: mapScale, abilitySize: abilitySize)
-            .scale(coordinateSystem.scaleFactor, coordinateSystem.scaleFactor);
+    final endPosition = screenAnchorForAbility(
+      ability: currentAbility!,
+      coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+    );
 
     canvas.drawLine(startPosition, endPosition, highlightPaint);
   }

--- a/lib/widgets/draggable_widgets/ability/placed_ability_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/placed_ability_widget.dart
@@ -194,6 +194,8 @@ class _PlacedAbilityWidgetState extends ConsumerState<PlacedAbilityWidget> {
       final screenPosition = screenPositionForWidget(
         widget: widget.ability,
         coordinateSystem: coordinateSystem,
+        mapScale: mapScale,
+        abilitySize: abilitySize,
       );
       final isCenterSquare = abilityData is CenterSquareAbility;
       final isResizableSquare = abilityData is ResizableSquareAbility;
@@ -384,6 +386,8 @@ class _PlacedAbilityWidgetState extends ConsumerState<PlacedAbilityWidget> {
     final screenPosition = screenPositionForWidget(
       widget: widget.ability,
       coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+      abilitySize: abilitySize,
     );
     return Positioned(
       left: screenPosition.dx,

--- a/lib/widgets/draggable_widgets/ability/placed_deadlock_barrier_mesh_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/placed_deadlock_barrier_mesh_widget.dart
@@ -137,6 +137,8 @@ class _PlacedDeadlockBarrierMeshWidgetState
     final screenPosition = screenPositionForWidget(
       widget: abilityRef,
       coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+      abilitySize: abilitySize,
     );
     final feedbackRotationOrigin = center.scale(
       ref.watch(screenZoomProvider),

--- a/lib/widgets/draggable_widgets/agents/placed_circle_agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/placed_circle_agent_widget.dart
@@ -7,6 +7,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/agent_provider.dart';
 import 'package:icarus/providers/duplicate_drag_modifier_provider.dart';
@@ -186,6 +187,11 @@ class _PlacedCircleAgentWidgetState
       agentSize: agentSize,
       mapScale: mapScale,
     );
+    final agentScreenPosition = screenPositionForWidget(
+      widget: current,
+      coordinateSystem: coordinateSystem,
+      agentSize: agentSize,
+    );
     final arcRegionSize = coordinateSystem.scale(32);
     final handleCenter = _computeHandleCenter(
       coordinateSystem: coordinateSystem,
@@ -204,10 +210,8 @@ class _PlacedCircleAgentWidgetState
     );
 
     return Positioned(
-      left: coordinateSystem.coordinateToScreen(current.position).dx -
-          compositeAgentOffset.dx,
-      top: coordinateSystem.coordinateToScreen(current.position).dy -
-          compositeAgentOffset.dy,
+      left: agentScreenPosition.dx - compositeAgentOffset.dx,
+      top: agentScreenPosition.dy - compositeAgentOffset.dy,
       child: SizedBox(
         width: scaledMaxDiameter + rightOverflow,
         height: scaledMaxDiameter + bottomOverflow,
@@ -229,8 +233,7 @@ class _PlacedCircleAgentWidgetState
               ),
               childWhenDragging: const SizedBox.shrink(),
               onDragStarted: () {
-                final shouldDuplicate =
-                    ref.read(duplicateDragModifierProvider);
+                final shouldDuplicate = ref.read(duplicateDragModifierProvider);
                 final duplicateId = shouldDuplicate
                     ? ref.read(agentProvider.notifier).duplicateAgentAt(
                           sourceId: current.id,

--- a/lib/widgets/draggable_widgets/agents/placed_lineup_agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/placed_lineup_agent_widget.dart
@@ -4,8 +4,10 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/canvas_resize_provider.dart';
 import 'package:icarus/providers/screen_zoom_provider.dart';
+import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/agents/agent_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
 
@@ -25,7 +27,12 @@ class PlacedLineupAgentWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(canvasResizeProvider);
     final coordinateSystem = CoordinateSystem.instance;
-    final screenPosition = coordinateSystem.coordinateToScreen(agent.position);
+    final agentSize = ref.watch(strategySettingsProvider).agentSize;
+    final screenPosition = screenPositionForWidget(
+      widget: agent,
+      coordinateSystem: coordinateSystem,
+      agentSize: agentSize,
+    );
 
     return Positioned(
       left: screenPosition.dx,

--- a/lib/widgets/draggable_widgets/agents/placed_view_cone_agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/placed_view_cone_agent_widget.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/agent_provider.dart';
 import 'package:icarus/providers/duplicate_drag_modifier_provider.dart';
@@ -188,6 +189,11 @@ class _PlacedViewConeAgentWidgetState
       coordinateSystem: coordinateSystem,
       agentSize: agentSize,
     );
+    final agentScreenPosition = screenPositionForWidget(
+      widget: current,
+      coordinateSystem: coordinateSystem,
+      agentSize: agentSize,
+    );
 
     if (!_isDragging && _rotationOrigin == Offset.zero) {
       if (_localRotation != current.rotation) {
@@ -202,10 +208,8 @@ class _PlacedViewConeAgentWidgetState
     final localLength = _localLength ?? current.length;
 
     return Positioned(
-      left: coordinateSystem.coordinateToScreen(current.position).dx -
-          compositeAgentOffset.dx,
-      top: coordinateSystem.coordinateToScreen(current.position).dy -
-          compositeAgentOffset.dy,
+      left: agentScreenPosition.dx - compositeAgentOffset.dx,
+      top: agentScreenPosition.dy - compositeAgentOffset.dy,
       child: RotatableWidget(
         rotation: localRotation,
         isDragging: _isDragging,

--- a/lib/widgets/draggable_widgets/placed_widget_builder.dart
+++ b/lib/widgets/draggable_widgets/placed_widget_builder.dart
@@ -184,10 +184,18 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
                   .updateData(AgentData.agents[placedAgent.type]!);
             } else if (details.data is DraggedAbilityData) {
               final abilityData = details.data as DraggedAbilityData;
+              final abilityPosition =
+                  storedAbilityPositionForRenderedScreenPosition(
+                ability: abilityData.ability.abilityData!,
+                coordinateSystem: coordinateSystem,
+                renderedScreenPosition: localOffset,
+                mapScale: mapScale,
+                abilitySize: abilitySize,
+              );
               PlacedAbility placedAbility = PlacedAbility(
                 id: uuid.v4(),
                 data: abilityData.ability,
-                position: normalizedPosition,
+                position: abilityPosition,
                 isAlly: abilityData.isAlly,
               );
 
@@ -201,10 +209,19 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
 
               ref.read(abilityProvider.notifier).addAbility(placedAbility);
             } else if (details.data is AbilityInfo) {
+              final abilityInfo = details.data as AbilityInfo;
+              final abilityPosition =
+                  storedAbilityPositionForRenderedScreenPosition(
+                ability: abilityInfo.abilityData!,
+                coordinateSystem: coordinateSystem,
+                renderedScreenPosition: localOffset,
+                mapScale: mapScale,
+                abilitySize: abilitySize,
+              );
               PlacedAbility placedAbility = PlacedAbility(
                 id: uuid.v4(),
-                data: details.data as AbilityInfo,
-                position: normalizedPosition,
+                data: abilityInfo,
+                position: abilityPosition,
                 isAlly: ref.read(teamProvider),
               );
 
@@ -391,9 +408,17 @@ class _AbilityList extends ConsumerWidget {
               final renderBox = context.findRenderObject() as RenderBox;
               final localOffset = renderBox.globalToLocal(details.offset);
               final virtualOffset =
-                  coordinateSystem.screenToCoordinate(localOffset);
-              final safeArea = ability.data.abilityData!
-                  .getAnchorPoint(mapScale: mapScale, abilitySize: abilitySize);
+                  storedAbilityPositionForRenderedScreenPosition(
+                ability: ability.data.abilityData!,
+                coordinateSystem: coordinateSystem,
+                renderedScreenPosition: localOffset,
+                mapScale: mapScale,
+                abilitySize: abilitySize,
+              );
+              final safeArea = storedAbilityAnchor(
+                ability: ability.data.abilityData!,
+                mapScale: mapScale,
+              );
 
               if (coordinateSystem.isOutOfBounds(
                   virtualOffset.translate(safeArea.dx, safeArea.dy))) {

--- a/lib/widgets/draggable_widgets/placed_widget_builder.dart
+++ b/lib/widgets/draggable_widgets/placed_widget_builder.dart
@@ -103,9 +103,10 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
     final coordinateSystem = CoordinateSystem.instance;
     final mapScale = Maps.mapScale[ref.watch(mapProvider).currentMap] ?? 1.0;
 
-    final agentSize =
-        coordinateSystem.scale(ref.watch(strategySettingsProvider).agentSize);
-    final abilitySize = ref.watch(strategySettingsProvider).abilitySize;
+    final strategySettings = ref.watch(strategySettingsProvider);
+    final agentSize = strategySettings.agentSize;
+    final scaledAgentSize = coordinateSystem.scale(agentSize);
+    final abilitySize = strategySettings.abilitySize;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -137,14 +138,17 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
                       mapScale: mapScale,
                       abilitySize: abilitySize,
                     ),
-                    _AgentList(coordinateSystem: coordinateSystem),
-                    _TextList(
+                    _AgentList(
                       coordinateSystem: coordinateSystem,
                       agentSize: agentSize,
                     ),
+                    _TextList(
+                      coordinateSystem: coordinateSystem,
+                      agentSize: scaledAgentSize,
+                    ),
                     _PlacedImageList(
                       coordinateSystem: coordinateSystem,
-                      agentSize: agentSize,
+                      agentSize: scaledAgentSize,
                     ),
                     _UtilityList(
                       coordinateSystem: coordinateSystem,
@@ -166,10 +170,16 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
             const uuid = Uuid();
 
             if (details.data is AgentData) {
+              final agentPosition =
+                  storedAgentPositionForRenderedScreenPosition(
+                coordinateSystem: coordinateSystem,
+                renderedScreenPosition: localOffset,
+                agentSize: agentSize,
+              );
               PlacedAgent placedAgent = PlacedAgent(
                 id: uuid.v4(),
                 type: (details.data as AgentData).type,
-                position: normalizedPosition,
+                position: agentPosition,
                 isAlly: ref.read(teamProvider),
               );
 
@@ -262,13 +272,23 @@ class _PlacedWidgetBuilderState extends ConsumerState<PlacedWidgetBuilder> {
               ref.read(utilityProvider.notifier).addUtility(placedUtility);
             } else if (details.data is RoleIconToolData) {
               final roleIconData = details.data as RoleIconToolData;
+              final placedUtility = PlacedUtility(
+                id: uuid.v4(),
+                type: roleIconData.type,
+                position: Offset.zero,
+                isAlly: ref.read(teamProvider),
+              );
+              placedUtility.position =
+                  storedUtilityPositionForRenderedScreenPosition(
+                utility: placedUtility,
+                coordinateSystem: coordinateSystem,
+                renderedScreenPosition: localOffset,
+                mapScale: mapScale,
+                agentSize: agentSize,
+                abilitySize: abilitySize,
+              );
               ref.read(utilityProvider.notifier).addUtility(
-                    PlacedUtility(
-                      id: uuid.v4(),
-                      type: roleIconData.type,
-                      position: normalizedPosition,
-                      isAlly: ref.read(teamProvider),
-                    ),
+                    placedUtility,
                   );
             } else if (details.data is CustomShapeToolData) {
               final customData = details.data as CustomShapeToolData;
@@ -439,9 +459,13 @@ class _AbilityList extends ConsumerWidget {
 }
 
 class _AgentList extends ConsumerStatefulWidget {
-  const _AgentList({required this.coordinateSystem});
+  const _AgentList({
+    required this.coordinateSystem,
+    required this.agentSize,
+  });
 
   final CoordinateSystem coordinateSystem;
+  final double agentSize;
 
   @override
   ConsumerState<_AgentList> createState() => _AgentListState();
@@ -463,12 +487,16 @@ class _AgentListState extends ConsumerState<_AgentList> {
           switch (agent) {
             PlacedAgent() => Positioned(
                 key: ValueKey(agent.id),
-                left: widget.coordinateSystem
-                    .coordinateToScreen(agent.position)
-                    .dx,
-                top: widget.coordinateSystem
-                    .coordinateToScreen(agent.position)
-                    .dy,
+                left: screenPositionForWidget(
+                  widget: agent,
+                  coordinateSystem: widget.coordinateSystem,
+                  agentSize: widget.agentSize,
+                ).dx,
+                top: screenPositionForWidget(
+                  widget: agent,
+                  coordinateSystem: widget.coordinateSystem,
+                  agentSize: widget.agentSize,
+                ).dy,
                 child: Draggable<PlacedWidget>(
                   data: agent,
                   dragAnchorStrategy: zoomDragAnchorStrategy,
@@ -502,7 +530,11 @@ class _AgentListState extends ConsumerState<_AgentList> {
                     final renderBox = context.findRenderObject() as RenderBox;
                     final localOffset = renderBox.globalToLocal(details.offset);
                     final virtualOffset =
-                        widget.coordinateSystem.screenToCoordinate(localOffset);
+                        storedAgentPositionForRenderedScreenPosition(
+                      coordinateSystem: widget.coordinateSystem,
+                      renderedScreenPosition: localOffset,
+                      agentSize: widget.agentSize,
+                    );
 
                     final duplicateId =
                         _pendingDuplicateDragBySource.remove(agent.id);
@@ -543,7 +575,11 @@ class _AgentListState extends ConsumerState<_AgentList> {
                         compositeOffset.scale(screenZoom, screenZoom),
                   );
                   final virtualOffset =
-                      widget.coordinateSystem.screenToCoordinate(localOffset);
+                      storedAgentPositionForRenderedScreenPosition(
+                    coordinateSystem: widget.coordinateSystem,
+                    renderedScreenPosition: localOffset,
+                    agentSize: agentSize,
+                  );
                   ref
                       .read(agentProvider.notifier)
                       .updatePosition(virtualOffset, draggedId);
@@ -569,7 +605,11 @@ class _AgentListState extends ConsumerState<_AgentList> {
                         compositeOffset.scale(screenZoom, screenZoom),
                   );
                   final virtualOffset =
-                      widget.coordinateSystem.screenToCoordinate(localOffset);
+                      storedAgentPositionForRenderedScreenPosition(
+                    coordinateSystem: widget.coordinateSystem,
+                    renderedScreenPosition: localOffset,
+                    agentSize: agentSize,
+                  );
                   ref
                       .read(agentProvider.notifier)
                       .updatePosition(virtualOffset, draggedId);
@@ -762,9 +802,20 @@ class _UtilityList extends ConsumerWidget {
         for (final placedUtility in utilities)
           Positioned(
             key: ValueKey(placedUtility.id),
-            left:
-                coordinateSystem.coordinateToScreen(placedUtility.position).dx,
-            top: coordinateSystem.coordinateToScreen(placedUtility.position).dy,
+            left: screenPositionForWidget(
+              widget: placedUtility,
+              coordinateSystem: coordinateSystem,
+              mapScale: mapScale,
+              agentSize: agentSize,
+              abilitySize: abilitySize,
+            ).dx,
+            top: screenPositionForWidget(
+              widget: placedUtility,
+              coordinateSystem: coordinateSystem,
+              mapScale: mapScale,
+              agentSize: agentSize,
+              abilitySize: abilitySize,
+            ).dy,
             child: UtilityWidgetBuilder(
               rotation: placedUtility.rotation,
               length: placedUtility.length,
@@ -774,15 +825,19 @@ class _UtilityList extends ConsumerWidget {
                 final renderBox = context.findRenderObject() as RenderBox;
                 final localOffset = renderBox.globalToLocal(details.offset);
                 final virtualOffset =
-                    coordinateSystem.screenToCoordinate(localOffset);
+                    storedUtilityPositionForRenderedScreenPosition(
+                  utility: placedUtility,
+                  coordinateSystem: coordinateSystem,
+                  renderedScreenPosition: localOffset,
+                  mapScale: mapScale,
+                  agentSize: agentSize,
+                  abilitySize: abilitySize,
+                );
 
-                final safeArea = UtilityData.utilityWidgets[placedUtility.type]!
-                        .getAnchorPoint(
-                      mapScale: mapScale,
-                      agentSize: agentSize,
-                      abilitySize: abilitySize,
-                    ) /
-                    2;
+                final safeArea = storedUtilityAnchor(
+                  utility: placedUtility,
+                  mapScale: mapScale,
+                );
 
                 if (coordinateSystem.isOutOfBounds(
                     virtualOffset.translate(safeArea.dx, safeArea.dy))) {

--- a/lib/widgets/line_up_line_painter.dart
+++ b/lib/widgets/line_up_line_painter.dart
@@ -119,9 +119,10 @@ class LinePainter extends CustomPainter {
 
     // Current lineup highlight moved to CurrentLineUpPainter.
     for (final group in groups) {
-      final startPosition =
-          coordinateSystem.coordinateToScreen(group.agent.position) +
-              Offset((agentSize / 2), (agentSize / 2));
+      final startPosition = screenAnchorForAgent(
+        agent: group.agent,
+        coordinateSystem: coordinateSystem,
+      );
 
       for (final item in group.items) {
         final endPosition = screenAnchorForAbility(

--- a/lib/widgets/line_up_line_painter.dart
+++ b/lib/widgets/line_up_line_painter.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 
@@ -123,17 +124,11 @@ class LinePainter extends CustomPainter {
               Offset((agentSize / 2), (agentSize / 2));
 
       for (final item in group.items) {
-        final endPosition =
-            coordinateSystem.coordinateToScreen(item.ability.position) +
-                item.ability.data.abilityData!
-                    .getAnchorPoint(
-                      mapScale: mapScale,
-                      abilitySize: abilitySize,
-                    )
-                    .scale(
-                      coordinateSystem.scaleFactor,
-                      coordinateSystem.scaleFactor,
-                    );
+        final endPosition = screenAnchorForAbility(
+          ability: item.ability,
+          coordinateSystem: coordinateSystem,
+          mapScale: mapScale,
+        );
 
         canvas.drawLine(
           startPosition,

--- a/lib/widgets/line_up_placer.dart
+++ b/lib/widgets/line_up_placer.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/ability_bar_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
@@ -87,11 +88,20 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
                     final abilitySize =
                         ref.read(strategySettingsProvider).abilitySize;
 
-                    Offset virtualOffset =
-                        coordinateSystem.screenToCoordinate(localOffset);
-                    Offset safeArea = lineUp.currentAbility!.data.abilityData!
-                        .getAnchorPoint(
-                            mapScale: mapScale, abilitySize: abilitySize);
+                    final abilityData =
+                        lineUp.currentAbility!.data.abilityData!;
+                    final virtualOffset =
+                        storedAbilityPositionForRenderedScreenPosition(
+                      ability: abilityData,
+                      coordinateSystem: coordinateSystem,
+                      renderedScreenPosition: localOffset,
+                      mapScale: mapScale,
+                      abilitySize: abilitySize,
+                    );
+                    final safeArea = storedAbilityAnchor(
+                      ability: abilityData,
+                      mapScale: mapScale,
+                    );
 
                     if (coordinateSystem.isOutOfBounds(
                         virtualOffset.translate(safeArea.dx, safeArea.dy))) {
@@ -101,8 +111,7 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
 
                     ref
                         .read(lineUpProvider.notifier)
-                        .updateCurrentAbilityPosition(
-                            coordinateSystem.screenToCoordinate(localOffset));
+                        .updateCurrentAbilityPosition(virtualOffset);
                   },
                 ),
               if (previewAgent != null && isLockedAddItemMode)
@@ -160,10 +169,19 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
                 .read(abilityBarProvider.notifier)
                 .updateData(AgentData.agents[placedAgent.type]!);
           } else if (details.data is AbilityInfo) {
+            final abilityInfo = details.data as AbilityInfo;
+            final abilityPosition =
+                storedAbilityPositionForRenderedScreenPosition(
+              ability: abilityInfo.abilityData!,
+              coordinateSystem: coordinateSystem,
+              renderedScreenPosition: localOffset,
+              mapScale: Maps.mapScale[ref.read(mapProvider).currentMap] ?? 1.0,
+              abilitySize: ref.read(strategySettingsProvider).abilitySize,
+            );
             PlacedAbility placedAbility = PlacedAbility(
               id: uuid.v4(),
-              data: details.data as AbilityInfo,
-              position: normalizedPosition,
+              data: abilityInfo,
+              position: abilityPosition,
               isAlly: ref.read(teamProvider),
             );
 

--- a/lib/widgets/line_up_placer.dart
+++ b/lib/widgets/line_up_placer.dart
@@ -130,7 +130,11 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
                         renderBox.globalToLocal(details.offset);
 
                     final virtualOffset =
-                        coordinateSystem.screenToCoordinate(localOffset);
+                        storedAgentPositionForRenderedScreenPosition(
+                      coordinateSystem: coordinateSystem,
+                      renderedScreenPosition: localOffset,
+                      agentSize: ref.read(strategySettingsProvider).agentSize,
+                    );
 
                     ref
                         .read(lineUpProvider.notifier)
@@ -143,8 +147,6 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
         onAcceptWithDetails: (details) {
           RenderBox renderBox = context.findRenderObject() as RenderBox;
           Offset localOffset = renderBox.globalToLocal(details.offset);
-          Offset normalizedPosition =
-              coordinateSystem.screenToCoordinate(localOffset);
           const uuid = Uuid();
 
           if (details.data is AgentData) {
@@ -157,10 +159,15 @@ class _LineupPositionWidgetState extends ConsumerState<LineupPositionWidget> {
               return;
             }
 
+            final agentPosition = storedAgentPositionForRenderedScreenPosition(
+              coordinateSystem: coordinateSystem,
+              renderedScreenPosition: localOffset,
+              agentSize: ref.read(strategySettingsProvider).agentSize,
+            );
             PlacedAgent placedAgent = PlacedAgent(
               id: uuid.v4(),
               type: (details.data as AgentData).type,
-              position: normalizedPosition,
+              position: agentPosition,
               isAlly: ref.read(teamProvider),
             );
 

--- a/lib/widgets/line_up_widget.dart
+++ b/lib/widgets/line_up_widget.dart
@@ -4,6 +4,7 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/ability_visibility_context_menu.dart';
@@ -54,10 +55,14 @@ class LineUpItemAbilityWidget extends ConsumerWidget {
     final currentMap =
         ref.watch(mapProvider.select((state) => state.currentMap));
     final mapScale = Maps.mapScale[currentMap] ?? 1.0;
-    final abilityScreen =
-        coordinateSystem.coordinateToScreen(item.ability.position);
     final isRotatable = item.ability.rotation != 0;
     final abilitySize = ref.watch(strategySettingsProvider).abilitySize;
+    final abilityScreen = screenPositionForWidget(
+      widget: item.ability,
+      coordinateSystem: coordinateSystem,
+      mapScale: mapScale,
+      abilitySize: abilitySize,
+    );
     final contextMenuItems = buildAbilityContextMenuItems(
       ref,
       item.ability,

--- a/lib/widgets/line_up_widget.dart
+++ b/lib/widgets/line_up_widget.dart
@@ -21,7 +21,12 @@ class LineUpGroupAgentWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final coordinateSystem = CoordinateSystem.instance;
-    final agentScreen = coordinateSystem.coordinateToScreen(group.agent.position);
+    final agentSize = ref.watch(strategySettingsProvider).agentSize;
+    final agentScreen = screenPositionForWidget(
+      widget: group.agent,
+      coordinateSystem: coordinateSystem,
+      agentSize: agentSize,
+    );
 
     return Positioned(
       key: ValueKey('lineup-agent-${group.id}'),

--- a/lib/widgets/page_transition_overlay.dart
+++ b/lib/widgets/page_transition_overlay.dart
@@ -23,12 +23,15 @@ Offset _overlayScreenPosition({
   required CoordinateSystem coordinateSystem,
   required double agentSize,
   required double mapScale,
+  required double abilitySize,
   Offset? coordinatePosition,
 }) {
   final screen = screenPositionForWidget(
     widget: widget,
     coordinateSystem: coordinateSystem,
     coordinatePosition: coordinatePosition,
+    mapScale: mapScale,
+    abilitySize: abilitySize,
   );
   if (widget is PlacedViewConeAgent) {
     return screen -
@@ -115,7 +118,7 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
   }
 
   Offset _startScreenPosition(PageTransitionEntry entry,
-      CoordinateSystem coordinateSystem, double agentSize) {
+      CoordinateSystem coordinateSystem, double agentSize, double abilitySize) {
     final mapScale = Maps.mapScale[ref.read(mapProvider).currentMap] ?? 1.0;
     return _overlayScreenPosition(
       widget: entry.from ?? entry.to!,
@@ -123,11 +126,12 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
       coordinatePosition: entry.startPos,
       agentSize: agentSize,
       mapScale: mapScale,
+      abilitySize: abilitySize,
     );
   }
 
   Offset _endScreenPosition(PageTransitionEntry entry,
-      CoordinateSystem coordinateSystem, double agentSize) {
+      CoordinateSystem coordinateSystem, double agentSize, double abilitySize) {
     final mapScale = Maps.mapScale[ref.read(mapProvider).currentMap] ?? 1.0;
     return _overlayScreenPosition(
       widget: entry.to ?? entry.from!,
@@ -135,6 +139,7 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
       coordinatePosition: entry.endPos,
       agentSize: agentSize,
       mapScale: mapScale,
+      abilitySize: abilitySize,
     );
   }
 
@@ -153,7 +158,12 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
         return _overlayItem(
           key: ValueKey('none_${entry.id}'),
           widget: entry.to!,
-          pos: _endScreenPosition(entry, coordinateSystem, agentSize),
+          pos: _endScreenPosition(
+            entry,
+            coordinateSystem,
+            agentSize,
+            abilitySize,
+          ),
           opacity: 1,
           length: entry.endLength,
           armLengthsMeters: entry.endArmLengths,
@@ -172,6 +182,7 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
           entry,
           coordinateSystem,
           agentSize,
+          abilitySize,
         ).translate(
           -directionSign * directionalOffset * t,
           0,
@@ -194,8 +205,18 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
           abilitySize: abilitySize,
         );
       case TransitionKind.move:
-        final start = _startScreenPosition(entry, coordinateSystem, agentSize);
-        final end = _endScreenPosition(entry, coordinateSystem, agentSize);
+        final start = _startScreenPosition(
+          entry,
+          coordinateSystem,
+          agentSize,
+          abilitySize,
+        );
+        final end = _endScreenPosition(
+          entry,
+          coordinateSystem,
+          agentSize,
+          abilitySize,
+        );
         return _overlayItem(
           key: ValueKey('move_${entry.id}'),
           widget: entry.to!,
@@ -231,6 +252,7 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
           entry,
           coordinateSystem,
           agentSize,
+          abilitySize,
         ).translate(
           directionSign * directionalOffset * (1 - t),
           0,
@@ -616,6 +638,7 @@ class TemporaryWidgetBuilder extends ConsumerWidget {
       coordinateSystem: coord,
       agentSize: agentSize,
       mapScale: mapScale,
+      abilitySize: abilitySize,
     );
 
     if (widget is PlacedUtility && widget.rotation != 0) {

--- a/lib/widgets/page_transition_overlay.dart
+++ b/lib/widgets/page_transition_overlay.dart
@@ -31,6 +31,7 @@ Offset _overlayScreenPosition({
     coordinateSystem: coordinateSystem,
     coordinatePosition: coordinatePosition,
     mapScale: mapScale,
+    agentSize: agentSize,
     abilitySize: abilitySize,
   );
   if (widget is PlacedViewConeAgent) {
@@ -415,10 +416,13 @@ class _PageTransitionOverlayState extends ConsumerState<PageTransitionOverlay>
         child = Transform.rotate(
           angle: angle,
           alignment: Alignment.topLeft,
-          origin: UtilityData.utilityWidgets[widget.type]!
-              .getAnchorPoint()
-              .scale(CoordinateSystem.instance.scaleFactor,
-                  CoordinateSystem.instance.scaleFactor),
+          origin: utilityAnchorForScale(
+            utility: widget,
+            mapScale: mapScale,
+            agentSize: agentSize,
+            abilitySize: abilitySize,
+          ).scale(CoordinateSystem.instance.scaleFactor,
+              CoordinateSystem.instance.scaleFactor),
           child: child,
         );
       }
@@ -648,10 +652,13 @@ class TemporaryWidgetBuilder extends ConsumerWidget {
           child: Transform.rotate(
             angle: widget.rotation,
             alignment: Alignment.topLeft,
-            origin: UtilityData.utilityWidgets[widget.type]!
-                .getAnchorPoint()
-                .scale(CoordinateSystem.instance.scaleFactor,
-                    CoordinateSystem.instance.scaleFactor),
+            origin: utilityAnchorForScale(
+              utility: widget,
+              mapScale: mapScale,
+              agentSize: agentSize,
+              abilitySize: abilitySize,
+            ).scale(CoordinateSystem.instance.scaleFactor,
+                CoordinateSystem.instance.scaleFactor),
             child: PlacedWidgetPreview.build(
               widget,
               mapScale,

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -291,6 +291,7 @@ class _StrategySettingsSections extends ConsumerWidget {
                   ref
                       .read(strategySettingsProvider.notifier)
                       .updateAgentSize(value);
+                  ref.read(strategyProvider.notifier).setUnsaved();
                 },
                 onChangeCommitted: (start, end) {
                   if (start == end) return;
@@ -318,6 +319,7 @@ class _StrategySettingsSections extends ConsumerWidget {
                   ref
                       .read(strategySettingsProvider.notifier)
                       .updateAbilitySize(value);
+                  ref.read(strategyProvider.notifier).setUnsaved();
                 },
                 onChangeCommitted: (start, end) {
                   if (start == end) return;

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -291,7 +291,16 @@ class _StrategySettingsSections extends ConsumerWidget {
                   ref
                       .read(strategySettingsProvider.notifier)
                       .updateAgentSize(value);
-                  ref.read(strategyProvider.notifier).setUnsaved();
+                },
+                onChangeCommitted: (start, end) {
+                  if (start == end) return;
+
+                  final settings = ref.read(strategySettingsProvider.notifier);
+                  settings.updateAgentSize(start);
+                  ref.read(actionProvider.notifier).performTransaction(
+                    groups: const [ActionGroup.strategySettings],
+                    mutation: () => settings.updateAgentSize(end),
+                  );
                 },
               ),
               const _SettingsItemDivider(),
@@ -313,8 +322,7 @@ class _StrategySettingsSections extends ConsumerWidget {
                 onChangeCommitted: (start, end) {
                   if (start == end) return;
 
-                  final settings =
-                      ref.read(strategySettingsProvider.notifier);
+                  final settings = ref.read(strategySettingsProvider.notifier);
                   settings.updateAbilitySize(start);
                   ref.read(actionProvider.notifier).performTransaction(
                     groups: const [ActionGroup.strategySettings],

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -5,6 +5,7 @@ import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/shortcut_info.dart';
+import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
 import 'package:icarus/providers/marker_sizes_sync.dart';
@@ -308,7 +309,17 @@ class _StrategySettingsSections extends ConsumerWidget {
                   ref
                       .read(strategySettingsProvider.notifier)
                       .updateAbilitySize(value);
-                  ref.read(strategyProvider.notifier).setUnsaved();
+                },
+                onChangeCommitted: (start, end) {
+                  if (start == end) return;
+
+                  final settings =
+                      ref.read(strategySettingsProvider.notifier);
+                  settings.updateAbilitySize(start);
+                  ref.read(actionProvider.notifier).performTransaction(
+                    groups: const [ActionGroup.strategySettings],
+                    mutation: () => settings.updateAbilitySize(end),
+                  );
                 },
               ),
               const _SettingsItemDivider(),
@@ -1280,7 +1291,7 @@ class _SettingsNavItem extends StatelessWidget {
   }
 }
 
-class _SettingsSliderTile extends StatelessWidget {
+class _SettingsSliderTile extends StatefulWidget {
   const _SettingsSliderTile({
     required this.icon,
     required this.title,
@@ -1291,6 +1302,7 @@ class _SettingsSliderTile extends StatelessWidget {
     required this.divisions,
     required this.accentColor,
     required this.onChanged,
+    this.onChangeCommitted,
   });
 
   final IconData icon;
@@ -1302,6 +1314,14 @@ class _SettingsSliderTile extends StatelessWidget {
   final int divisions;
   final Color accentColor;
   final ValueChanged<double> onChanged;
+  final void Function(double start, double end)? onChangeCommitted;
+
+  @override
+  State<_SettingsSliderTile> createState() => _SettingsSliderTileState();
+}
+
+class _SettingsSliderTileState extends State<_SettingsSliderTile> {
+  double? _dragStartValue;
 
   @override
   Widget build(BuildContext context) {
@@ -1314,8 +1334,8 @@ class _SettingsSliderTile extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _SettingLeadingIcon(
-                icon: icon,
-                accentColor: accentColor,
+                icon: widget.icon,
+                accentColor: widget.accentColor,
               ),
               const SizedBox(width: 10),
               Expanded(
@@ -1323,12 +1343,12 @@ class _SettingsSliderTile extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      title,
+                      widget.title,
                       style: const TextStyle(fontWeight: FontWeight.w600),
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      description,
+                      widget.description,
                       style: ShadTheme.of(context).textTheme.small.copyWith(
                             color: Settings.tacticalVioletTheme.mutedForeground,
                             height: 1.3,
@@ -1339,26 +1359,34 @@ class _SettingsSliderTile extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               _SettingValuePill(
-                value: value.toStringAsFixed(0),
-                accentColor: accentColor,
+                value: widget.value.toStringAsFixed(0),
+                accentColor: widget.accentColor,
               ),
             ],
           ),
           const SizedBox(height: 8),
           SliderTheme(
             data: SliderTheme.of(context).copyWith(
-              activeTrackColor: accentColor,
-              thumbColor: accentColor,
-              overlayColor: accentColor.withValues(alpha: 0.12),
+              activeTrackColor: widget.accentColor,
+              thumbColor: widget.accentColor,
+              overlayColor: widget.accentColor.withValues(alpha: 0.12),
               inactiveTrackColor: Settings.tacticalVioletTheme.secondary,
               trackHeight: 2.8,
             ),
             child: Slider(
-              min: min,
-              max: max,
-              divisions: divisions,
-              value: value,
-              onChanged: onChanged,
+              min: widget.min,
+              max: widget.max,
+              divisions: widget.divisions,
+              value: widget.value,
+              onChangeStart: (value) => _dragStartValue = value,
+              onChangeEnd: (value) {
+                widget.onChangeCommitted?.call(
+                  _dragStartValue ?? widget.value,
+                  value,
+                );
+                _dragStartValue = null;
+              },
+              onChanged: widget.onChanged,
             ),
           ),
         ],

--- a/lib/widgets/sidebar_widgets/agent_role_icon_tools.dart
+++ b/lib/widgets/sidebar_widgets/agent_role_icon_tools.dart
@@ -4,6 +4,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/default_placement.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/interaction_state_provider.dart';
 import 'package:icarus/providers/placement_center_provider.dart';
@@ -133,7 +134,7 @@ class _RoleIconTile extends ConsumerWidget {
       child: ShadTooltip(
         builder: (context) => Text(label),
         child: GestureDetector(
-          onTap: () => _placeAtCenter(ref, toolData),
+          onTap: () => _placeAtCenter(ref),
           child: utility.createWidget(
             id: null,
             isAlly: isAlly,
@@ -144,25 +145,28 @@ class _RoleIconTile extends ConsumerWidget {
     );
   }
 
-  void _placeAtCenter(WidgetRef ref, RoleIconToolData toolData) {
+  void _placeAtCenter(WidgetRef ref) {
     ref
         .read(interactionStateProvider.notifier)
         .update(InteractionState.navigation);
 
     const uuid = Uuid();
     final placementCenter = ref.read(placementCenterProvider);
+    final placedUtility = PlacedUtility(
+      position: Offset.zero,
+      id: uuid.v4(),
+      type: type,
+      isAlly: ref.read(teamProvider),
+    );
     final centeredTopLeft = DefaultPlacement.topLeftFromVirtualAnchor(
       viewportCenter: placementCenter,
-      anchorVirtual: toolData.centerPoint,
+      anchorVirtual: storedUtilityAnchor(
+        utility: placedUtility,
+        mapScale: 1,
+      ),
     );
+    placedUtility.position = centeredTopLeft;
 
-    ref.read(utilityProvider.notifier).addUtility(
-          PlacedUtility(
-            position: centeredTopLeft,
-            id: uuid.v4(),
-            type: type,
-            isAlly: ref.read(teamProvider),
-          ),
-        );
+    ref.read(utilityProvider.notifier).addUtility(placedUtility);
   }
 }

--- a/test/ability_anchor_scaling_test.dart
+++ b/test/ability_anchor_scaling_test.dart
@@ -7,6 +7,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/transition_data.dart';
+import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
@@ -200,6 +201,198 @@ void main() {
     });
   });
 
+  group('agent-scaled widgetAnchor scaling', () {
+    final representativeAgents = <PlacedAgentNode>[
+      PlacedAgent(
+        id: 'plain-agent',
+        type: AgentType.jett,
+        position: const Offset(318.5, 211.25),
+      ),
+      PlacedViewConeAgent(
+        id: 'view-cone-agent',
+        type: AgentType.sova,
+        presetType: UtilityType.viewCone90,
+        position: const Offset(318.5, 211.25),
+      ),
+      PlacedCircleAgent(
+        id: 'circle-agent',
+        type: AgentType.viper,
+        position: const Offset(318.5, 211.25),
+        diameterMeters: 12,
+      ),
+    ];
+
+    test('every agent icon family keeps its center anchor fixed at all sizes',
+        () {
+      final coordinateSystem = CoordinateSystem.instance;
+
+      for (final agent in representativeAgents) {
+        Offset? expectedAnchor;
+        for (final size in <double>{
+          Settings.agentSizeMin,
+          Settings.agentSize,
+          Settings.agentSizeMax,
+        }) {
+          final topLeft = screenPositionForWidget(
+            widget: agent,
+            coordinateSystem: coordinateSystem,
+            agentSize: size,
+          );
+          final actualAnchor = topLeft +
+              Offset(size / 2, size / 2).scale(
+                coordinateSystem.scaleFactor,
+                coordinateSystem.scaleFactor,
+              );
+          expectedAnchor ??= actualAnchor;
+
+          expect(
+            actualAnchor.dx,
+            closeTo(expectedAnchor.dx, 0.0001),
+            reason: '${agent.runtimeType} x at size $size',
+          );
+          expect(
+            actualAnchor.dy,
+            closeTo(expectedAnchor.dy, 0.0001),
+            reason: '${agent.runtimeType} y at size $size',
+          );
+        }
+      }
+    });
+
+    test('agent drag conversion round-trips stable serialized positions', () {
+      final coordinateSystem = CoordinateSystem.instance;
+
+      for (final agent in representativeAgents) {
+        Offset? expectedStoredPosition;
+        for (final size in <double>{
+          Settings.agentSizeMin,
+          Settings.agentSizeMax,
+        }) {
+          final renderedTopLeft = screenPositionForWidget(
+            widget: agent,
+            coordinateSystem: coordinateSystem,
+            agentSize: size,
+          );
+          final restored = storedAgentPositionForRenderedScreenPosition(
+            coordinateSystem: coordinateSystem,
+            renderedScreenPosition: renderedTopLeft,
+            agentSize: size,
+          );
+          expectedStoredPosition ??= restored;
+
+          expect(restored.dx, closeTo(expectedStoredPosition.dx, 0.0001));
+          expect(restored.dy, closeTo(expectedStoredPosition.dy, 0.0001));
+        }
+      }
+    });
+
+    test('role icon utilities keep their semantic anchor fixed at all sizes',
+        () {
+      const mapScale = 1.13;
+      final coordinateSystem = CoordinateSystem.instance;
+
+      for (final type in UtilityType.values.where(UtilityData.isRoleIcon)) {
+        final utility = PlacedUtility(
+          id: 'role-${type.name}',
+          type: type,
+          position: const Offset(276.5, 163.75),
+        );
+        Offset? expectedAnchor;
+
+        for (final size in <double>{
+          Settings.agentSizeMin,
+          Settings.agentSize,
+          Settings.agentSizeMax,
+        }) {
+          final topLeft = screenPositionForWidget(
+            widget: utility,
+            coordinateSystem: coordinateSystem,
+            mapScale: mapScale,
+            agentSize: size,
+            abilitySize: Settings.abilitySize,
+          );
+          final renderedAnchor = utilityAnchorForScale(
+            utility: utility,
+            mapScale: mapScale,
+            agentSize: size,
+            abilitySize: Settings.abilitySize,
+          );
+          final actualAnchor = topLeft +
+              renderedAnchor.scale(
+                coordinateSystem.scaleFactor,
+                coordinateSystem.scaleFactor,
+              );
+          expectedAnchor ??= actualAnchor;
+
+          expect(actualAnchor.dx, closeTo(expectedAnchor.dx, 0.0001));
+          expect(actualAnchor.dy, closeTo(expectedAnchor.dy, 0.0001));
+        }
+      }
+    });
+
+    test('role icon drag conversion round-trips stable positions', () {
+      const mapScale = 0.87;
+      final coordinateSystem = CoordinateSystem.instance;
+      final utility = PlacedUtility(
+        id: 'role-icon',
+        type: UtilityType.controller,
+        position: const Offset(356.25, 194.5),
+      );
+      Offset? expectedStoredPosition;
+
+      for (final size in <double>{
+        Settings.agentSizeMin,
+        Settings.agentSizeMax,
+      }) {
+        final renderedTopLeft = screenPositionForWidget(
+          widget: utility,
+          coordinateSystem: coordinateSystem,
+          mapScale: mapScale,
+          agentSize: size,
+          abilitySize: Settings.abilitySize,
+        );
+        final restored = storedUtilityPositionForRenderedScreenPosition(
+          utility: utility,
+          coordinateSystem: coordinateSystem,
+          renderedScreenPosition: renderedTopLeft,
+          mapScale: mapScale,
+          agentSize: size,
+          abilitySize: Settings.abilitySize,
+        );
+        expectedStoredPosition ??= restored;
+
+        expect(restored.dx, closeTo(expectedStoredPosition.dx, 0.0001));
+        expect(restored.dy, closeTo(expectedStoredPosition.dy, 0.0001));
+      }
+    });
+
+    test('side switching is independent of runtime agent scale', () {
+      final atMinimum = representativeAgents.first.deepCopy<PlacedAgentNode>();
+      final atMaximum = representativeAgents.first.deepCopy<PlacedAgentNode>();
+      atMinimum.switchSides(Settings.agentSizeMin);
+      atMaximum.switchSides(Settings.agentSizeMax);
+      expect(atMaximum.position, atMinimum.position);
+
+      final roleAtMinimum = PlacedUtility(
+        id: 'role-min',
+        type: UtilityType.initiator,
+        position: const Offset(205, 305),
+      );
+      final roleAtMaximum = roleAtMinimum.copyWith(id: 'role-max');
+      roleAtMinimum.switchSides(
+        mapScale: 1,
+        agentSize: Settings.agentSizeMin,
+        abilitySize: Settings.abilitySizeMin,
+      );
+      roleAtMaximum.switchSides(
+        mapScale: 1,
+        agentSize: Settings.agentSizeMax,
+        abilitySize: Settings.abilitySizeMax,
+      );
+      expect(roleAtMaximum.position, roleAtMinimum.position);
+    });
+  });
+
   test('ability size changes participate in transaction undo and redo', () {
     final container = ProviderContainer(
       overrides: [
@@ -231,6 +424,40 @@ void main() {
     expect(
       container.read(strategySettingsProvider).abilitySize,
       Settings.abilitySizeMax,
+    );
+  });
+
+  test('agent size changes participate in transaction undo and redo', () {
+    final container = ProviderContainer(
+      overrides: [
+        strategyProvider.overrideWith(_NoopStrategyProvider.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final settings = container.read(strategySettingsProvider.notifier);
+    container.read(actionProvider.notifier).performTransaction(
+      groups: const [ActionGroup.strategySettings],
+      mutation: () => settings.updateAgentSize(Settings.agentSizeMax),
+    );
+
+    expect(
+      container.read(strategySettingsProvider).agentSize,
+      Settings.agentSizeMax,
+    );
+    expect(container.read(actionProvider), hasLength(1));
+    expect(container.read(actionProvider).single.type, ActionType.transaction);
+
+    container.read(actionProvider.notifier).undoAction();
+    expect(
+      container.read(strategySettingsProvider).agentSize,
+      Settings.agentSize,
+    );
+
+    container.read(actionProvider.notifier).redoAction();
+    expect(
+      container.read(strategySettingsProvider).agentSize,
+      Settings.agentSizeMax,
     );
   });
 }

--- a/test/ability_anchor_scaling_test.dart
+++ b/test/ability_anchor_scaling_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/abilities.dart';
+import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
+import 'package:icarus/providers/action_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_settings_provider.dart';
+
+class _NoopStrategyProvider extends StrategyProvider {
+  @override
+  StrategyState build() {
+    return StrategyState(
+      isSaved: true,
+      stratName: 'anchor-test',
+      id: 'anchor-test',
+      storageDirectory: null,
+      activePageId: null,
+    );
+  }
+
+  @override
+  void setUnsaved() {
+    state = state.copyWith(isSaved: false);
+  }
+}
+
+Iterable<AbilityInfo> _representativeAbilityInfos() sync* {
+  final seenTypes = <Type>{};
+  for (final agent in AgentData.agents.values) {
+    for (final info in agent.abilities) {
+      final ability = info.abilityData;
+      if (ability != null && seenTypes.add(ability.runtimeType)) {
+        yield info;
+      }
+    }
+  }
+}
+
+PlacedAbility _placedAbility(AbilityInfo info, {String? id}) {
+  return PlacedAbility(
+    id: id ?? '${info.type.name}-${info.index}',
+    data: info,
+    position: const Offset(411.25, 287.75),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    CoordinateSystem(playAreaSize: const Size(1920, 1080));
+  });
+
+  group('ability widgetAnchor scaling', () {
+    test('catalog covers every supported ability geometry type', () {
+      final types = _representativeAbilityInfos()
+          .map((info) => info.abilityData.runtimeType)
+          .toSet();
+
+      expect(
+        types,
+        containsAll(<Type>{
+          BaseAbility,
+          ImageAbility,
+          CircleAbility,
+          SectorCircleAbility,
+          SquareAbility,
+          CenterSquareAbility,
+          RotatableImageAbility,
+          ResizableSquareAbility,
+          DeadlockBarrierMeshAbility,
+        }),
+      );
+    });
+
+    test('every ability type keeps its semantic anchor fixed at all sizes', () {
+      const mapScale = 1.17;
+      final coordinateSystem = CoordinateSystem.instance;
+
+      for (final info in _representativeAbilityInfos()) {
+        final placed = _placedAbility(info);
+        Offset? expectedAnchor;
+
+        for (final size in <double>{
+          Settings.abilitySizeMin,
+          Settings.abilitySize,
+          Settings.abilitySizeMax,
+        }) {
+          final topLeft = screenPositionForWidget(
+            widget: placed,
+            coordinateSystem: coordinateSystem,
+            mapScale: mapScale,
+            abilitySize: size,
+          );
+          final renderedAnchor = info.abilityData!.getAnchorPoint(
+            mapScale: mapScale,
+            abilitySize: size,
+          );
+          final actualAnchor = topLeft +
+              renderedAnchor.scale(
+                coordinateSystem.scaleFactor,
+                coordinateSystem.scaleFactor,
+              );
+          expectedAnchor ??= actualAnchor;
+
+          expect(
+            actualAnchor.dx,
+            closeTo(expectedAnchor.dx, 0.0001),
+            reason: '${info.abilityData.runtimeType} x at size $size',
+          );
+          expect(
+            actualAnchor.dy,
+            closeTo(expectedAnchor.dy, 0.0001),
+            reason: '${info.abilityData.runtimeType} y at size $size',
+          );
+        }
+      }
+    });
+
+    test('drag conversion round-trips stable serialized positions', () {
+      const mapScale = 0.91;
+      final coordinateSystem = CoordinateSystem.instance;
+
+      for (final info in _representativeAbilityInfos()) {
+        final placed = _placedAbility(info);
+        Offset? expectedStoredPosition;
+        for (final size in <double>{
+          Settings.abilitySizeMin,
+          Settings.abilitySizeMax,
+        }) {
+          final renderedTopLeft = screenPositionForWidget(
+            widget: placed,
+            coordinateSystem: coordinateSystem,
+            mapScale: mapScale,
+            abilitySize: size,
+          );
+          final restored = storedAbilityPositionForRenderedScreenPosition(
+            ability: info.abilityData!,
+            coordinateSystem: coordinateSystem,
+            renderedScreenPosition: renderedTopLeft,
+            mapScale: mapScale,
+            abilitySize: size,
+          );
+          expectedStoredPosition ??= restored;
+
+          expect(
+            restored.dx,
+            closeTo(expectedStoredPosition.dx, 0.0001),
+            reason: '${info.abilityData.runtimeType} x at size $size',
+          );
+          expect(
+            restored.dy,
+            closeTo(expectedStoredPosition.dy, 0.0001),
+            reason: '${info.abilityData.runtimeType} y at size $size',
+          );
+        }
+      }
+    });
+
+    test('side switching is independent of the selected runtime size', () {
+      const mapScale = 1.2;
+      final sizeDependentInfos = _representativeAbilityInfos().where((info) {
+        final ability = info.abilityData!;
+        final minAnchor = ability.getAnchorPoint(
+          mapScale: mapScale,
+          abilitySize: Settings.abilitySizeMin,
+        );
+        final maxAnchor = ability.getAnchorPoint(
+          mapScale: mapScale,
+          abilitySize: Settings.abilitySizeMax,
+        );
+        return minAnchor != maxAnchor;
+      });
+
+      expect(sizeDependentInfos, isNotEmpty);
+      for (final info in sizeDependentInfos) {
+        final atMinimum = _placedAbility(info, id: 'minimum');
+        final atMaximum = _placedAbility(info, id: 'maximum');
+
+        atMinimum.switchSides(
+          mapScale: mapScale,
+          abilitySize: Settings.abilitySizeMin,
+        );
+        atMaximum.switchSides(
+          mapScale: mapScale,
+          abilitySize: Settings.abilitySizeMax,
+        );
+
+        expect(
+          atMaximum.position,
+          atMinimum.position,
+          reason: '${info.abilityData.runtimeType}',
+        );
+      }
+    });
+  });
+
+  test('ability size changes participate in transaction undo and redo', () {
+    final container = ProviderContainer(
+      overrides: [
+        strategyProvider.overrideWith(_NoopStrategyProvider.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final settings = container.read(strategySettingsProvider.notifier);
+    container.read(actionProvider.notifier).performTransaction(
+      groups: const [ActionGroup.strategySettings],
+      mutation: () => settings.updateAbilitySize(Settings.abilitySizeMax),
+    );
+
+    expect(
+      container.read(strategySettingsProvider).abilitySize,
+      Settings.abilitySizeMax,
+    );
+    expect(container.read(actionProvider), hasLength(1));
+    expect(container.read(actionProvider).single.type, ActionType.transaction);
+
+    container.read(actionProvider.notifier).undoAction();
+    expect(
+      container.read(strategySettingsProvider).abilitySize,
+      Settings.abilitySize,
+    );
+
+    container.read(actionProvider.notifier).redoAction();
+    expect(
+      container.read(strategySettingsProvider).abilitySize,
+      Settings.abilitySizeMax,
+    );
+  });
+}

--- a/test/deadlock_barrier_switch_sides_test.dart
+++ b/test/deadlock_barrier_switch_sides_test.dart
@@ -8,6 +8,7 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_provider.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
@@ -111,7 +112,7 @@ void main() {
       final fullSize = abilityData
           .getSize(
             mapScale: explicitMapScale,
-            abilitySize: explicitAbilitySize,
+            abilitySize: Settings.abilitySize,
           )
           .scale(
             CoordinateSystem.instance.scaleFactor,

--- a/test/resizable_square_ability_test.dart
+++ b/test/resizable_square_ability_test.dart
@@ -8,6 +8,7 @@ import 'package:icarus/const/agents.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
@@ -322,7 +323,7 @@ void main() {
       );
 
       final fullSize = abilityInfo.abilityData!
-          .getSize(mapScale: mapScale, abilitySize: abilitySize)
+          .getSize(mapScale: mapScale, abilitySize: Settings.abilitySize)
           .scale(
             CoordinateSystem.instance.scaleFactor,
             CoordinateSystem.instance.scaleFactor,
@@ -355,7 +356,7 @@ void main() {
       );
 
       final fullSize = abilityInfo.abilityData!
-          .getSize(mapScale: mapScale, abilitySize: abilitySize)
+          .getSize(mapScale: mapScale, abilitySize: Settings.abilitySize)
           .scale(
             CoordinateSystem.instance.scaleFactor,
             CoordinateSystem.instance.scaleFactor,

--- a/test/role_icon_agent_size_test.dart
+++ b/test/role_icon_agent_size_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
@@ -158,7 +159,8 @@ void main() {
       expect(framedShell.size, isNot(abilitySize));
     });
 
-    test('utility side switching uses the role icon agent footprint', () {
+    test('utility side switching uses the stable default role icon footprint',
+        () {
       final container = _createContainer(
         settings: StrategySettings(
           agentSize: agentSize,
@@ -181,8 +183,8 @@ void main() {
       final expectedPosition = getFlippedPosition(
         position: initialPosition,
         scaledSize: Offset(
-          CoordinateSystem.instance.scale(agentSize),
-          CoordinateSystem.instance.scale(agentSize),
+          CoordinateSystem.instance.scale(Settings.agentSize),
+          CoordinateSystem.instance.scale(Settings.agentSize),
         ),
       );
 


### PR DESCRIPTION
## Summary
- scale every ability widget around its semantic `widgetAnchor` so resizing does not visually shift its position
- preserve positional compatibility for existing strategies and keep drag/drop, side switching, transitions, and lineup geometry anchor-correct
- group ability-size slider edits into a single undo/redo settings transaction
- add focused geometry coverage for all nine ability widget types

## Testing
- 54 focused tests passed
- full suite: 257 passed; one pre-existing unrelated version-registry assertion remains
- targeted analyzer clean
- Windows debug build passed
- visual audit covers all nine widget types across multiple sizes