### PR TITLE
Reduce map drag frame work

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,0 +1,19 @@
+# Profile benchmarks
+
+Run the map interaction benchmarks against the Windows profile engine:
+
+```powershell
+flutter drive `
+  --driver=test_driver/performance_test.dart `
+  --target=integration_test/map_drag_performance_test.dart `
+  --profile `
+  -d windows
+```
+
+The run prints a compact `PERF_RESULT` line and writes the complete report to
+`build/map_drag_performance.json`.
+
+Compare builds using the same machine, viewport, Flutter version, and power
+state. The Windows engine can report zero-valued raster durations through
+`FrameTiming`; build-time percentiles remain valid, but use DevTools timeline
+traces when raster-thread timing is required.

--- a/integration_test/map_drag_performance_test.dart
+++ b/integration_test/map_drag_performance_test.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
+import 'package:icarus/providers/agent_provider.dart';
+import 'package:icarus/providers/map_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/placed_widget_builder.dart';
+import 'package:icarus/widgets/draggable_widgets/agents/agent_widget.dart';
+import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
+import 'package:icarus/widgets/hovered_map_item_name_card.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const _viewportSize = Size(1200, 675);
+const _dragSourceKey = ValueKey('performance-drag-source');
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('dragging across placed agents', (tester) async {
+    tester.view
+      ..physicalSize = _viewportSize
+      ..devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final coordinateSystem = CoordinateSystem(playAreaSize: _viewportSize);
+    final container = ProviderContainer(
+      overrides: [
+        mapProvider.overrideWith(_BenchmarkMapProvider.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final agents = <PlacedAgent>[
+      for (var index = 0; index < 12; index++)
+        PlacedAgent(
+          id: 'performance-agent-$index',
+          type: AgentType.values[index % AgentType.values.length],
+          position: storedAgentPositionForRenderedScreenPosition(
+            coordinateSystem: coordinateSystem,
+            renderedScreenPosition: Offset(150 + (index * 80), 310),
+            agentSize: Settings.agentSize,
+          ),
+          isAlly: index.isEven,
+        ),
+    ];
+    container.read(agentProvider.notifier).fromHive(agents);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: ShadApp(
+          themeMode: ThemeMode.dark,
+          darkTheme: ShadThemeData(
+            brightness: Brightness.dark,
+            colorScheme: Settings.tacticalVioletTheme,
+          ),
+          home: Scaffold(
+            body: SizedBox.fromSize(
+              size: _viewportSize,
+              child: const Stack(
+                children: [
+                  Positioned.fill(child: PlacedWidgetBuilder()),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: HoveredMapItemNameCard(),
+                  ),
+                  Positioned(
+                    left: 50,
+                    top: 315,
+                    child: _BenchmarkDragSource(key: _dragSourceKey),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Decode and raster-cache the feedback before collecting timings.
+    await _dragAcrossAgents(tester, leftToRight: true);
+    await tester.pumpAndSettle();
+
+    await binding.watchPerformance(
+      () async {
+        for (var pass = 0; pass < 6; pass++) {
+          await _dragAcrossAgents(tester, leftToRight: pass.isEven);
+        }
+        await tester.pumpAndSettle();
+      },
+      reportKey: 'map_drag_performance',
+    );
+    _printPerformanceSummary(binding, 'map_drag_performance');
+  });
+}
+
+void _printPerformanceSummary(
+  IntegrationTestWidgetsFlutterBinding binding,
+  String reportKey,
+) {
+  final report = binding.reportData?[reportKey] as Map<String, dynamic>?;
+  if (report == null) return;
+
+  const metricKeys = [
+    'average_frame_build_time_millis',
+    '90th_percentile_frame_build_time_millis',
+    '99th_percentile_frame_build_time_millis',
+    'worst_frame_build_time_millis',
+    'missed_frame_build_budget_count',
+    'average_frame_rasterizer_time_millis',
+    '90th_percentile_frame_rasterizer_time_millis',
+    '99th_percentile_frame_rasterizer_time_millis',
+    'worst_frame_rasterizer_time_millis',
+    'missed_frame_rasterizer_budget_count',
+    'frame_count',
+    'new_gen_gc_count',
+    'old_gen_gc_count',
+  ];
+  final summary = <String, dynamic>{
+    'report': reportKey,
+    for (final key in metricKeys) key: report[key],
+  };
+  debugPrint('PERF_RESULT ${jsonEncode(summary)}');
+}
+
+Future<void> _dragAcrossAgents(
+  WidgetTester tester, {
+  required bool leftToRight,
+}) async {
+  final source = tester.getCenter(find.byKey(_dragSourceKey));
+  final start = leftToRight ? source : const Offset(1100, 337.5);
+  final end = leftToRight ? const Offset(1100, 337.5) : source;
+  final gesture =
+      await tester.startGesture(start, kind: PointerDeviceKind.mouse);
+
+  for (var step = 1; step <= 72; step++) {
+    await gesture.moveTo(Offset.lerp(start, end, step / 72)!);
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+
+  await gesture.up();
+  await tester.pump();
+}
+
+class _BenchmarkDragSource extends StatelessWidget {
+  const _BenchmarkDragSource({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Draggable<Object>(
+      data: const Object(),
+      feedback: Opacity(
+        opacity: Settings.feedbackOpacity,
+        child: ZoomTransform(
+          child: AgentWidget(
+            id: '',
+            isAlly: true,
+            agent: AgentData.agents[AgentType.jett]!,
+          ),
+        ),
+      ),
+      childWhenDragging: const SizedBox.square(dimension: 45),
+      child: const _DragMarker(),
+    );
+  }
+}
+
+class _BenchmarkMapProvider extends MapProvider {
+  @override
+  MapState build() => MapState(
+        currentMap: MapValue.ascent,
+        isAttack: true,
+      );
+}
+
+class _DragMarker extends StatelessWidget {
+  const _DragMarker();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Settings.tacticalVioletTheme.primary,
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+      ),
+      child: const SizedBox.square(dimension: 45),
+    );
+  }
+}

--- a/integration_test/map_drag_performance_test.dart
+++ b/integration_test/map_drag_performance_test.dart
@@ -20,7 +20,9 @@ import 'package:integration_test/integration_test.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 const _viewportSize = Size(1200, 675);
-const _dragSourceKey = ValueKey('performance-drag-source');
+const _leftDragSourceKey = ValueKey('performance-left-drag-source');
+const _rightDragSourceKey = ValueKey('performance-right-drag-source');
+const _dragFeedbackKey = ValueKey('performance-drag-feedback');
 
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -77,7 +79,12 @@ void main() {
                   Positioned(
                     left: 50,
                     top: 315,
-                    child: _BenchmarkDragSource(key: _dragSourceKey),
+                    child: _BenchmarkDragSource(key: _leftDragSourceKey),
+                  ),
+                  Positioned(
+                    right: 50,
+                    top: 315,
+                    child: _BenchmarkDragSource(key: _rightDragSourceKey),
                   ),
                 ],
               ),
@@ -88,8 +95,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Decode and raster-cache the feedback before collecting timings.
-    await _dragAcrossAgents(tester, leftToRight: true);
+    // Verify and raster-cache feedback from both sources before collecting
+    // timings. This keeps every measured pass representative of a real drag.
+    await _dragAcrossAgents(
+      tester,
+      leftToRight: true,
+      verifyFeedback: true,
+    );
+    await _dragAcrossAgents(
+      tester,
+      leftToRight: false,
+      verifyFeedback: true,
+    );
     await tester.pumpAndSettle();
 
     await binding.watchPerformance(
@@ -137,16 +154,23 @@ void _printPerformanceSummary(
 Future<void> _dragAcrossAgents(
   WidgetTester tester, {
   required bool leftToRight,
+  bool verifyFeedback = false,
 }) async {
-  final source = tester.getCenter(find.byKey(_dragSourceKey));
-  final start = leftToRight ? source : const Offset(1100, 337.5);
-  final end = leftToRight ? const Offset(1100, 337.5) : source;
+  final start = tester.getCenter(
+    find.byKey(leftToRight ? _leftDragSourceKey : _rightDragSourceKey),
+  );
+  final end = tester.getCenter(
+    find.byKey(leftToRight ? _rightDragSourceKey : _leftDragSourceKey),
+  );
   final gesture =
       await tester.startGesture(start, kind: PointerDeviceKind.mouse);
 
   for (var step = 1; step <= 72; step++) {
     await gesture.moveTo(Offset.lerp(start, end, step / 72)!);
     await tester.pump(const Duration(milliseconds: 16));
+    if (verifyFeedback && step == 2) {
+      expect(find.byKey(_dragFeedbackKey), findsOneWidget);
+    }
   }
 
   await gesture.up();
@@ -161,6 +185,7 @@ class _BenchmarkDragSource extends StatelessWidget {
     return Draggable<Object>(
       data: const Object(),
       feedback: Opacity(
+        key: _dragFeedbackKey,
         opacity: Settings.feedbackOpacity,
         child: ZoomTransform(
           child: AgentWidget(

--- a/lib/widgets/draggable_widgets/agents/agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/agent_widget.dart
@@ -86,6 +86,7 @@ class AgentWidget extends ConsumerWidget {
     this.state = AgentState.none,
     this.forcedAgentSize,
     this.deadStateProgress,
+    this.isInteractive = true,
   });
 
   final String? lineUpId;
@@ -95,21 +96,27 @@ class AgentWidget extends ConsumerWidget {
   final AgentState state;
   final double? forcedAgentSize;
   final double? deadStateProgress;
+  final bool isInteractive;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final coordinateSystem = CoordinateSystem.instance;
-    final mapState = ref.watch(mapProvider);
-    final mapScale = Maps.mapScale[mapState.currentMap] ?? 1.0;
-    final agentSize =
-        forcedAgentSize ?? ref.watch(strategySettingsProvider).agentSize;
-    final useNeutralTeamColors =
-        ref.watch(strategySettingsProvider).useNeutralTeamColors;
+    final strategySettings = ref.watch(strategySettingsProvider);
+    final agentSize = forcedAgentSize ?? strategySettings.agentSize;
+    final useNeutralTeamColors = strategySettings.useNeutralTeamColors;
     final isScreenshot = ref.watch(screenshotProvider);
+    final canInteract = isInteractive &&
+        !isScreenshot &&
+        (lineUpId != null || (id?.isNotEmpty ?? false));
+    final mapState = canInteract ? ref.watch(mapProvider) : null;
+    final mapScale =
+        mapState == null ? 1.0 : (Maps.mapScale[mapState.currentMap] ?? 1.0);
     final deadProgress =
         (deadStateProgress ?? (state == AgentState.dead ? 1.0 : 0.0))
             .clamp(0.0, 1.0);
     final hasDeadStyling = deadProgress > 0;
-    final hoverTarget = ref.watch(hoveredLineUpTargetProvider);
+    final hoverTarget = canInteract && lineUpId != null
+        ? ref.watch(hoveredLineUpTargetProvider)
+        : null;
     final isLineUpHovered =
         lineUpId != null && (hoverTarget?.matchesAgent(lineUpId!) ?? false);
 
@@ -183,34 +190,38 @@ class AgentWidget extends ConsumerWidget {
     );
 
     final scaledSize = coordinateSystem.scale(agentSize);
-    final deleteTarget = lineUpId != null
-        ? HoveredDeleteTarget.lineup(id: lineUpId!, ownerToken: Object())
-        : (id?.isNotEmpty ?? false)
-            ? HoveredDeleteTarget.agent(id: id!, ownerToken: Object())
+    final deleteTarget = !canInteract
+        ? null
+        : lineUpId != null
+            ? HoveredDeleteTarget.lineup(id: lineUpId!, ownerToken: Object())
+            : (id?.isNotEmpty ?? false)
+                ? HoveredDeleteTarget.agent(id: id!, ownerToken: Object())
+                : null;
+    final placedAgentNode =
+        canInteract && lineUpId == null && (id?.isNotEmpty ?? false)
+            ? ref.watch(
+                agentProvider.select((agents) {
+                  for (final entry in agents) {
+                    if (entry.id == id) return entry;
+                  }
+                  return null;
+                }),
+              )
             : null;
-    final placedAgentNode = lineUpId == null && (id?.isNotEmpty ?? false)
-        ? ref.watch(
-            agentProvider.select((agents) {
-              for (final entry in agents) {
-                if (entry.id == id) return entry;
-              }
-              return null;
-            }),
-          )
-        : null;
     final plainAgent = placedAgentNode is PlacedAgent ? placedAgentNode : null;
     final viewConeAgent =
         placedAgentNode is PlacedViewConeAgent ? placedAgentNode : null;
-    final visionGeometry = viewConeAgent == null || isScreenshot
+    final visionGeometry = viewConeAgent == null || mapState == null
         ? null
         : ref
             .watch(viewConeGeometryProvider(mapState.currentMap))
             .asData
             ?.value;
-    final viewConeDebugEnabled = ref.watch(viewConeDebugProvider);
+    final viewConeDebugEnabled =
+        viewConeAgent == null ? false : ref.watch(viewConeDebugProvider);
 
     final contextMenuItems = <ShadContextMenuItem>[
-      if (!isScreenshot)
+      if (canInteract)
         ShadContextMenuItem.raw(
           variant: ShadContextMenuItemVariant.primary,
           height: 36,
@@ -225,13 +236,13 @@ class AgentWidget extends ConsumerWidget {
             mapScale: mapScale,
           ),
         ),
-      if (!isScreenshot && viewConeAgent != null && visionGeometry != null)
+      if (canInteract && viewConeAgent != null && visionGeometry != null)
         buildViewConeElevationMenuItem(
           geometry: visionGeometry,
           selectedElevation: viewConeAgent.visionElevation,
           automaticElevation: visionGeometry
               .layerForPosition(
-                isAttack: mapState.isAttack,
+                isAttack: mapState!.isAttack,
                 position: viewConeAgent.position +
                     coordinateSystem.virtualOffsetToWorld(
                       Offset(agentSize / 2, agentSize / 2),
@@ -245,13 +256,13 @@ class AgentWidget extends ConsumerWidget {
                 );
           },
         ),
-      if (!isScreenshot && viewConeAgent != null && visionGeometry != null)
+      if (canInteract && viewConeAgent != null && visionGeometry != null)
         buildViewConeDebugMenuItem(
           enabled: viewConeDebugEnabled,
           onChanged: (enabled) =>
               ref.read(viewConeDebugProvider.notifier).state = enabled,
         ),
-      if (lineUpId != null)
+      if (canInteract && lineUpId != null)
         ShadContextMenuItem(
           leading: const Icon(LucideIcons.plus),
           child: const Text('Add Lineup Item'),
@@ -268,7 +279,7 @@ class AgentWidget extends ConsumerWidget {
             ref.read(lineUpProvider.notifier).startNewItemForGroup(lineUpId!);
           },
         ),
-      if (lineUpId != null)
+      if (canInteract && lineUpId != null)
         ShadContextMenuItem(
           leading: Icon(
             Icons.delete,
@@ -279,7 +290,10 @@ class AgentWidget extends ConsumerWidget {
             ref.read(lineUpProvider.notifier).deleteGroupById(lineUpId!);
           },
         ),
-      if (lineUpId == null && plainAgent != null && plainAgent.id.isNotEmpty)
+      if (canInteract &&
+          lineUpId == null &&
+          plainAgent != null &&
+          plainAgent.id.isNotEmpty)
         ShadContextMenuItem(
           leading: const Icon(LucideIcons.plus),
           child: const Text('Create Lineup'),
@@ -295,7 +309,7 @@ class AgentWidget extends ConsumerWidget {
     Widget agentCard;
     // Use Ink + InkWell so the ripple shows on top of the background
 
-    if (isLineUp || isScreenshot) {
+    if (isLineUp || !canInteract) {
       agentCard = Container(
         decoration: decoration,
         width: scaledSize,
@@ -322,6 +336,10 @@ class AgentWidget extends ConsumerWidget {
           ),
         ),
       );
+    }
+
+    if (!canInteract) {
+      return RepaintBoundary(child: agentCard);
     }
 
     return MouseWatch(

--- a/lib/widgets/draggable_widgets/agents/placed_circle_agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/placed_circle_agent_widget.dart
@@ -52,10 +52,12 @@ class CircleAgentComposite extends ConsumerWidget {
     super.key,
     required this.agent,
     this.forcedAgentSize,
+    this.isInteractive = true,
   });
 
   final PlacedCircleAgent agent;
   final double? forcedAgentSize;
+  final bool isInteractive;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -100,6 +102,7 @@ class CircleAgentComposite extends ConsumerWidget {
               id: agent.id,
               agent: AgentData.agents[agent.type]!,
               forcedAgentSize: agentSize,
+              isInteractive: isInteractive,
             ),
           ),
         ],
@@ -228,6 +231,7 @@ class _PlacedCircleAgentWidgetState
                   child: CircleAgentComposite(
                     agent: current.copyWith(diameterMeters: diameterMeters),
                     forcedAgentSize: agentSize,
+                    isInteractive: false,
                   ),
                 ),
               ),

--- a/lib/widgets/draggable_widgets/agents/placed_view_cone_agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/placed_view_cone_agent_widget.dart
@@ -51,6 +51,7 @@ class ViewConeAgentComposite extends ConsumerWidget {
     this.forcedAgentSize,
     this.applyRotation = true,
     this.clipToGeometry = true,
+    this.isInteractive = true,
   });
 
   final PlacedViewConeAgent agent;
@@ -59,6 +60,7 @@ class ViewConeAgentComposite extends ConsumerWidget {
   final double? forcedAgentSize;
   final bool applyRotation;
   final bool clipToGeometry;
+  final bool isInteractive;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -115,6 +117,7 @@ class ViewConeAgentComposite extends ConsumerWidget {
                 id: agent.id,
                 agent: AgentData.agents[agent.type]!,
                 forcedAgentSize: agentSize,
+                isInteractive: isInteractive,
               ),
             ),
           ),
@@ -279,6 +282,7 @@ class _PlacedViewConeAgentWidgetState
                 length: localLength,
                 forcedAgentSize: agentSize,
                 clipToGeometry: false,
+                isInteractive: false,
               ),
             ),
           ),

--- a/lib/widgets/hovered_map_item_name_card.dart
+++ b/lib/widgets/hovered_map_item_name_card.dart
@@ -25,7 +25,6 @@ class _HoveredMapItemNameCardState
 
   Timer? _hideTimer;
   String? _visibleName;
-  int _visibleNameVersion = 0;
   late final List<ProviderSubscription<dynamic>> _subscriptions;
 
   @override
@@ -148,7 +147,6 @@ class _HoveredMapItemNameCardState
       _hideTimer = null;
       if (_visibleName != nextName) {
         setState(() {
-          _visibleNameVersion++;
           _visibleName = nextName;
         });
       }
@@ -176,7 +174,10 @@ class _HoveredMapItemNameCardState
         switchOutCurve: Curves.easeOutCubic,
         child: shouldShow
             ? IntrinsicWidth(
-                key: ValueKey('hovered-map-item-$_visibleNameVersion'),
+                // Keep the same child across name changes. AnimatedSwitcher
+                // should animate the card appearing and disappearing, not
+                // stack outgoing cards while a drag crosses several items.
+                key: const ValueKey('hovered-map-item-name'),
                 child: ConstrainedBox(
                   constraints: const BoxConstraints(
                     minWidth: 48,

--- a/lib/widgets/mouse_watch.dart
+++ b/lib/widgets/mouse_watch.dart
@@ -322,6 +322,14 @@ class _MouseWatchState extends ConsumerState<MouseWatch> {
     );
   }
 
+  void _updateLineUpHoverState(bool isHovered) {
+    // Only lineup widgets use this local state to control their notes portal.
+    // Regular map widgets still publish their hovered delete target, but do
+    // not need to rebuild just because a drag crossed their hitbox.
+    if (widget.lineUpId == null || isMouseInRegion == isHovered) return;
+    setState(() => isMouseInRegion = isHovered);
+  }
+
   @override
   Widget build(BuildContext context) {
     if (CoordinateSystem.instance.isScreenshot) {
@@ -389,15 +397,11 @@ class _MouseWatchState extends ConsumerState<MouseWatch> {
           }
         }
         _publishHoveredDeleteTarget();
-        setState(() {
-          isMouseInRegion = true;
-        });
+        _updateLineUpHoverState(true);
       },
       onExit: (_) {
         _scheduleHoverCleanup();
-        setState(() {
-          isMouseInRegion = false;
-        });
+        _updateLineUpHoverState(false);
       },
       child: KeyedSubtree(
         key: _hitboxKey,

--- a/lib/widgets/page_transition_overlay.dart
+++ b/lib/widgets/page_transition_overlay.dart
@@ -546,6 +546,7 @@ class PlacedWidgetPreview {
         state: w.state,
         deadStateProgress: deadStateProgress,
         forcedAgentSize: agentSize,
+        isInteractive: false,
       );
     }
     if (w is PlacedViewConeAgent) {
@@ -557,12 +558,14 @@ class PlacedWidgetPreview {
         rotation: rotation ?? w.rotation,
         length: length ?? w.length,
         forcedAgentSize: agentSize,
+        isInteractive: false,
       );
     }
     if (w is PlacedCircleAgent) {
       return CircleAgentComposite(
         agent: w.copyWith(diameterMeters: customDiameter ?? w.diameterMeters),
         forcedAgentSize: agentSize,
+        isInteractive: false,
       );
     }
     if (w is PlacedAbility) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -389,6 +389,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -532,6 +537,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   get_it:
     dependency: transitive
     description:
@@ -628,6 +638,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.7.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: transitive
     description:
@@ -892,6 +907,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1081,6 +1104,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1297,6 +1328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependency_overrides:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   hive_ce_generator: ^1.8.2
   # riverpod_generator: ^2.6.4
   build_runner: ^2.4.14

--- a/test/hovered_map_item_name_card_test.dart
+++ b/test/hovered_map_item_name_card_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/providers/agent_provider.dart';
+import 'package:icarus/providers/hovered_delete_target_provider.dart';
+import 'package:icarus/widgets/hovered_map_item_name_card.dart';
+
+void main() {
+  testWidgets('name changes update one visible card without stacking fades',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(agentProvider.notifier).fromHive([
+      PlacedAgent(
+        id: 'jett',
+        type: AgentType.jett,
+        position: Offset.zero,
+      ),
+      PlacedAgent(
+        id: 'sova',
+        type: AgentType.sova,
+        position: Offset.zero,
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: HoveredMapItemNameCard()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    container.read(hoveredDeleteTargetProvider.notifier).state =
+        HoveredDeleteTarget.agent(id: 'jett', ownerToken: Object());
+    await tester.pump();
+    expect(find.text('Jett'), findsOneWidget);
+
+    container.read(hoveredDeleteTargetProvider.notifier).state =
+        HoveredDeleteTarget.agent(id: 'sova', ownerToken: Object());
+    await tester.pump();
+
+    expect(find.text('Sova'), findsOneWidget);
+    expect(find.byType(IntrinsicWidth), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('hovered-map-item-name')),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/page_transition_overlay_test.dart
+++ b/test/page_transition_overlay_test.dart
@@ -12,6 +12,7 @@ import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/transition_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/view_cone_widget.dart';
+import 'package:icarus/widgets/mouse_watch.dart';
 import 'package:icarus/widgets/page_transition_overlay.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -70,6 +71,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(ColorFiltered), findsOneWidget);
+    expect(find.byType(MouseWatch), findsNothing);
 
     await tester.pumpWidget(
       UncontrolledProviderScope(
@@ -127,8 +129,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final ink = tester.widget<Ink>(find.byType(Ink));
-    final decoration = ink.decoration! as BoxDecoration;
+    final agentContainer = tester
+        .widgetList<Container>(find.byType(Container))
+        .singleWhere((widget) => widget.decoration is BoxDecoration);
+    final decoration = agentContainer.decoration! as BoxDecoration;
     expect(
       decoration.color,
       Color.lerp(Settings.allyBGColor, _expectedMutedAllyBgColor, 0.5),

--- a/test_driver/performance_test.dart
+++ b/test_driver/performance_test.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver(
+      responseDataCallback: (data) async {
+        if (data == null) return;
+
+        for (final entry in data.entries) {
+          await writeResponseData(
+            entry.value as Map<String, dynamic>,
+            testOutputFilename: entry.key,
+          );
+        }
+      },
+    );


### PR DESCRIPTION
﻿## Summary

- stop ordinary map hitboxes from rebuilding on every drag enter/exit while preserving lineup note hover state
- keep the hovered-item card mounted across name changes so rapid crossings do not accumulate outgoing `AnimatedSwitcher` children
- render agent drag feedback and page-transition previews as explicitly non-interactive, skipping MouseWatch, Ink/Material hover machinery, context-menu construction, and irrelevant provider subscriptions
- add a repeatable Windows profile-mode benchmark and focused regression coverage

## Root cause

Dragging across placed agents crossed multiple hover regions. Every crossing rebuilt a `MouseWatch` even though ordinary map widgets do not use its local hover state, and every hovered-name change got a new key, retaining an outgoing shadowed/IntrinsicWidth card for the duration of the transition.

At the same time, the moving agent feedback was a complete interactive `AgentWidget`. It constructed input and context-menu infrastructure that could never be used. The same unnecessary work also occurred for agent previews during page transitions.

## Profile results

Measured on Windows with Flutter 3.44.4 in profile mode at a fixed 1200?675 viewport. The fixture verifies drag feedback from sources at both ends, warms image/raster caches, places 12 agents, then records six alternating 72-frame mouse drags across them.

Command:

```powershell
flutter drive `
  --driver=test_driver/performance_test.dart `
  --target=integration_test/map_drag_performance_test.dart `
  --profile `
  -d windows
```

| Build metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Average | 0.177 ms | 0.125 ms | -29.4% |
| p90 | 0.337 ms | 0.245 ms | -27.3% |
| p99 | 0.525 ms | 0.426 ms | -18.9% |
| Worst | 0.657 ms | 0.580 ms | -11.7% |
| New-gen GC | 60 | 42 | -30.0% |
| Old-gen GC | 4 | 2 | -50.0% |
| Missed build budgets | 0 | 0 | unchanged |

These before/after runs used the corrected bidirectional fixture on the parent and PR commits respectively. Windows returned zero-valued raster durations through `FrameTiming`, so the checked-in harness documents that limitation and keeps raster investigation routed to a DevTools timeline.

## Validation

- `flutter drive --driver=test_driver/performance_test.dart --target=integration_test/map_drag_performance_test.dart --profile -d windows`
- `flutter test` ? 348 passed, 1 existing skip
- focused hover, transition, lineup, and attached-view-cone drag feedback tests
- `flutter analyze` ? no new findings; two existing info-level findings remain in `pages_bar.dart` and `tmp/verify/seed_pr98_demo.dart`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows map-interaction performance benchmarks with drag simulations and frame/GC metrics.
  * Added instructions for running benchmarks, locating results, and comparing raster timing.

* **Bug Fixes**
  * Improved non-interactive previews and drag feedback by disabling unavailable controls and hover behavior.
  * Reduced unnecessary widget rebuilds during hover interactions.
  * Improved hovered name transitions to prevent stacked cards or animations.

* **Tests**
  * Added coverage for hovered name updates, transition overlays, and performance reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
