### PR TITLE
Add inline page duplication semantics

### DIFF
--- a/lib/const/folder_icons.dart
+++ b/lib/const/folder_icons.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:icarus/const/custom_icons.dart';
 
-const int folderIconRegistryVersion = 94;
+const int folderIconRegistryVersion = 95;
 
 enum FolderIconRenderKind {
   material,

--- a/lib/const/settings.dart
+++ b/lib/const/settings.dart
@@ -100,7 +100,7 @@ class Settings {
   static final Uri dicordLink = Uri.parse("https://discord.gg/PN2uKwCqYB");
 
   static const Duration autoSaveOffset = Duration(seconds: 15);
-  static const int versionNumber = 94;
+  static const int versionNumber = 95;
   static const String versionName = "4.5.1";
   static final Uri desktopUpdaterArchiveUrl =
       buildDesktopUpdaterArchiveUrl(kResolvedUpdateChannel);

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -972,6 +972,7 @@ class StrategyPageAdapter extends TypeAdapter<StrategyPage> {
     return StrategyPage(
       id: fields[0] as String,
       name: fields[2] as String,
+      isAutoNamed: fields[14] == null ? false : fields[14] as bool,
       drawingData: (fields[3] as List).cast<DrawingElement>(),
       agentData: (fields[4] as List).cast<PlacedAgentNode>(),
       abilityData: (fields[5] as List).cast<PlacedAbility>(),
@@ -992,7 +993,7 @@ class StrategyPageAdapter extends TypeAdapter<StrategyPage> {
   @override
   void write(BinaryWriter writer, StrategyPage obj) {
     writer
-      ..writeByte(13)
+      ..writeByte(14)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -1018,7 +1019,9 @@ class StrategyPageAdapter extends TypeAdapter<StrategyPage> {
       ..writeByte(11)
       ..write(obj.lineUps)
       ..writeByte(12)
-      ..write(obj.lineUpGroups);
+      ..write(obj.lineUpGroups)
+      ..writeByte(14)
+      ..write(obj.isAutoNamed);
   }
 
   @override

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -972,7 +972,7 @@ class StrategyPageAdapter extends TypeAdapter<StrategyPage> {
     return StrategyPage(
       id: fields[0] as String,
       name: fields[2] as String,
-      isAutoNamed: fields[14] == null ? false : fields[14] as bool,
+      isAutoNamed: fields[14] as bool?,
       drawingData: (fields[3] as List).cast<DrawingElement>(),
       agentData: (fields[4] as List).cast<PlacedAgentNode>(),
       abilityData: (fields[5] as List).cast<PlacedAbility>(),

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -345,7 +345,7 @@ types:
         index: 6
   StrategyPage:
     typeId: 20
-    nextIndex: 14
+    nextIndex: 15
     fields:
       id:
         index: 0
@@ -373,6 +373,8 @@ types:
         index: 11
       lineUpGroups:
         index: 12
+      isAutoNamed:
+        index: 14
   LineUp:
     typeId: 21
     nextIndex: 6

--- a/lib/migrations/page_name_provenance_migration.dart
+++ b/lib/migrations/page_name_provenance_migration.dart
@@ -6,11 +6,11 @@ class PageNameProvenanceMigration {
   static List<StrategyPage> migratePages({
     required List<StrategyPage> pages,
   }) {
+    // Historical pages have no trusted signal that distinguishes an automatic
+    // "Page N" from a custom name with the same text. Preserve null provenance
+    // so structural changes never rewrite a name based on a guess.
     return [
-      for (final page in pages)
-        page.copyWith(
-          isAutoNamed: page.name == 'Page ${page.sortIndex + 1}',
-        ),
+      for (final page in pages) page.copyWith(),
     ];
   }
 }

--- a/lib/migrations/page_name_provenance_migration.dart
+++ b/lib/migrations/page_name_provenance_migration.dart
@@ -1,0 +1,16 @@
+import 'package:icarus/providers/strategy_page.dart';
+
+class PageNameProvenanceMigration {
+  static const int version = 95;
+
+  static List<StrategyPage> migratePages({
+    required List<StrategyPage> pages,
+  }) {
+    return [
+      for (final page in pages)
+        page.copyWith(
+          isAutoNamed: page.name == 'Page ${page.sortIndex + 1}',
+        ),
+    ];
+  }
+}

--- a/lib/providers/strategy_page.dart
+++ b/lib/providers/strategy_page.dart
@@ -18,6 +18,7 @@ class StrategyPage extends HiveObject {
   final String id;
   final int sortIndex;
   final String name;
+  final bool isAutoNamed;
   final List<DrawingElement> drawingData;
   final List<PlacedAgentNode> agentData;
   final List<PlacedAbility> abilityData;
@@ -53,6 +54,7 @@ class StrategyPage extends HiveObject {
   StrategyPage({
     required this.id,
     required this.name,
+    this.isAutoNamed = false,
     required this.drawingData,
     required this.agentData,
     required this.abilityData,
@@ -79,6 +81,7 @@ class StrategyPage extends HiveObject {
     String? id,
     int? sortIndex,
     String? name,
+    bool? isAutoNamed,
     List<DrawingElement>? drawingData,
     List<PlacedAgentNode>? agentData,
     List<PlacedAbility>? abilityData,
@@ -99,6 +102,7 @@ class StrategyPage extends HiveObject {
       id: id ?? this.id,
       sortIndex: sortIndex ?? this.sortIndex,
       name: name ?? this.name,
+      isAutoNamed: isAutoNamed ?? this.isAutoNamed,
       drawingData: DrawingProvider.fromJson(
           DrawingProvider.objectToJson(drawingData ?? this.drawingData)),
       agentData: AgentProvider.fromJson(AgentProvider.objectToJson(
@@ -128,6 +132,7 @@ class StrategyPage extends HiveObject {
                "id": "$id",
                "sortIndex": "$sortIndex",
                "name": "$name",
+               "isAutoNamed": $isAutoNamed,
                "drawingData": ${DrawingProvider.objectToJson(drawingData)},
                "agentData": ${AgentProvider.objectToJson(agentData)},
                "abilityData": ${AbilityProvider.objectToJson(abilityData)},
@@ -190,6 +195,8 @@ class StrategyPage extends HiveObject {
       id: json['id'],
       sortIndex: int.parse(json['sortIndex']),
       name: json['name'],
+      isAutoNamed:
+          json['isAutoNamed'] == true || json['isAutoNamed'] == 'true',
       drawingData: DrawingProvider.fromJson(jsonEncode(json['drawingData'])),
       agentData: AgentProvider.fromJson(jsonEncode(json['agentData'])),
       abilityData: AbilityProvider.fromJson(jsonEncode(json['abilityData'])),

--- a/lib/providers/strategy_page.dart
+++ b/lib/providers/strategy_page.dart
@@ -18,7 +18,9 @@ class StrategyPage extends HiveObject {
   final String id;
   final int sortIndex;
   final String name;
-  final bool isAutoNamed;
+  // Null means this page predates persisted name provenance. Treat it as
+  // custom so structural changes never overwrite a name we cannot classify.
+  final bool? isAutoNamed;
   final List<DrawingElement> drawingData;
   final List<PlacedAgentNode> agentData;
   final List<PlacedAbility> abilityData;
@@ -54,7 +56,7 @@ class StrategyPage extends HiveObject {
   StrategyPage({
     required this.id,
     required this.name,
-    this.isAutoNamed = false,
+    this.isAutoNamed,
     required this.drawingData,
     required this.agentData,
     required this.abilityData,
@@ -145,7 +147,11 @@ class StrategyPage extends HiveObject {
                }
              ''';
 
-    return jsonDecode(data);
+    final result = jsonDecode(data) as Map<String, dynamic>;
+    if (isAutoNamed == null) {
+      result.remove('isAutoNamed');
+    }
+    return result;
   }
 
   static Future<List<StrategyPage>> listFromJson(
@@ -172,6 +178,17 @@ class StrategyPage extends HiveObject {
       {required Map<String, dynamic> json,
       required String strategyID,
       required bool isZip}) async {
+    final bool? isAutoNamed;
+    if (!json.containsKey('isAutoNamed')) {
+      isAutoNamed = null;
+    } else if (json['isAutoNamed'] is bool) {
+      isAutoNamed = json['isAutoNamed'] as bool;
+    } else {
+      throw const FormatException(
+        'Strategy page isAutoNamed must be a boolean',
+      );
+    }
+
     List<PlacedImage> imageData = [];
 
     if (!kIsWeb) {
@@ -191,12 +208,12 @@ class StrategyPage extends HiveObject {
     } else {
       isAttack = false;
     }
+
     return StrategyPage(
       id: json['id'],
       sortIndex: int.parse(json['sortIndex']),
       name: json['name'],
-      isAutoNamed:
-          json['isAutoNamed'] == true || json['isAutoNamed'] == 'true',
+      isAutoNamed: isAutoNamed,
       drawingData: DrawingProvider.fromJson(jsonEncode(json['drawingData'])),
       agentData: AgentProvider.fromJson(jsonEncode(json['agentData'])),
       abilityData: AbilityProvider.fromJson(jsonEncode(json['abilityData'])),

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -973,6 +973,21 @@ class StrategyProvider extends Notifier<StrategyState> {
     );
   }
 
+  static List<StrategyPage> reindexPagesAfterStructuralChange(
+    List<StrategyPage> orderedPages,
+  ) {
+    return [
+      for (var i = 0; i < orderedPages.length; i++)
+        orderedPages[i].copyWith(
+          sortIndex: i,
+          name: orderedPages[i].name ==
+                  'Page ${orderedPages[i].sortIndex + 1}'
+              ? 'Page ${i + 1}'
+              : orderedPages[i].name,
+        ),
+    ];
+  }
+
   Future<void> reorderPage(int oldIndex, int newIndex) async {
     if (oldIndex == newIndex) return;
 
@@ -996,10 +1011,7 @@ class StrategyProvider extends Notifier<StrategyState> {
     final moved = ordered.removeAt(oldIndex);
     ordered.insert(newIndex, moved);
 
-    final reindexed = [
-      for (var i = 0; i < ordered.length; i++)
-        ordered[i].copyWith(sortIndex: i),
-    ];
+    final reindexed = reindexPagesAfterStructuralChange(ordered);
 
     final updated =
         strat.copyWith(pages: reindexed, lastEdited: DateTime.now());
@@ -1160,6 +1172,151 @@ class StrategyProvider extends Notifier<StrategyState> {
   ) =>
       TransitionPlanner.diff(prev, next);
 
+  List<PageTransitionDirection> copyDirectionsForPlacedWidget(
+    String widgetId,
+  ) {
+    if (widgetId.isEmpty ||
+        !Hive.isBoxOpen(HiveBoxNames.strategiesBox)) return const [];
+
+    final strat = Hive.box<StrategyData>(HiveBoxNames.strategiesBox).get(
+      state.id,
+    );
+    if (strat == null || strat.pages.length < 2) return const [];
+
+    final orderedPages = [...strat.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex));
+    final currentPageId = activePageID ?? state.activePageId;
+    final currentIndex = orderedPages.indexWhere(
+      (page) => page.id == currentPageId,
+    );
+    if (currentIndex < 0) return const [];
+
+    final directions = <PageTransitionDirection>[];
+    if (currentIndex > 0 &&
+        !_pageContainsPlacedWidget(orderedPages[currentIndex - 1], widgetId)) {
+      directions.add(PageTransitionDirection.backward);
+    }
+    if (currentIndex < orderedPages.length - 1 &&
+        !_pageContainsPlacedWidget(orderedPages[currentIndex + 1], widgetId)) {
+      directions.add(PageTransitionDirection.forward);
+    }
+    return directions;
+  }
+
+  Future<bool> copyPlacedWidgetToAdjacentPage({
+    required String widgetId,
+    required PageTransitionDirection direction,
+  }) async {
+    if (widgetId.isEmpty ||
+        !Hive.isBoxOpen(HiveBoxNames.strategiesBox)) return false;
+
+    await _syncCurrentPageToHive();
+
+    final box = Hive.box<StrategyData>(HiveBoxNames.strategiesBox);
+    final strat = box.get(state.id);
+    if (strat == null || strat.pages.length < 2) return false;
+
+    final orderedPages = [...strat.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex));
+    final currentPageId = activePageID ?? state.activePageId;
+    final currentIndex = orderedPages.indexWhere(
+      (page) => page.id == currentPageId,
+    );
+    if (currentIndex < 0) return false;
+
+    final targetIndex = switch (direction) {
+      PageTransitionDirection.backward => currentIndex - 1,
+      PageTransitionDirection.forward => currentIndex + 1,
+    };
+    if (targetIndex < 0 || targetIndex >= orderedPages.length) return false;
+
+    final sourcePage = orderedPages[currentIndex];
+    final targetPage = orderedPages[targetIndex];
+    if (_pageContainsPlacedWidget(targetPage, widgetId)) return false;
+
+    final updatedTarget = _copyPlacedWidgetBetweenPages(
+      widgetId: widgetId,
+      source: sourcePage,
+      target: targetPage,
+    );
+    if (updatedTarget == null) return false;
+
+    final updatedPages = [
+      for (final page in strat.pages)
+        if (page.id == targetPage.id) updatedTarget else page,
+    ];
+    final updated = strat.copyWith(
+      pages: updatedPages,
+      lastEdited: DateTime.now(),
+    );
+    await box.put(updated.id, updated);
+    return true;
+  }
+
+  static bool _pageContainsPlacedWidget(
+    StrategyPage page,
+    String widgetId,
+  ) {
+    return page.agentData.any((widget) => widget.id == widgetId) ||
+        page.abilityData.any((widget) => widget.id == widgetId) ||
+        page.textData.any((widget) => widget.id == widgetId) ||
+        page.imageData.any((widget) => widget.id == widgetId) ||
+        page.utilityData.any((widget) => widget.id == widgetId);
+  }
+
+  static StrategyPage? _copyPlacedWidgetBetweenPages({
+    required String widgetId,
+    required StrategyPage source,
+    required StrategyPage target,
+  }) {
+    final agentIndex = source.agentData.indexWhere(
+      (widget) => widget.id == widgetId,
+    );
+    if (agentIndex >= 0) {
+      return target.copyWith(
+        agentData: [...target.agentData, source.agentData[agentIndex]],
+      );
+    }
+
+    final abilityIndex = source.abilityData.indexWhere(
+      (widget) => widget.id == widgetId,
+    );
+    if (abilityIndex >= 0) {
+      return target.copyWith(
+        abilityData: [...target.abilityData, source.abilityData[abilityIndex]],
+      );
+    }
+
+    final textIndex = source.textData.indexWhere(
+      (widget) => widget.id == widgetId,
+    );
+    if (textIndex >= 0) {
+      return target.copyWith(
+        textData: [...target.textData, source.textData[textIndex]],
+      );
+    }
+
+    final imageIndex = source.imageData.indexWhere(
+      (widget) => widget.id == widgetId,
+    );
+    if (imageIndex >= 0) {
+      return target.copyWith(
+        imageData: [...target.imageData, source.imageData[imageIndex]],
+      );
+    }
+
+    final utilityIndex = source.utilityData.indexWhere(
+      (widget) => widget.id == widgetId,
+    );
+    if (utilityIndex >= 0) {
+      return target.copyWith(
+        utilityData: [...target.utilityData, source.utilityData[utilityIndex]],
+      );
+    }
+
+    return null;
+  }
+
   Future<void> addPage([String? name]) async {
     final box = Hive.box<StrategyData>(HiveBoxNames.strategiesBox);
 
@@ -1167,30 +1324,29 @@ class StrategyProvider extends Notifier<StrategyState> {
     await _syncCurrentPageToHive();
 
     final strat = box.get(state.id);
-    if (strat == null) return;
+    if (strat == null || strat.pages.isEmpty) return;
 
-    name ??= "Page ${strat.pages.length + 1}";
-    //TODO Make this function of the index
-    final newPage = strat.pages.last.copyWith(
+    final orderedPages = [...strat.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex));
+    final currentPageId = activePageID ?? state.activePageId;
+    final currentIndex = orderedPages.indexWhere(
+      (page) => page.id == currentPageId,
+    );
+    final sourceIndex =
+        currentIndex >= 0 ? currentIndex : orderedPages.length - 1;
+    final insertionIndex = sourceIndex + 1;
+    name ??= "Page ${insertionIndex + 1}";
+    final newPage = orderedPages[sourceIndex].copyWith(
       id: const Uuid().v4(),
       name: name,
-      sortIndex: strat.pages.length,
+      sortIndex: insertionIndex,
     );
 
-    // final newPage = StrategyPage(
-    //   id: const Uuid().v4(),
-    //   name: name,
-    //   drawingData: ,
-    //   agentData: const [],
-    //   abilityData: const [],
-    //   textData: const [],
-    //   imageData: const [],
-    //   utilityData: const [],
-    //   sortIndex: strat.pages.length, // corrected
-    // );
+    orderedPages.insert(insertionIndex, newPage);
+    final reindexed = reindexPagesAfterStructuralChange(orderedPages);
 
     final updated = strat.copyWith(
-      pages: [...strat.pages, newPage],
+      pages: reindexed,
       lastEdited: DateTime.now(),
     );
     await box.put(updated.id, updated);

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -22,6 +22,7 @@ import 'package:icarus/const/settings.dart';
 import 'package:icarus/migrations/ability_scale_migration.dart';
 import 'package:icarus/migrations/custom_circle_wrapper_migration.dart';
 import 'package:icarus/migrations/lineup_group_migration.dart';
+import 'package:icarus/migrations/page_name_provenance_migration.dart';
 import 'package:icarus/providers/ability_provider.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/agent_provider.dart';
@@ -598,7 +599,28 @@ class StrategyProvider extends Notifier<StrategyState> {
         migrateAbilityScale(worldMigrated, force: forceAbilityScale);
     final squareAoeMigrated = migrateSquareAoeCenter(abilityScaleMigrated);
     final customCircleMigrated = migrateCustomCircleWrapper(squareAoeMigrated);
-    return migrateLineUpGroups(customCircleMigrated);
+    final lineUpGroupMigrated = migrateLineUpGroups(customCircleMigrated);
+    return migratePageNameProvenance(
+      lineUpGroupMigrated,
+      force: strat.versionNumber < PageNameProvenanceMigration.version,
+    );
+  }
+
+  static StrategyData migratePageNameProvenance(StrategyData strat,
+      {bool force = false}) {
+    if (!force &&
+        strat.versionNumber >= PageNameProvenanceMigration.version) {
+      return strat;
+    }
+
+    final migratedPages =
+        PageNameProvenanceMigration.migratePages(pages: strat.pages);
+
+    return strat.copyWith(
+      pages: migratedPages,
+      versionNumber: Settings.versionNumber,
+      lastEdited: DateTime.now(),
+    );
   }
 
   static StrategyData migrateLineUpGroups(StrategyData strat,
@@ -647,6 +669,7 @@ class StrategyProvider extends Notifier<StrategyState> {
     final firstPage = StrategyPage(
       id: const Uuid().v4(),
       name: "Page 1",
+      isAutoNamed: true,
       // ignore: deprecated_member_use, deprecated_member_use_from_same_package
       drawingData: [...strat.drawingData],
       // ignore: deprecated_member_use, deprecated_member_use_from_same_package
@@ -980,8 +1003,7 @@ class StrategyProvider extends Notifier<StrategyState> {
       for (var i = 0; i < orderedPages.length; i++)
         orderedPages[i].copyWith(
           sortIndex: i,
-          name: orderedPages[i].name ==
-                  'Page ${orderedPages[i].sortIndex + 1}'
+          name: orderedPages[i].isAutoNamed
               ? 'Page ${i + 1}'
               : orderedPages[i].name,
         ),
@@ -1335,10 +1357,12 @@ class StrategyProvider extends Notifier<StrategyState> {
     final sourceIndex =
         currentIndex >= 0 ? currentIndex : orderedPages.length - 1;
     final insertionIndex = sourceIndex + 1;
+    final isAutoNamed = name == null;
     name ??= "Page ${insertionIndex + 1}";
     final newPage = orderedPages[sourceIndex].copyWith(
       id: const Uuid().v4(),
       name: name,
+      isAutoNamed: isAutoNamed,
       sortIndex: insertionIndex,
     );
 
@@ -3225,6 +3249,7 @@ class StrategyProvider extends Notifier<StrategyState> {
         StrategyPage(
           id: pageID,
           name: "Page 1",
+          isAutoNamed: true,
           drawingData: [],
           agentData: [],
           abilityData: [],

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -1003,7 +1003,7 @@ class StrategyProvider extends Notifier<StrategyState> {
       for (var i = 0; i < orderedPages.length; i++)
         orderedPages[i].copyWith(
           sortIndex: i,
-          name: orderedPages[i].isAutoNamed
+          name: orderedPages[i].isAutoNamed == true
               ? 'Page ${i + 1}'
               : orderedPages[i].name,
         ),

--- a/lib/widgets/draggable_widgets/ability/ability_visibility_context_menu.dart
+++ b/lib/widgets/draggable_widgets/ability/ability_visibility_context_menu.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_provider.dart';
 import 'package:icarus/providers/action_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 bool supportsAbilityVisibilityMenu(Ability? ability) {
@@ -31,13 +32,17 @@ List<ShadContextMenuItem>? buildAbilityContextMenuItems(
     lineUpGroupId: lineUpGroupId,
     lineUpItemId: lineUpItemId,
   );
+  final adjacentPageItems = lineUpGroupId == null && lineUpItemId == null
+      ? buildAdjacentPageCopyMenuItems(ref, ability.id)
+      : const <ShadContextMenuItem>[];
 
-  if (visibilityItems.isEmpty && !includeDelete) {
+  if (visibilityItems.isEmpty && adjacentPageItems.isEmpty && !includeDelete) {
     return null;
   }
 
   return [
     ...visibilityItems,
+    ...adjacentPageItems,
     if (includeDelete && lineUpGroupId != null && lineUpItemId != null)
       _buildDeleteItem(ref, lineUpGroupId, lineUpItemId),
   ];

--- a/lib/widgets/draggable_widgets/adjacent_page_copy_menu.dart
+++ b/lib/widgets/draggable_widgets/adjacent_page_copy_menu.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/transition_data.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+List<ShadContextMenuItem> buildAdjacentPageCopyMenuItems(
+  WidgetRef ref,
+  String widgetId,
+) {
+  if (widgetId.isEmpty) return const [];
+
+  final notifier = ref.read(strategyProvider.notifier);
+  final directions = notifier.copyDirectionsForPlacedWidget(widgetId);
+
+  return [
+    if (directions.contains(PageTransitionDirection.backward))
+      ShadContextMenuItem(
+        leading: const Icon(Icons.arrow_upward),
+        child: const Text('Copy to previous page'),
+        onPressed: () async {
+          await notifier.copyPlacedWidgetToAdjacentPage(
+            widgetId: widgetId,
+            direction: PageTransitionDirection.backward,
+          );
+        },
+      ),
+    if (directions.contains(PageTransitionDirection.forward))
+      ShadContextMenuItem(
+        leading: const Icon(Icons.arrow_downward),
+        child: const Text('Copy to next page'),
+        onPressed: () async {
+          await notifier.copyPlacedWidgetToAdjacentPage(
+            widgetId: widgetId,
+            direction: PageTransitionDirection.forward,
+          );
+        },
+      ),
+  ];
+}

--- a/lib/widgets/draggable_widgets/agents/agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/agent_widget.dart
@@ -263,8 +263,6 @@ class AgentWidget extends ConsumerWidget {
           onChanged: (enabled) =>
               ref.read(viewConeDebugProvider.notifier).state = enabled,
         ),
-      if (canInteract && lineUpId == null && placedAgentNode != null)
-        ...buildAdjacentPageCopyMenuItems(ref, placedAgentNode.id),
       if (canInteract && lineUpId != null)
         ShadContextMenuItem(
           leading: const Icon(LucideIcons.plus),
@@ -307,6 +305,8 @@ class AgentWidget extends ConsumerWidget {
             ref.read(lineUpProvider.notifier).startNewGroup(plainAgent);
           },
         ),
+      if (canInteract && lineUpId == null && placedAgentNode != null)
+        ...buildAdjacentPageCopyMenuItems(ref, placedAgentNode.id),
     ];
 
     Widget agentCard;

--- a/lib/widgets/draggable_widgets/agents/agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/agent_widget.dart
@@ -16,6 +16,7 @@ import 'package:icarus/providers/screenshot_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/providers/view_cone_debug_provider.dart';
 import 'package:icarus/providers/view_cone_geometry_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/view_cone_elevation_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
@@ -262,6 +263,8 @@ class AgentWidget extends ConsumerWidget {
           onChanged: (enabled) =>
               ref.read(viewConeDebugProvider.notifier).state = enabled,
         ),
+      if (canInteract && lineUpId == null && placedAgentNode != null)
+        ...buildAdjacentPageCopyMenuItems(ref, placedAgentNode.id),
       if (canInteract && lineUpId != null)
         ShadContextMenuItem(
           leading: const Icon(LucideIcons.plus),

--- a/lib/widgets/draggable_widgets/image/placed_image_builder.dart
+++ b/lib/widgets/draggable_widgets/image/placed_image_builder.dart
@@ -9,6 +9,7 @@ import 'package:icarus/providers/image_provider.dart';
 
 import 'package:icarus/providers/screen_zoom_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/draggable_widgets/image/image_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/image/scalable_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
@@ -144,6 +145,7 @@ class _PlacedImageBuilderState extends State<PlacedImageBuilder> {
 
   List<ShadContextMenuItem> _buildTagColorItems(WidgetRef ref) {
     return [
+      ...buildAdjacentPageCopyMenuItems(ref, widget.placedImage.id),
       ShadContextMenuItem(
         child: const Text('Reset tag to gray'),
         onPressed: () {

--- a/lib/widgets/draggable_widgets/image/placed_image_builder.dart
+++ b/lib/widgets/draggable_widgets/image/placed_image_builder.dart
@@ -145,7 +145,6 @@ class _PlacedImageBuilderState extends State<PlacedImageBuilder> {
 
   List<ShadContextMenuItem> _buildTagColorItems(WidgetRef ref) {
     return [
-      ...buildAdjacentPageCopyMenuItems(ref, widget.placedImage.id),
       ShadContextMenuItem(
         child: const Text('Reset tag to gray'),
         onPressed: () {
@@ -173,6 +172,7 @@ class _PlacedImageBuilderState extends State<PlacedImageBuilder> {
               },
             ),
           ),
+      ...buildAdjacentPageCopyMenuItems(ref, widget.placedImage.id),
     ];
   }
 

--- a/lib/widgets/draggable_widgets/text/placed_text_builder.dart
+++ b/lib/widgets/draggable_widgets/text/placed_text_builder.dart
@@ -150,7 +150,6 @@ class _PlacedTextBuilderState extends ConsumerState<PlacedTextBuilder> {
 
   List<ShadContextMenuItem> _buildTagColorItems() {
     return [
-      ...buildAdjacentPageCopyMenuItems(ref, widget.placedText.id),
       ShadContextMenuItem(
         child: const Text('Reset tag to gray'),
         onPressed: () {
@@ -179,6 +178,7 @@ class _PlacedTextBuilderState extends ConsumerState<PlacedTextBuilder> {
           },
         ),
       ),
+      ...buildAdjacentPageCopyMenuItems(ref, widget.placedText.id),
     ];
   }
 

--- a/lib/widgets/draggable_widgets/text/placed_text_builder.dart
+++ b/lib/widgets/draggable_widgets/text/placed_text_builder.dart
@@ -7,6 +7,7 @@ import 'package:icarus/providers/screen_zoom_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/providers/text_draft_provider.dart';
 import 'package:icarus/providers/text_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/draggable_widgets/text/text_scale_controller.dart';
 import 'package:icarus/widgets/draggable_widgets/text/text_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
@@ -149,6 +150,7 @@ class _PlacedTextBuilderState extends ConsumerState<PlacedTextBuilder> {
 
   List<ShadContextMenuItem> _buildTagColorItems() {
     return [
+      ...buildAdjacentPageCopyMenuItems(ref, widget.placedText.id),
       ShadContextMenuItem(
         child: const Text('Reset tag to gray'),
         onPressed: () {

--- a/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
 class CustomCircleUtilityWidget extends ConsumerWidget {
@@ -90,6 +91,9 @@ class CustomCircleUtilityWidget extends ConsumerWidget {
                 cursor: SystemMouseCursors.click,
                 deleteTarget: (id?.isNotEmpty ?? false)
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
+                    : null,
+                contextMenuItems: (id?.isNotEmpty ?? false)
+                    ? buildAdjacentPageCopyMenuItems(ref, id!)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
 class CustomRectangleUtilityWidget extends ConsumerWidget {
@@ -90,6 +91,9 @@ class CustomRectangleUtilityWidget extends ConsumerWidget {
                 cursor: SystemMouseCursors.click,
                 deleteTarget: (id?.isNotEmpty ?? false)
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
+                    : null,
+                contextMenuItems: (id?.isNotEmpty ?? false)
+                    ? buildAdjacentPageCopyMenuItems(ref, id!)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/image_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/image_utility_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
 class ImageUtilityWidget extends ConsumerWidget {
@@ -23,6 +24,9 @@ class ImageUtilityWidget extends ConsumerWidget {
       cursor: SystemMouseCursors.click,
       deleteTarget: (id?.isNotEmpty ?? false)
           ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
+          : null,
+      contextMenuItems: (id?.isNotEmpty ?? false)
+          ? buildAdjacentPageCopyMenuItems(ref, id!)
           : null,
       child: SvgPicture.asset(
         imagePath,

--- a/lib/widgets/draggable_widgets/utilities/role_icon_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/role_icon_utility_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/draggable_widgets/shared/framed_ability_icon_shell.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
@@ -24,6 +25,9 @@ class RoleIconUtilityWidget extends ConsumerWidget {
       cursor: SystemMouseCursors.click,
       deleteTarget: (id?.isNotEmpty ?? false)
           ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
+          : null,
+      contextMenuItems: (id?.isNotEmpty ?? false)
+          ? buildAdjacentPageCopyMenuItems(ref, id!)
           : null,
       child: FramedAbilityIconShell(
         size: size,

--- a/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
@@ -211,7 +211,6 @@ class ViewConeWidget extends ConsumerWidget {
     final elevationMenuItems = placedUtility == null
         ? null
         : [
-            ...buildAdjacentPageCopyMenuItems(ref, placedUtility.id),
             if (geometry != null)
               buildViewConeElevationMenuItem(
                 geometry: geometry,
@@ -234,6 +233,7 @@ class ViewConeWidget extends ConsumerWidget {
                 onChanged: (enabled) =>
                     ref.read(viewConeDebugProvider.notifier).state = enabled,
               ),
+            ...buildAdjacentPageCopyMenuItems(ref, placedUtility.id),
           ];
 
     return SizedBox(

--- a/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
@@ -13,6 +13,7 @@ import 'package:icarus/providers/utility_provider.dart';
 import 'package:icarus/providers/view_cone_debug_provider.dart';
 import 'package:icarus/providers/view_cone_geometry_provider.dart';
 import 'package:icarus/view_cone/vision_geometry.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/view_cone_elevation_menu.dart';
 
@@ -207,30 +208,33 @@ class ViewConeWidget extends ConsumerWidget {
       }
     }
 
-    final elevationMenuItems = placedUtility != null && geometry != null
-        ? [
-            buildViewConeElevationMenuItem(
-              geometry: geometry,
-              selectedElevation: placedUtility.visionElevation,
-              automaticElevation: geometry
-                  .layerForPosition(
-                    isAttack: ref.read(mapProvider).isAttack,
-                    position: resolvedWorldOrigin!,
-                  )
-                  .elevation,
-              onChanged: (elevation) {
-                ref
-                    .read(utilityProvider.notifier)
-                    .updateViewConeElevation(placedUtility!.id, elevation);
-              },
-            ),
-            buildViewConeDebugMenuItem(
-              enabled: debugEnabled,
-              onChanged: (enabled) =>
-                  ref.read(viewConeDebugProvider.notifier).state = enabled,
-            ),
-          ]
-        : null;
+    final elevationMenuItems = placedUtility == null
+        ? null
+        : [
+            ...buildAdjacentPageCopyMenuItems(ref, placedUtility.id),
+            if (geometry != null)
+              buildViewConeElevationMenuItem(
+                geometry: geometry,
+                selectedElevation: placedUtility.visionElevation,
+                automaticElevation: geometry
+                    .layerForPosition(
+                      isAttack: ref.read(mapProvider).isAttack,
+                      position: resolvedWorldOrigin!,
+                    )
+                    .elevation,
+                onChanged: (elevation) {
+                  ref
+                      .read(utilityProvider.notifier)
+                      .updateViewConeElevation(placedUtility!.id, elevation);
+                },
+              ),
+            if (geometry != null)
+              buildViewConeDebugMenuItem(
+                enabled: debugEnabled,
+                onChanged: (enabled) =>
+                    ref.read(viewConeDebugProvider.notifier).state = enabled,
+              ),
+          ];
 
     return SizedBox(
       width: totalWidth,

--- a/lib/widgets/pages_bar.dart
+++ b/lib/widgets/pages_bar.dart
@@ -256,12 +256,11 @@ class _PagesBarState extends ConsumerState<PagesBar> {
     if (confirm != true) return;
 
     final box = Hive.box<StrategyData>(HiveBoxNames.strategiesBox);
-    final remaining = [...strat.pages]..removeWhere((p) => p.id == page.id);
-    // Reindex sortIndex to keep dense ordering
-    final reindexed = [
-      for (var i = 0; i < remaining.length; i++)
-        remaining[i].copyWith(sortIndex: i),
-    ];
+    final remaining = [...strat.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex))
+      ..removeWhere((p) => p.id == page.id);
+    final reindexed =
+        StrategyProvider.reindexPagesAfterStructuralChange(remaining);
     final activeId = ref.read(strategyProvider.notifier).activePageID;
     final newActive = (activeId == page.id) ? reindexed.first.id : activeId;
 

--- a/lib/widgets/pages_bar.dart
+++ b/lib/widgets/pages_bar.dart
@@ -229,7 +229,7 @@ class _PagesBarState extends ConsumerState<PagesBar> {
     );
     if (newName == null ||
         newName.isEmpty ||
-        (newName == page.name && !page.isAutoNamed)) {
+        (newName == page.name && page.isAutoNamed == false)) {
       return;
     }
 

--- a/lib/widgets/pages_bar.dart
+++ b/lib/widgets/pages_bar.dart
@@ -227,12 +227,19 @@ class _PagesBarState extends ConsumerState<PagesBar> {
         ),
       ),
     );
-    if (newName == null || newName.isEmpty || newName == page.name) return;
+    if (newName == null ||
+        newName.isEmpty ||
+        (newName == page.name && !page.isAutoNamed)) {
+      return;
+    }
 
     final box = Hive.box<StrategyData>(HiveBoxNames.strategiesBox);
     final updatedPages = [
       for (final p in strat.pages)
-        if (p.id == page.id) p.copyWith(name: newName) else p,
+        if (p.id == page.id)
+          p.copyWith(name: newName, isAutoNamed: false)
+        else
+          p,
     ];
     final updated =
         strat.copyWith(pages: updatedPages, lastEdited: DateTime.now());

--- a/test/strategy_integrity_test.dart
+++ b/test/strategy_integrity_test.dart
@@ -346,7 +346,7 @@ void main() {
       expect(restored.lineUps, hasLength(1));
       expect(restored.lineUps.single.id, legacyLineUp.id);
       expect(restored.lineUpGroups, hasLength(1));
-      expect(restored.isAutoNamed, isFalse);
+      expect(restored.isAutoNamed, isNull);
       expect(restored.lineUpGroups.single.id, legacyLineUp.id);
       expect(restored.lineUpGroups.single.items, hasLength(1));
       expect(
@@ -430,6 +430,78 @@ void main() {
 
       expect(restored.name, 'Page 2');
       expect(restored.isAutoNamed, isFalse);
+    });
+
+    test('legacy custom Page N stays unresolved and is never renumbered',
+        () async {
+      final page = StrategyPage(
+        id: 'legacy-custom-page-2',
+        sortIndex: 1,
+        name: 'Page 2',
+        drawingData: const [],
+        agentData: const [],
+        abilityData: const [],
+        textData: const [],
+        imageData: const [],
+        utilityData: const [],
+        isAttack: true,
+        settings: StrategySettings(),
+      );
+      final legacyJson = page.toJson('strategy-id');
+      expect(legacyJson, isNot(contains('isAutoNamed')));
+      final restored = await StrategyPage.fromJson(
+        json: legacyJson,
+        strategyID: 'strategy-id',
+        isZip: true,
+      );
+      final oldStrategy = StrategyData(
+        id: 'legacy-strategy',
+        name: 'Legacy Strategy',
+        mapData: MapValue.ascent,
+        versionNumber: Settings.versionNumber - 1,
+        lastEdited: DateTime.utc(2026, 1, 1),
+        folderID: null,
+        pages: [restored],
+      );
+
+      final migrated = StrategyProvider.migrateToCurrentVersion(oldStrategy);
+      final reindexed = StrategyProvider.reindexPagesAfterStructuralChange(
+        migrated.pages,
+      );
+
+      expect(migrated.pages.single.isAutoNamed, isNull);
+      expect(reindexed.single.name, 'Page 2');
+    });
+
+    test('page-name provenance rejects non-boolean export values', () async {
+      final page = StrategyPage(
+        id: 'invalid-provenance',
+        sortIndex: 0,
+        name: 'Page 1',
+        drawingData: const [],
+        agentData: const [],
+        abilityData: const [],
+        textData: const [],
+        imageData: const [],
+        utilityData: const [],
+        isAttack: true,
+        settings: StrategySettings(),
+      );
+
+      for (final invalidValue in <Object?>['true', 'yes', 1, null]) {
+        final json = page.toJson('strategy-id')
+          ..['isAutoNamed'] = invalidValue;
+
+        await expectLater(
+          StrategyPage.fromJson(
+            json: json,
+            strategyID: 'strategy-id',
+            isZip: true,
+          ),
+          throwsFormatException,
+          reason: 'accepted invalid isAutoNamed value: $invalidValue',
+        );
+      }
     });
 
     test('current schema export -> import preserves canonical structure',

--- a/test/strategy_integrity_test.dart
+++ b/test/strategy_integrity_test.dart
@@ -346,6 +346,7 @@ void main() {
       expect(restored.lineUps, hasLength(1));
       expect(restored.lineUps.single.id, legacyLineUp.id);
       expect(restored.lineUpGroups, hasLength(1));
+      expect(restored.isAutoNamed, isFalse);
       expect(restored.lineUpGroups.single.id, legacyLineUp.id);
       expect(restored.lineUpGroups.single.items, hasLength(1));
       expect(
@@ -405,6 +406,32 @@ void main() {
           ]));
     });
 
+    test('custom Page N provenance round-trips through export JSON', () async {
+      final page = StrategyPage(
+        id: 'custom-page-2',
+        sortIndex: 1,
+        name: 'Page 2',
+        isAutoNamed: false,
+        drawingData: const [],
+        agentData: const [],
+        abilityData: const [],
+        textData: const [],
+        imageData: const [],
+        utilityData: const [],
+        isAttack: true,
+        settings: StrategySettings(),
+      );
+
+      final restored = await StrategyPage.fromJson(
+        json: page.toJson('strategy-id'),
+        strategyID: 'strategy-id',
+        isZip: true,
+      );
+
+      expect(restored.name, 'Page 2');
+      expect(restored.isAutoNamed, isFalse);
+    });
+
     test('current schema export -> import preserves canonical structure',
         () async {
       final currentPayload = <String, dynamic>{
@@ -415,6 +442,7 @@ void main() {
             'id': 'page-1',
             'sortIndex': '0',
             'name': 'Page 1',
+            'isAutoNamed': true,
             'drawingData': [
               {
                 'type': 'lineDrawing',
@@ -932,6 +960,7 @@ void main() {
             id: 'page-1',
             sortIndex: 0,
             name: 'Page 1',
+            isAutoNamed: true,
             drawingData: const [],
             agentData: const [],
             abilityData: const [],
@@ -952,6 +981,7 @@ void main() {
       final page = restored.pages.single;
 
       expect(page.lineUpGroups, hasLength(1));
+      expect(page.isAutoNamed, isTrue);
       expect(page.lineUpGroups.single.items, hasLength(1));
       expect(page.lineUps, hasLength(1));
       expect(page.lineUps.single.id, 'item-1');

--- a/test/strategy_page_semantics_test.dart
+++ b/test/strategy_page_semantics_test.dart
@@ -124,6 +124,56 @@ void main() {
     ]);
   });
 
+  test('a custom name matching Page N is never automatically renumbered', () {
+    final pages = [
+      _page(id: 'page-1', name: 'Page 1', sortIndex: 0),
+      _page(
+        id: 'custom-page-2',
+        name: 'Page 2',
+        sortIndex: 1,
+        isAutoNamed: false,
+      ),
+      _page(id: 'page-3', name: 'Page 3', sortIndex: 2),
+    ];
+
+    final reindexed = StrategyProvider.reindexPagesAfterStructuralChange([
+      pages[1],
+      pages[0],
+      pages[2],
+    ]);
+
+    expect(reindexed.map((page) => page.name), [
+      'Page 2',
+      'Page 2',
+      'Page 3',
+    ]);
+    expect(reindexed.first.isAutoNamed, isFalse);
+    expect(reindexed[1].isAutoNamed, isTrue);
+  });
+
+  test('page-name migration records provenance for historical pages', () {
+    final oldStrategy = _strategy([
+      _page(
+        id: 'page-1',
+        name: 'Page 1',
+        sortIndex: 0,
+        isAutoNamed: false,
+      ),
+      _page(
+        id: 'custom-page',
+        name: 'Site Execute',
+        sortIndex: 1,
+        isAutoNamed: false,
+      ),
+    ]).copyWith(versionNumber: Settings.versionNumber - 1);
+
+    final migrated = StrategyProvider.migrateToCurrentVersion(oldStrategy);
+
+    expect(migrated.versionNumber, Settings.versionNumber);
+    expect(migrated.pages[0].isAutoNamed, isTrue);
+    expect(migrated.pages[1].isAutoNamed, isFalse);
+  });
+
   test('delete renumbering closes gaps without changing custom names', () {
     final pages = [
       _page(id: 'page-1', name: 'Page 1', sortIndex: 0),
@@ -288,6 +338,7 @@ StrategyPage _page({
   required String id,
   required String name,
   required int sortIndex,
+  bool? isAutoNamed,
   List<PlacedAgentNode> agents = const [],
   List<PlacedAbility> abilities = const [],
   List<PlacedText> text = const [],
@@ -297,6 +348,7 @@ StrategyPage _page({
   return StrategyPage(
     id: id,
     name: name,
+    isAutoNamed: isAutoNamed ?? name == 'Page ${sortIndex + 1}',
     sortIndex: sortIndex,
     drawingData: const [],
     agentData: agents,

--- a/test/strategy_page_semantics_test.dart
+++ b/test/strategy_page_semantics_test.dart
@@ -151,18 +151,24 @@ void main() {
     expect(reindexed[1].isAutoNamed, isTrue);
   });
 
-  test('page-name migration records provenance for historical pages', () {
+  test('page-name migration leaves historical provenance unresolved', () {
     final oldStrategy = _strategy([
       _page(
         id: 'page-1',
         name: 'Page 1',
         sortIndex: 0,
-        isAutoNamed: false,
+        hasNameProvenance: false,
       ),
       _page(
         id: 'custom-page',
         name: 'Site Execute',
         sortIndex: 1,
+        hasNameProvenance: false,
+      ),
+      _page(
+        id: 'explicit-custom-page',
+        name: 'Page 3',
+        sortIndex: 2,
         isAutoNamed: false,
       ),
     ]).copyWith(versionNumber: Settings.versionNumber - 1);
@@ -170,8 +176,9 @@ void main() {
     final migrated = StrategyProvider.migrateToCurrentVersion(oldStrategy);
 
     expect(migrated.versionNumber, Settings.versionNumber);
-    expect(migrated.pages[0].isAutoNamed, isTrue);
-    expect(migrated.pages[1].isAutoNamed, isFalse);
+    expect(migrated.pages[0].isAutoNamed, isNull);
+    expect(migrated.pages[1].isAutoNamed, isNull);
+    expect(migrated.pages[2].isAutoNamed, isFalse);
   });
 
   test('delete renumbering closes gaps without changing custom names', () {
@@ -339,6 +346,7 @@ StrategyPage _page({
   required String name,
   required int sortIndex,
   bool? isAutoNamed,
+  bool hasNameProvenance = true,
   List<PlacedAgentNode> agents = const [],
   List<PlacedAbility> abilities = const [],
   List<PlacedText> text = const [],
@@ -348,7 +356,9 @@ StrategyPage _page({
   return StrategyPage(
     id: id,
     name: name,
-    isAutoNamed: isAutoNamed ?? name == 'Page ${sortIndex + 1}',
+    isAutoNamed: hasNameProvenance
+        ? isAutoNamed ?? name == 'Page ${sortIndex + 1}'
+        : null,
     sortIndex: sortIndex,
     drawingData: const [],
     agentData: agents,

--- a/test/strategy_page_semantics_test.dart
+++ b/test/strategy_page_semantics_test.dart
@@ -1,0 +1,340 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:icarus/const/agents.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/hive_boxes.dart';
+import 'package:icarus/const/line_provider.dart';
+import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/settings.dart';
+import 'package:icarus/const/transition_data.dart';
+import 'package:icarus/const/utilities.dart';
+import 'package:icarus/hive/hive_registration.dart';
+import 'package:icarus/providers/ability_provider.dart';
+import 'package:icarus/providers/agent_provider.dart';
+import 'package:icarus/providers/drawing_provider.dart';
+import 'package:icarus/providers/folder_provider.dart';
+import 'package:icarus/providers/image_provider.dart';
+import 'package:icarus/providers/map_provider.dart';
+import 'package:icarus/providers/strategy_page.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_settings_provider.dart';
+import 'package:icarus/providers/text_provider.dart';
+import 'package:icarus/providers/user_preferences_provider.dart';
+import 'package:icarus/providers/utility_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  CoordinateSystem(playAreaSize: const Size(1920, 1080));
+
+  late Directory tempDir;
+  late Box<StrategyData> strategyBox;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('icarus-page-semantics-');
+    Hive.init(tempDir.path);
+    if (!Hive.isAdapterRegistered(9)) {
+      registerIcarusAdapters(Hive);
+    }
+    strategyBox = await Hive.openBox<StrategyData>(HiveBoxNames.strategiesBox);
+    await Hive.openBox<Folder>(HiveBoxNames.foldersBox);
+    await Hive.openBox<MapThemeProfile>(HiveBoxNames.mapThemeProfilesBox);
+    await Hive.openBox<AppPreferences>(HiveBoxNames.appPreferencesBox);
+    await Hive.openBox<bool>(HiveBoxNames.favoriteAgentsBox);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('addPage duplicates and renumbers immediately after the active page',
+      () async {
+    final sourceAgent = PlacedAgent(
+      id: 'agent-on-page-2',
+      type: AgentType.jett,
+      position: const Offset(120, 240),
+    );
+    final pages = [
+      _page(
+        id: 'page-1',
+        name: 'Page 1',
+        sortIndex: 0,
+        agents: [sourceAgent],
+      ),
+      _page(id: 'page-2', name: 'Page 2', sortIndex: 1),
+      _page(id: 'page-3', name: 'Page 3', sortIndex: 2),
+    ];
+    final strategy = _strategy(pages);
+    await strategyBox.put(strategy.id, strategy);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    _activatePage(container, strategy, pages[0]);
+
+    await container.read(strategyProvider.notifier).addPage();
+
+    final saved = strategyBox.get(strategy.id)!;
+    final ordered = [...saved.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex));
+
+    expect(ordered.map((page) => page.id), [
+      'page-1',
+      isNot(anyOf('page-1', 'page-2', 'page-3')),
+      'page-2',
+      'page-3',
+    ]);
+    expect(ordered.map((page) => page.sortIndex), [0, 1, 2, 3]);
+    expect(ordered.map((page) => page.name), [
+      'Page 1',
+      'Page 2',
+      'Page 3',
+      'Page 4',
+    ]);
+    expect(ordered[1].agentData.single.id, sourceAgent.id);
+    expect(container.read(strategyProvider).activePageId, ordered[1].id);
+  });
+
+  test('reorder renumbers default names and preserves custom names', () async {
+    final pages = [
+      _page(id: 'page-1', name: 'Page 1', sortIndex: 0),
+      _page(id: 'page-2', name: 'Site Execute', sortIndex: 1),
+      _page(id: 'page-3', name: 'Page 3', sortIndex: 2),
+    ];
+    final strategy = _strategy(pages);
+    await strategyBox.put(strategy.id, strategy);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    _activatePage(container, strategy, pages.first);
+
+    await container.read(strategyProvider.notifier).reorderPage(2, 0);
+
+    final ordered = [...strategyBox.get(strategy.id)!.pages]
+      ..sort((a, b) => a.sortIndex.compareTo(b.sortIndex));
+    expect(ordered.map((page) => page.id), ['page-3', 'page-1', 'page-2']);
+    expect(ordered.map((page) => page.name), [
+      'Page 1',
+      'Page 2',
+      'Site Execute',
+    ]);
+  });
+
+  test('delete renumbering closes gaps without changing custom names', () {
+    final pages = [
+      _page(id: 'page-1', name: 'Page 1', sortIndex: 0),
+      _page(id: 'page-2', name: 'Site Execute', sortIndex: 1),
+      _page(id: 'page-3', name: 'Page 3', sortIndex: 2),
+    ];
+
+    final reindexed = StrategyProvider.reindexPagesAfterStructuralChange([
+      pages[1],
+      pages[2],
+    ]);
+
+    expect(reindexed.map((page) => page.name), ['Site Execute', 'Page 2']);
+    expect(reindexed.map((page) => page.sortIndex), [0, 1]);
+  });
+
+  test('placed widgets copy to the next page with their IDs intact', () async {
+    final agent = PlacedAgent(
+      id: 'agent-id',
+      type: AgentType.jett,
+      position: const Offset(10, 20),
+    );
+    final ability = PlacedAbility(
+      id: 'ability-id',
+      data: AgentData.agents[AgentType.jett]!.abilities.first,
+      position: const Offset(30, 40),
+    );
+    final text = PlacedText(id: 'text-id', position: const Offset(50, 60))
+      ..text = 'Rotate A';
+    final image = PlacedImage(
+      id: 'image-id',
+      position: const Offset(70, 80),
+      aspectRatio: 1.5,
+      scale: 220,
+      fileExtension: '.png',
+      sizeVersion: worldSizedMediaVersion,
+    )..link = 'strategy/images/image-id.png';
+    final utility = PlacedUtility(
+      id: 'utility-id',
+      type: UtilityType.spike,
+      position: const Offset(90, 100),
+    );
+    final pages = [
+      _page(id: 'page-1', name: 'Page 1', sortIndex: 0),
+      _page(
+        id: 'page-2',
+        name: 'Page 2',
+        sortIndex: 1,
+        agents: [agent],
+        abilities: [ability],
+        text: [text],
+        images: [image],
+        utilities: [utility],
+      ),
+      _page(id: 'page-3', name: 'Page 3', sortIndex: 2),
+    ];
+    final strategy = _strategy(pages);
+    await strategyBox.put(strategy.id, strategy);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    _activatePage(container, strategy, pages[1]);
+    final notifier = container.read(strategyProvider.notifier);
+
+    for (final id in [agent.id, ability.id, text.id, image.id, utility.id]) {
+      expect(
+        await notifier.copyPlacedWidgetToAdjacentPage(
+          widgetId: id,
+          direction: PageTransitionDirection.forward,
+        ),
+        isTrue,
+      );
+    }
+
+    final target = strategyBox
+        .get(strategy.id)!
+        .pages
+        .singleWhere((page) => page.id == 'page-3');
+    expect(target.agentData.single.id, agent.id);
+    expect(target.abilityData.single.id, ability.id);
+    expect(target.textData.single.id, text.id);
+    expect(target.imageData.single.id, image.id);
+    expect(target.utilityData.single.id, utility.id);
+    expect(container.read(strategyProvider).activePageId, 'page-2');
+    expect(notifier.copyDirectionsForPlacedWidget(agent.id), [
+      PageTransitionDirection.backward,
+    ]);
+  });
+
+  test(
+    'copying is linear and never overwrites an existing transition ID',
+    () async {
+      final sourceAgent = PlacedAgent(
+        id: 'shared-agent',
+        type: AgentType.jett,
+        position: const Offset(10, 20),
+      );
+      final existingTargetAgent = sourceAgent.copyWith(
+        position: const Offset(300, 400),
+      );
+      final pages = [
+        _page(
+          id: 'page-1',
+          name: 'Page 1',
+          sortIndex: 0,
+          agents: [sourceAgent],
+        ),
+        _page(
+          id: 'page-2',
+          name: 'Page 2',
+          sortIndex: 1,
+          agents: [existingTargetAgent],
+        ),
+      ];
+      final strategy = _strategy(pages);
+      await strategyBox.put(strategy.id, strategy);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      _activatePage(container, strategy, pages.first);
+      final notifier = container.read(strategyProvider.notifier);
+
+      expect(notifier.copyDirectionsForPlacedWidget(sourceAgent.id), isEmpty);
+      expect(
+        await notifier.copyPlacedWidgetToAdjacentPage(
+          widgetId: sourceAgent.id,
+          direction: PageTransitionDirection.backward,
+        ),
+        isFalse,
+      );
+      expect(
+        await notifier.copyPlacedWidgetToAdjacentPage(
+          widgetId: sourceAgent.id,
+          direction: PageTransitionDirection.forward,
+        ),
+        isFalse,
+      );
+
+      final savedTarget = strategyBox
+          .get(strategy.id)!
+          .pages
+          .singleWhere((page) => page.id == 'page-2');
+      expect(savedTarget.agentData, hasLength(1));
+      expect(savedTarget.agentData.single.position, const Offset(300, 400));
+    },
+  );
+}
+
+StrategyData _strategy(List<StrategyPage> pages) {
+  return StrategyData(
+    id: 'strategy-id',
+    name: 'Strategy',
+    mapData: MapValue.ascent,
+    versionNumber: Settings.versionNumber,
+    lastEdited: DateTime.utc(2026, 1, 1),
+    folderID: null,
+    pages: pages,
+  );
+}
+
+StrategyPage _page({
+  required String id,
+  required String name,
+  required int sortIndex,
+  List<PlacedAgentNode> agents = const [],
+  List<PlacedAbility> abilities = const [],
+  List<PlacedText> text = const [],
+  List<PlacedImage> images = const [],
+  List<PlacedUtility> utilities = const [],
+}) {
+  return StrategyPage(
+    id: id,
+    name: name,
+    sortIndex: sortIndex,
+    drawingData: const [],
+    agentData: agents,
+    abilityData: abilities,
+    textData: text,
+    imageData: images,
+    utilityData: utilities,
+    isAttack: true,
+    settings: StrategySettings(),
+  );
+}
+
+void _activatePage(
+  ProviderContainer container,
+  StrategyData strategy,
+  StrategyPage page,
+) {
+  container.read(agentProvider.notifier).fromHive(page.agentData);
+  container.read(abilityProvider.notifier).fromHive(page.abilityData);
+  container.read(drawingProvider.notifier).fromHive(page.drawingData);
+  container.read(textProvider.notifier).fromHive(page.textData);
+  container.read(placedImageProvider.notifier).fromHive(page.imageData);
+  container.read(utilityProvider.notifier).fromHive(page.utilityData);
+  container.read(lineUpProvider.notifier).fromHive(page.lineUpGroups);
+  container
+      .read(mapProvider.notifier)
+      .fromHive(strategy.mapData, page.isAttack);
+  container.read(strategySettingsProvider.notifier).fromHive(page.settings);
+
+  container.read(strategyProvider.notifier)
+    ..setFromState(
+      StrategyState(
+        isSaved: true,
+        stratName: strategy.name,
+        id: strategy.id,
+        storageDirectory: null,
+        activePageId: page.id,
+      ),
+    )
+    ..activePageID = page.id;
+}


### PR DESCRIPTION
## Summary
- insert duplicated pages immediately after the active page
- keep automatic Page N names positional across add, reorder, and delete while preserving custom names
- copy placed widgets to adjacent pages with stable IDs for transitions
- expose previous/next copy actions for agents, abilities, text, images, and utilities

## Verification
- `flutter test` (353 passed, 1 skipped)
- changed-path `flutter analyze` (clean)

## Notes
- no Hive schema or generated adapter changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Copy placed agents, abilities, text, images, and utilities to adjacent pages from context menus.
  - Create new pages after the active page.
  - Preserve automatically generated page names during page reordering, insertion, and deletion.

- **Bug Fixes**
  - Improved context-menu availability for placed widgets, including items without complete geometry.
  - Prevented duplicate widget IDs when copying content between pages.
  - Preserved custom page names while automatically updating generated names.
  - Maintained consistent page ordering after reordering and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->