### PR TITLE
Add mouse side-button back/forward navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:icarus/services/discord_presence_service.dart';
 import 'package:icarus/strategy_view.dart';
 import 'package:icarus/widgets/folder_navigator.dart';
 import 'package:icarus/widgets/global_shortcuts.dart';
+import 'package:icarus/widgets/mouse_navigation.dart';
 import 'package:icarus/widgets/settings_tab.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -349,6 +350,7 @@ class _MyAppState extends ConsumerState<MyApp> {
       ),
       child: ShadApp(
         navigatorKey: appNavigatorKey,
+        navigatorObservers: [mouseNavigationRouteObserver],
         themeMode: ThemeMode.dark,
         darkTheme: ShadThemeData(
           brightness: Brightness.dark,
@@ -362,7 +364,9 @@ class _MyAppState extends ConsumerState<MyApp> {
           Routes.settings: (context) => const SettingsTab(),
         },
         builder: (context, child) {
-          return GlobalShortcuts(child: child ?? const SizedBox.shrink());
+          return GlobalShortcuts(
+            child: MouseNavigation(child: child ?? const SizedBox.shrink()),
+          );
         },
       ),
     );

--- a/lib/strategy_view.dart
+++ b/lib/strategy_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/custom_icons.dart';
 import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/routes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/interactive_map.dart';
 import 'package:icarus/providers/agent_filter_provider.dart';
@@ -49,6 +50,7 @@ class StrategyView extends ConsumerStatefulWidget {
     bool initialIsAttack = true,
   }) {
     return PageRouteBuilder<void>(
+      settings: const RouteSettings(name: Routes.strategyView),
       transitionDuration: const Duration(milliseconds: 200),
       reverseTransitionDuration: const Duration(milliseconds: 200),
       pageBuilder: (context, animation, _) => StrategyView(

--- a/lib/widgets/folder_navigator.dart
+++ b/lib/widgets/folder_navigator.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show debugPrint, kDebugMode, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/routes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/update_checker.dart';
 import 'package:icarus/main.dart';
@@ -255,6 +256,7 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
         Navigator.push(
           context,
           PageRouteBuilder(
+            settings: const RouteSettings(name: Routes.strategyView),
             transitionDuration: const Duration(milliseconds: 200),
             reverseTransitionDuration:
                 const Duration(milliseconds: 200), // pop duration

--- a/lib/widgets/mouse_navigation.dart
+++ b/lib/widgets/mouse_navigation.dart
@@ -156,15 +156,24 @@ class _MouseNavigationState extends ConsumerState<MouseNavigation> {
   }
 
   bool _hasOpenShadMenu() {
-    final focusContext = FocusManager.instance.primaryFocus?.context;
-    if (focusContext == null) return false;
+    bool found = false;
 
-    final contextMenu =
-        focusContext.findAncestorStateOfType<ShadContextMenuState>();
-    if (contextMenu?.controller.isOpen ?? false) return true;
+    void visit(Element element) {
+      if (found) return;
 
-    final popover = focusContext.findAncestorWidgetOfExactType<ShadPopover>();
-    return popover?.controller?.isOpen ?? popover?.visible ?? false;
+      final widget = element.widget;
+      if (widget is ShadPopover &&
+          (widget.controller?.isOpen ?? widget.visible ?? false)) {
+        found = true;
+        return;
+      }
+
+      element.visitChildren(visit);
+    }
+
+    final root = WidgetsBinding.instance.rootElement;
+    if (root != null) visit(root);
+    return found;
   }
 
   void _handlePointerDown(PointerDownEvent event) {

--- a/lib/widgets/mouse_navigation.dart
+++ b/lib/widgets/mouse_navigation.dart
@@ -1,0 +1,315 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce_flutter/adapters.dart';
+import 'package:icarus/const/app_navigator.dart';
+import 'package:icarus/const/hive_boxes.dart';
+import 'package:icarus/const/routes.dart';
+import 'package:icarus/providers/agent_filter_provider.dart';
+import 'package:icarus/providers/delete_menu_provider.dart';
+import 'package:icarus/providers/folder_provider.dart';
+import 'package:icarus/providers/interaction_state_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/services/unsaved_strategy_guard.dart';
+import 'package:icarus/strategy_view.dart';
+
+/// Tracks the live route stack so [MouseNavigation] can tell what is on top:
+/// the library, the strategy view, a dialog, or an auxiliary screen.
+final MouseNavigationRouteObserver mouseNavigationRouteObserver =
+    MouseNavigationRouteObserver();
+
+class MouseNavigationRouteObserver extends NavigatorObserver {
+  final List<Route<dynamic>> _stack = [];
+
+  Route<dynamic>? get topRoute => _stack.isEmpty ? null : _stack.last;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.add(route);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.remove(route);
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.remove(route);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    final index = oldRoute == null ? -1 : _stack.indexOf(oldRoute);
+    if (index == -1) {
+      if (newRoute != null) _stack.add(newRoute);
+      return;
+    }
+    if (newRoute == null) {
+      _stack.removeAt(index);
+    } else {
+      _stack[index] = newRoute;
+    }
+  }
+}
+
+/// A place the user can be while browsing their library: a folder (null id is
+/// the library root) or an open strategy.
+sealed class _NavLocation {
+  const _NavLocation();
+}
+
+class _FolderLocation extends _NavLocation {
+  const _FolderLocation(this.folderId);
+
+  final String? folderId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _FolderLocation && other.folderId == folderId;
+
+  @override
+  int get hashCode => Object.hash(_FolderLocation, folderId);
+}
+
+class _StrategyLocation extends _NavLocation {
+  const _StrategyLocation(this.strategyId);
+
+  final String strategyId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _StrategyLocation && other.strategyId == strategyId;
+
+  @override
+  int get hashCode => Object.hash(_StrategyLocation, strategyId);
+}
+
+/// Makes the mouse side buttons (back/forward) walk the user's browsing
+/// history, browser-style: folders visited in the library and strategies
+/// opened. Back from an open strategy returns to the library (respecting the
+/// unsaved-changes guard); forward re-opens it.
+class MouseNavigation extends ConsumerStatefulWidget {
+  const MouseNavigation({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<MouseNavigation> createState() => _MouseNavigationState();
+}
+
+class _MouseNavigationState extends ConsumerState<MouseNavigation> {
+  static const int _maxHistoryEntries = 50;
+
+  final List<_NavLocation> _backStack = [];
+  final List<_NavLocation> _forwardStack = [];
+  _NavLocation _currentLocation = const _FolderLocation(null);
+  bool _isNavigating = false;
+
+  ProviderSubscription<String?>? _folderSub;
+  ProviderSubscription<StrategyState>? _strategySub;
+
+  @override
+  void initState() {
+    super.initState();
+    _folderSub = ref.listenManual(
+      folderProvider,
+      (_, __) => _recordLocationChange(),
+    );
+    _strategySub = ref.listenManual(
+      strategyProvider,
+      (_, __) => _recordLocationChange(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _folderSub?.close();
+    _strategySub?.close();
+    super.dispose();
+  }
+
+  _NavLocation _deriveLocation() {
+    final strategy = ref.read(strategyProvider);
+    if (strategy.stratName != null) {
+      return _StrategyLocation(strategy.id);
+    }
+    return _FolderLocation(ref.read(folderProvider));
+  }
+
+  /// Records navigation the user performs by any other means (folder tiles,
+  /// breadcrumb, opening a strategy, the quick switcher, ...).
+  void _recordLocationChange() {
+    if (_isNavigating) return;
+    final next = _deriveLocation();
+    if (next == _currentLocation) return;
+
+    _backStack.add(_currentLocation);
+    if (_backStack.length > _maxHistoryEntries) {
+      _backStack.removeAt(0);
+    }
+    _forwardStack.clear();
+    _currentLocation = next;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (event.kind != PointerDeviceKind.mouse) return;
+    final bool isBack = event.buttons & kBackMouseButton != 0;
+    final bool isForward = event.buttons & kForwardMouseButton != 0;
+    if (!isBack && !isForward) return;
+
+    final topRoute = mouseNavigationRouteObserver.topRoute;
+    if (topRoute is PopupRoute) {
+      // A dialog or menu owns the screen; never navigate underneath it.
+      return;
+    }
+
+    final String? name = topRoute?.settings.name;
+    final bool onKnownScreen = topRoute == null ||
+        name == Navigator.defaultRouteName ||
+        name == Routes.strategyView;
+    if (!onKnownScreen) {
+      // Auxiliary screens (e.g. the fullscreen image viewer): back closes
+      // them, forward is a no-op.
+      if (isBack) {
+        appNavigatorKey.currentState?.maybePop();
+      }
+      return;
+    }
+
+    if (isBack) {
+      unawaited(_goBack());
+    } else {
+      unawaited(_goForward());
+    }
+  }
+
+  Future<void> _goBack() => _walkHistory(from: _backStack, to: _forwardStack);
+
+  Future<void> _goForward() =>
+      _walkHistory(from: _forwardStack, to: _backStack);
+
+  Future<void> _walkHistory({
+    required List<_NavLocation> from,
+    required List<_NavLocation> to,
+  }) async {
+    if (_isNavigating) return;
+    _isNavigating = true;
+    try {
+      while (from.isNotEmpty) {
+        final target = from.removeLast();
+        if (!_isLocationAvailable(target)) {
+          // Folder or strategy has been deleted since; drop the stale entry.
+          continue;
+        }
+        final bool moved = await _navigateTo(target);
+        if (!moved) {
+          // The user cancelled the unsaved-changes dialog; keep history as-is.
+          from.add(target);
+          return;
+        }
+        to.add(_currentLocation);
+        _currentLocation = target;
+        return;
+      }
+    } finally {
+      _isNavigating = false;
+    }
+  }
+
+  bool _isLocationAvailable(_NavLocation location) {
+    switch (location) {
+      case _FolderLocation(:final folderId):
+        return folderId == null ||
+            ref.read(folderProvider.notifier).findFolderByID(folderId) != null;
+      case _StrategyLocation(:final strategyId):
+        return Hive.box<StrategyData>(HiveBoxNames.strategiesBox)
+                .get(strategyId) !=
+            null;
+    }
+  }
+
+  Future<bool> _navigateTo(_NavLocation target) async {
+    final navigator = appNavigatorKey.currentState;
+    if (navigator == null || !mounted) return false;
+
+    final bool inStrategyRoute = mouseNavigationRouteObserver
+            .topRoute?.settings.name ==
+        Routes.strategyView;
+    final bool strategyOpen = ref.read(strategyProvider).stratName != null;
+
+    switch (target) {
+      case _FolderLocation(:final folderId):
+        if (strategyOpen || inStrategyRoute) {
+          final bool left = await guardUnsavedStrategyExit(
+            context: navigator.context,
+            ref: ref,
+            source: 'MouseNavigation.navigateToFolder',
+            onContinue: () async {
+              _resetStrategyUiState();
+              await ref.read(strategyProvider.notifier).clearCurrentStrategy();
+              if (inStrategyRoute && navigator.mounted) {
+                navigator.pop();
+              }
+            },
+          );
+          if (!left || !mounted) return false;
+        }
+        ref.read(folderProvider.notifier).updateID(folderId);
+        return true;
+
+      case _StrategyLocation(:final strategyId):
+        if (strategyOpen) {
+          // Already in the strategy view; swap strategies in place, exactly
+          // like the quick switcher does.
+          final bool switched = await guardUnsavedStrategyExit(
+            context: navigator.context,
+            ref: ref,
+            source: 'MouseNavigation.navigateToStrategy',
+            onContinue: () async {
+              _resetStrategyUiState();
+              await ref
+                  .read(strategyProvider.notifier)
+                  .loadFromHive(strategyId);
+            },
+          );
+          return switched && mounted;
+        }
+
+        final strategy = Hive.box<StrategyData>(HiveBoxNames.strategiesBox)
+            .get(strategyId);
+        if (strategy == null) return false;
+        unawaited(
+          navigator.push(
+            StrategyView.route(
+              initialStrategyId: strategy.id,
+              initialStrategyName: strategy.name,
+              initialMapValue: strategy.mapData,
+              initialIsAttack:
+                  strategy.pages.isEmpty || strategy.pages.first.isAttack,
+            ),
+          ),
+        );
+        return true;
+    }
+  }
+
+  void _resetStrategyUiState() {
+    ref
+        .read(interactionStateProvider.notifier)
+        .update(InteractionState.navigation);
+    ref.read(agentFilterProvider.notifier).updateFilterState(FilterState.all);
+    ref.read(deleteMenuProvider.notifier).requestClose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _handlePointerDown,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/widgets/mouse_navigation.dart
+++ b/lib/widgets/mouse_navigation.dart
@@ -14,6 +14,7 @@ import 'package:icarus/providers/interaction_state_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/services/unsaved_strategy_guard.dart';
 import 'package:icarus/strategy_view.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 /// Tracks the live route stack so [MouseNavigation] can tell what is on top:
 /// the library, the strategy view, a dialog, or an auxiliary screen.
@@ -154,6 +155,18 @@ class _MouseNavigationState extends ConsumerState<MouseNavigation> {
     _currentLocation = next;
   }
 
+  bool _hasOpenShadMenu() {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    if (focusContext == null) return false;
+
+    final contextMenu =
+        focusContext.findAncestorStateOfType<ShadContextMenuState>();
+    if (contextMenu?.controller.isOpen ?? false) return true;
+
+    final popover = focusContext.findAncestorWidgetOfExactType<ShadPopover>();
+    return popover?.controller?.isOpen ?? popover?.visible ?? false;
+  }
+
   void _handlePointerDown(PointerDownEvent event) {
     if (event.kind != PointerDeviceKind.mouse) return;
     final bool isBack = event.buttons & kBackMouseButton != 0;
@@ -161,7 +174,7 @@ class _MouseNavigationState extends ConsumerState<MouseNavigation> {
     if (!isBack && !isForward) return;
 
     final topRoute = mouseNavigationRouteObserver.topRoute;
-    if (topRoute is PopupRoute) {
+    if (topRoute is PopupRoute || _hasOpenShadMenu()) {
       // A dialog or menu owns the screen; never navigate underneath it.
       return;
     }

--- a/test/mouse_navigation_test.dart
+++ b/test/mouse_navigation_test.dart
@@ -10,7 +10,9 @@ void main() {
   testWidgets('mouse back does not navigate under an open Shad popover',
       (tester) async {
     final popoverController = ShadPopoverController();
+    final unrelatedFocusNode = FocusNode();
     addTearDown(popoverController.dispose);
+    addTearDown(unrelatedFocusNode.dispose);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -27,10 +29,15 @@ void main() {
       MaterialPageRoute<void>(
         settings: const RouteSettings(name: '/auxiliary'),
         builder: (_) => Scaffold(
-          body: ShadPopover(
-            controller: popoverController,
-            popover: (_) => const Text('menu'),
-            child: const SizedBox.expand(child: Text('auxiliary')),
+          body: Stack(
+            children: [
+              TextField(focusNode: unrelatedFocusNode),
+              ShadPopover(
+                controller: popoverController,
+                popover: (_) => const Text('menu'),
+                child: const SizedBox.expand(child: Text('auxiliary')),
+              ),
+            ],
           ),
         ),
       ),
@@ -40,6 +47,9 @@ void main() {
     popoverController.show();
     await tester.pumpAndSettle();
     expect(find.text('menu'), findsOneWidget);
+    unrelatedFocusNode.requestFocus();
+    await tester.pump();
+    expect(unrelatedFocusNode.hasFocus, isTrue);
 
     await tester.sendEventToBinding(
       const PointerDownEvent(
@@ -57,7 +67,9 @@ void main() {
   testWidgets('mouse back does not navigate under an open Shad context menu',
       (tester) async {
     final menuController = ShadContextMenuController();
+    final unrelatedFocusNode = FocusNode();
     addTearDown(menuController.dispose);
+    addTearDown(unrelatedFocusNode.dispose);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -74,10 +86,15 @@ void main() {
       MaterialPageRoute<void>(
         settings: const RouteSettings(name: '/auxiliary'),
         builder: (_) => Scaffold(
-          body: ShadContextMenu(
-            controller: menuController,
-            items: const [ShadContextMenuItem(child: Text('menu item'))],
-            child: const SizedBox.expand(child: Text('auxiliary')),
+          body: Stack(
+            children: [
+              TextField(focusNode: unrelatedFocusNode),
+              ShadContextMenu(
+                controller: menuController,
+                items: const [ShadContextMenuItem(child: Text('menu item'))],
+                child: const SizedBox.expand(child: Text('auxiliary')),
+              ),
+            ],
           ),
         ),
       ),
@@ -87,6 +104,9 @@ void main() {
     menuController.show();
     await tester.pumpAndSettle();
     expect(find.text('menu item'), findsOneWidget);
+    unrelatedFocusNode.requestFocus();
+    await tester.pump();
+    expect(unrelatedFocusNode.hasFocus, isTrue);
 
     await tester.sendEventToBinding(
       const PointerDownEvent(

--- a/test/mouse_navigation_test.dart
+++ b/test/mouse_navigation_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/app_navigator.dart';
+import 'package:icarus/widgets/mouse_navigation.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+void main() {
+  testWidgets('mouse back does not navigate under an open Shad popover',
+      (tester) async {
+    final popoverController = ShadPopoverController();
+    addTearDown(popoverController.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: ShadApp(
+          navigatorKey: appNavigatorKey,
+          navigatorObservers: [mouseNavigationRouteObserver],
+          builder: (_, child) => MouseNavigation(child: child!),
+          home: const Scaffold(body: Text('library')),
+        ),
+      ),
+    );
+
+    appNavigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/auxiliary'),
+        builder: (_) => Scaffold(
+          body: ShadPopover(
+            controller: popoverController,
+            popover: (_) => const Text('menu'),
+            child: const SizedBox.expand(child: Text('auxiliary')),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    popoverController.show();
+    await tester.pumpAndSettle();
+    expect(find.text('menu'), findsOneWidget);
+
+    await tester.sendEventToBinding(
+      const PointerDownEvent(
+        kind: PointerDeviceKind.mouse,
+        buttons: kBackMouseButton,
+        position: Offset(400, 300),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('auxiliary'), findsOneWidget);
+    expect(find.text('library'), findsNothing);
+  });
+
+  testWidgets('mouse back does not navigate under an open Shad context menu',
+      (tester) async {
+    final menuController = ShadContextMenuController();
+    addTearDown(menuController.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: ShadApp(
+          navigatorKey: appNavigatorKey,
+          navigatorObservers: [mouseNavigationRouteObserver],
+          builder: (_, child) => MouseNavigation(child: child!),
+          home: const Scaffold(body: Text('library')),
+        ),
+      ),
+    );
+
+    appNavigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/auxiliary'),
+        builder: (_) => Scaffold(
+          body: ShadContextMenu(
+            controller: menuController,
+            items: const [ShadContextMenuItem(child: Text('menu item'))],
+            child: const SizedBox.expand(child: Text('auxiliary')),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    menuController.show();
+    await tester.pumpAndSettle();
+    expect(find.text('menu item'), findsOneWidget);
+
+    await tester.sendEventToBinding(
+      const PointerDownEvent(
+        kind: PointerDeviceKind.mouse,
+        buttons: kBackMouseButton,
+        position: Offset(400, 300),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('auxiliary'), findsOneWidget);
+    expect(find.text('library'), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

The mouse side buttons (back/forward, XButton1/XButton2) now navigate the user's browsing history while moving through the library and strategies.

## Interpretation chosen

Browser-style history, not prev/next-strategy cycling. A "location" is either a folder in the library (root included) or an open strategy. Every navigation the user performs by any means — folder tiles, the breadcrumb, opening a strategy, the quick switcher — is recorded, and:

- **Back** returns to the previous location. Backing out of an open strategy goes through the existing unsaved-changes guard (cancel aborts the navigation and keeps history intact), exactly like the home button.
- **Forward** re-applies what back undid: re-enters the folder, or re-opens the strategy (swapping in place like the quick switcher when one is already open). Any new manual navigation clears the forward stack, as in a browser.

## How

- `lib/widgets/mouse_navigation.dart` — a `MouseNavigation` widget wrapping the app (inside `ShadApp.builder`) with a translucent `Listener` that checks `PointerDownEvent.buttons` for `kBackMouseButton`/`kForwardMouseButton`. It derives the current location from `folderProvider`/`strategyProvider` and keeps capped back/forward stacks. Stale entries (deleted folders/strategies) are skipped silently.
- A small `NavigatorObserver` tracks the route stack so the buttons never navigate underneath dialogs or menus (`PopupRoute` on top = no-op). On auxiliary pushed screens like the fullscreen image viewer, back just closes them and forward is a no-op.
- The two strategy-view route pushes now carry `RouteSettings(name: Routes.strategyView)` so the handler can recognize where it is.

## Platform caveats

- **Windows desktop** (primary target): the embedder delivers XButton1/XButton2 as pointer-down events with the back/forward button flags — this is the supported path.
- **Web demo**: the browser itself owns these buttons for its own history and Flutter web cannot reliably preventDefault them; since the demo is a single-page app with no pushed browser history, back usually leaves the page entirely regardless of in-app handling. No web-specific behavior was added.

## Demo

[▶ Watch the mouse back/forward navigation demo](https://codex-file-host.shawnadedeji.workers.dev/files/icarus-pr-110/a72497b2e2f4-mouse-navigation-demo.mp4)

![Home → strategy → mouse back → mouse forward](https://codex-file-host.shawnadedeji.workers.dev/files/icarus-pr-110/9a01c5dfc9e9-demo-contact-sheet.png)

The clip shows Home → strategy → Home via XButton1 (Back) → strategy via XButton2 (Forward).

## Testing

- `flutter analyze`: clean (one pre-existing deprecation info in `pages_bar.dart`, untouched).
- `flutter test`: all 339 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse back and forward navigation for folders and strategies.
  * Navigation history now supports route changes, strategy loading, and folder changes.
  * Back navigation closes auxiliary screens and skips unavailable destinations.
  * Unsaved-change prompts preserve navigation history when navigation is cancelled.
  * Strategy pages now use consistent route naming for reliable navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->