### PR TITLE
Fix page control alignment

### DIFF
--- a/lib/widgets/pages_bar.dart
+++ b/lib/widgets/pages_bar.dart
@@ -12,7 +12,12 @@ import 'package:icarus/widgets/dialogs/confirm_alert_dialog.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 const double _pagesBarCornerRadius = 12;
-const double _pagesBarInnerButtonRadius = 6;
+const double _pagesBarFooterHeight = 48;
+const double _pagesBarControlInset = 8;
+const double _pagesBarControlSize =
+    _pagesBarFooterHeight - (2 * _pagesBarControlInset);
+const double _pagesBarInnerButtonRadius =
+    _pagesBarCornerRadius - _pagesBarControlInset;
 
 class PagesBar extends ConsumerStatefulWidget {
   const PagesBar({super.key});
@@ -382,10 +387,10 @@ class _CollapsedPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return SizedBox(
-      height: 48,
+      height: _pagesBarFooterHeight,
       child: Row(
         children: [
-          const SizedBox(width: 8),
+          const SizedBox(width: _pagesBarControlInset),
           _SquareIconButton(
             icon: Icons.add,
             onTap: onAdd,
@@ -405,9 +410,17 @@ class _CollapsedPill extends StatelessWidget {
             ),
           ),
           ShadIconButton.ghost(
+            width: _pagesBarControlSize,
+            height: _pagesBarControlSize,
+            padding: EdgeInsets.zero,
             foregroundColor: Colors.white,
             onPressed: onToggle,
             icon: const Icon(Icons.keyboard_arrow_down, color: Colors.white),
+            decoration: ShadDecoration(
+              border: ShadBorder(
+                radius: BorderRadius.circular(_pagesBarInnerButtonRadius),
+              ),
+            ),
           ),
         ],
       ),
@@ -450,7 +463,8 @@ class _ExpandedPanel extends ConsumerWidget {
   static const double _rowHeight = 40; // each page tile height
   static const double _verticalSpacing = 10; // separator height
   static const double _resizeHandleHeight = 8;
-  static const double _headerFooterHeight = 48 + 1; // bottom bar + divider
+  static const double _headerFooterHeight =
+      _pagesBarFooterHeight + 1; // bottom bar + divider
   static const double _topPadding = 0; // handle + gap should match side inset
   static const double _bottomPadding = 0; // list bottom padding inside Expanded
 
@@ -576,10 +590,10 @@ class _ExpandedPanel extends ConsumerWidget {
           ),
           Divider(height: 1, color: Settings.tacticalVioletTheme.border),
           SizedBox(
-            height: 48,
+            height: _pagesBarFooterHeight,
             child: Row(
               children: [
-                const SizedBox(width: 8),
+                const SizedBox(width: _pagesBarControlInset),
                 _SquareIconButton(
                   icon: Icons.add,
                   onTap: onAdd,
@@ -589,10 +603,20 @@ class _ExpandedPanel extends ConsumerWidget {
                 ),
                 const Spacer(),
                 ShadIconButton.ghost(
+                  width: _pagesBarControlSize,
+                  height: _pagesBarControlSize,
+                  padding: EdgeInsets.zero,
                   foregroundColor: Colors.white,
                   onPressed: onCollapse,
                   icon:
                       const Icon(Icons.keyboard_arrow_up, color: Colors.white),
+                  decoration: ShadDecoration(
+                    border: ShadBorder(
+                      radius: BorderRadius.circular(
+                        _pagesBarInnerButtonRadius,
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -938,8 +962,9 @@ class _SquareIconButton extends StatelessWidget {
         hoverBackgroundColor: color,
         foregroundColor: Colors.white,
         icon: Icon(icon),
-        width: 36,
-        height: 36,
+        width: _pagesBarControlSize,
+        height: _pagesBarControlSize,
+        padding: EdgeInsets.zero,
         onPressed: onTap,
         decoration: ShadDecoration(
           border: ShadBorder(
@@ -954,8 +979,8 @@ class _SquareIconButton extends StatelessWidget {
     }
 
     return SizedBox(
-      width: 36,
-      height: 36,
+      width: _pagesBarControlSize,
+      height: _pagesBarControlSize,
       child: Stack(
         clipBehavior: Clip.none,
         children: [

--- a/lib/widgets/sidebar_widgets/tool_grid.dart
+++ b/lib/widgets/sidebar_widgets/tool_grid.dart
@@ -115,7 +115,7 @@ class ToolGrid extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Padding(
-          padding: EdgeInsets.all(16.0),
+          padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
           child: Text(
             "Tools",
             style: TextStyle(fontSize: 20),


### PR DESCRIPTION
## What changed

- give the new-page and caret controls the same 8px inset and 32px footprint
- derive the 4px inner control radius from the page bar's 12px outer radius and 8px inset
- apply the geometry consistently in collapsed and expanded page-bar states
- reduce the Tools heading-to-grid spacing from 24px to 16px

## Why

The caret used the Shad icon button's 40px default while the new-page control was 36px inside a 48px bar. That produced mismatched 4px and 6px vertical insets, and the independent 6px control radius did not follow the outer-radius-minus-inset relationship.

## Impact

The page controls now align to the same pixel grid and their nested corners remain visually concentric. The tools panel also matches the 16px section rhythm used by the Agents area.

## Validation

- `dart analyze lib/widgets/pages_bar.dart lib/widgets/sidebar_widgets/tool_grid.dart`
  - no errors or warnings
  - one existing informational deprecation for `ReorderableListView.onReorder`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sizing consistency for page navigation controls and footer layouts.
  * Standardized button padding and rounded styling.
  * Refined spacing around the Tools section header.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->