### PR TITLE
Show rotation controls on hover

### DIFF
--- a/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/coordinate_system.dart';
@@ -37,8 +39,12 @@ class RotatableWidget extends ConsumerStatefulWidget {
 
 class _RotatableWidgetState extends ConsumerState<RotatableWidget>
     with SingleTickerProviderStateMixin {
+  static const _hoverExitDelay = Duration(milliseconds: 150);
+
   late final AnimationController _animationController;
   late final Animation<double> _scaleAnimation;
+  Timer? _hoverExitTimer;
+  bool _isExitGraceActive = false;
   bool _isTargetHovered = false;
   bool _isHandleHovered = false;
   bool _isHandleDragging = false;
@@ -57,8 +63,34 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
 
   @override
   void dispose() {
+    _hoverExitTimer?.cancel();
     _animationController.dispose();
     super.dispose();
+  }
+
+  void _showTargetHandle() {
+    _hoverExitTimer?.cancel();
+    if (_isTargetHovered && !_isExitGraceActive) return;
+
+    setState(() {
+      _isTargetHovered = true;
+      _isExitGraceActive = false;
+    });
+  }
+
+  void _scheduleTargetHandleHide() {
+    _hoverExitTimer?.cancel();
+    setState(() {
+      _isTargetHovered = false;
+      _isExitGraceActive = true;
+    });
+    _hoverExitTimer = Timer(_hoverExitDelay, () {
+      if (!mounted) return;
+
+      setState(() {
+        _isExitGraceActive = false;
+      });
+    });
   }
 
   @override
@@ -70,24 +102,18 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
     );
     final isScreenshot = ref.watch(screenshotProvider);
     final buttonSize = coordinateSystem.scale(15);
-    final showHandle =
-        _isTargetHovered || _isHandleHovered || _isHandleDragging;
+    final showHandle = _isTargetHovered ||
+        _isExitGraceActive ||
+        _isHandleHovered ||
+        _isHandleDragging;
 
     return MouseRegion(
       opaque: false,
       // Keep spatially separated handles reachable across transparent parts
       // of a view cone without blocking pointer targets underneath.
       hitTestBehavior: HitTestBehavior.translucent,
-      onEnter: (_) {
-        setState(() {
-          _isTargetHovered = true;
-        });
-      },
-      onExit: (_) {
-        setState(() {
-          _isTargetHovered = false;
-        });
-      },
+      onEnter: (_) => _showTargetHandle(),
+      onExit: (_) => _scheduleTargetHandleHide(),
       child: Transform.rotate(
         angle: widget.rotation,
         alignment: Alignment.topLeft,
@@ -106,7 +132,9 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
                   visible: showHandle,
                   child: MouseRegion(
                     onEnter: (_) {
+                      _hoverExitTimer?.cancel();
                       setState(() {
+                        _isExitGraceActive = false;
                         _isHandleHovered = true;
                       });
                       _animationController.forward();

--- a/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
@@ -75,6 +75,9 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
 
     return MouseRegion(
       opaque: false,
+      // Keep spatially separated handles reachable across transparent parts
+      // of a view cone without blocking pointer targets underneath.
+      hitTestBehavior: HitTestBehavior.translucent,
       onEnter: (_) {
         setState(() {
           _isTargetHovered = true;

--- a/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/providers/screenshot_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/utilities/shape_indicator_fade.dart';
 
 class RotatableWidget extends ConsumerStatefulWidget {
   final Widget child;
@@ -38,7 +39,8 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
   late final Animation<double> _scaleAnimation;
-  bool _isHovered = false;
+  bool _isTargetHovered = false;
+  bool _isHandleHovered = false;
   bool _isHandleDragging = false;
 
   @override
@@ -48,13 +50,9 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
       duration: const Duration(milliseconds: 150),
       vsync: this,
     );
-    _scaleAnimation = Tween<double>(
-      begin: 1.0,
-      end: 1.03,
-    ).animate(CurvedAnimation(
-      parent: _animationController,
-      curve: Curves.easeOut,
-    ));
+    _scaleAnimation = Tween<double>(begin: 1.0, end: 1.03).animate(
+      CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
+    );
   }
 
   @override
@@ -66,81 +64,103 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
   @override
   Widget build(BuildContext context) {
     final coordinateSystem = CoordinateSystem.instance;
-    final rotationOrigin = widget.origin
-        .scale(coordinateSystem.scaleFactor, coordinateSystem.scaleFactor);
+    final rotationOrigin = widget.origin.scale(
+      coordinateSystem.scaleFactor,
+      coordinateSystem.scaleFactor,
+    );
     final isScreenshot = ref.watch(screenshotProvider);
     final buttonSize = coordinateSystem.scale(15);
-    return Transform.rotate(
-      angle: widget.rotation,
-      alignment: Alignment.topLeft,
-      origin: rotationOrigin,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          widget.child,
-          if (widget.showHandle && !widget.isDragging && !isScreenshot)
-            Positioned(
-              left: coordinateSystem
-                  .scale((widget.buttonLeft ?? widget.origin.dx - 7.5)),
-              top: coordinateSystem.scale((widget.buttonTop ?? 0)),
-              child: MouseRegion(
-                onEnter: (event) {
-                  setState(() {
-                    _isHovered = true;
-                  });
-                  _animationController.forward();
-                },
-                onExit: (event) {
-                  setState(() {
-                    _isHovered = false;
-                  });
-                  if (!_isHandleDragging) {
-                    _animationController.reverse();
-                  }
-                },
-                child: SizedBox(
-                  width: buttonSize,
-                  height: buttonSize,
+    final showHandle =
+        _isTargetHovered || _isHandleHovered || _isHandleDragging;
+
+    return MouseRegion(
+      opaque: false,
+      onEnter: (_) {
+        setState(() {
+          _isTargetHovered = true;
+        });
+      },
+      onExit: (_) {
+        setState(() {
+          _isTargetHovered = false;
+        });
+      },
+      child: Transform.rotate(
+        angle: widget.rotation,
+        alignment: Alignment.topLeft,
+        origin: rotationOrigin,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            widget.child,
+            if (widget.showHandle && !widget.isDragging && !isScreenshot)
+              Positioned(
+                left: coordinateSystem.scale(
+                  (widget.buttonLeft ?? widget.origin.dx - 7.5),
+                ),
+                top: coordinateSystem.scale((widget.buttonTop ?? 0)),
+                child: ShapeIndicatorFade(
+                  visible: showHandle,
                   child: MouseRegion(
-                    cursor: SystemMouseCursors.click,
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onPanStart: (details) {
-                        setState(() {
-                          _isHandleDragging = true;
-                        });
-                        _animationController.forward();
-                        widget.onPanStart(details);
-                      },
-                      onPanUpdate: widget.onPanUpdate,
-                      onPanEnd: (details) {
-                        widget.onPanEnd(details);
-                        setState(() {
-                          _isHandleDragging = false;
-                        });
-                        if (!_isHovered) {
-                          _animationController.reverse();
-                        }
-                      },
-                      onTap: () {},
-                      child: Center(
-                        child: AnimatedBuilder(
-                          animation: _scaleAnimation,
-                          builder: (context, child) {
-                            return Transform.scale(
-                              scale: _scaleAnimation.value,
-                              child: child,
-                            );
+                    onEnter: (_) {
+                      setState(() {
+                        _isHandleHovered = true;
+                      });
+                      _animationController.forward();
+                    },
+                    onExit: (_) {
+                      setState(() {
+                        _isHandleHovered = false;
+                      });
+                      if (!_isHandleDragging) {
+                        _animationController.reverse();
+                      }
+                    },
+                    child: SizedBox(
+                      width: buttonSize,
+                      height: buttonSize,
+                      child: MouseRegion(
+                        cursor: SystemMouseCursors.click,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onPanStart: (details) {
+                            setState(() {
+                              _isHandleDragging = true;
+                            });
+                            _animationController.forward();
+                            widget.onPanStart(details);
                           },
-                          child: SizedBox(
-                            width: buttonSize,
-                            height: buttonSize,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: _isHovered
-                                    ? Colors.white
-                                    : Colors.white.withAlpha(200),
-                                shape: BoxShape.circle,
+                          onPanUpdate: widget.onPanUpdate,
+                          onPanEnd: (details) {
+                            widget.onPanEnd(details);
+                            setState(() {
+                              _isHandleDragging = false;
+                            });
+                            if (!_isHandleHovered) {
+                              _animationController.reverse();
+                            }
+                          },
+                          onTap: () {},
+                          child: Center(
+                            child: AnimatedBuilder(
+                              animation: _scaleAnimation,
+                              builder: (context, child) {
+                                return Transform.scale(
+                                  scale: _scaleAnimation.value,
+                                  child: child,
+                                );
+                              },
+                              child: SizedBox(
+                                width: buttonSize,
+                                height: buttonSize,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: _isHandleHovered
+                                        ? Colors.white
+                                        : Colors.white.withAlpha(200),
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
                               ),
                             ),
                           ),
@@ -150,8 +170,8 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
                   ),
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/test/rotatable_widget_hover_test.dart
+++ b/test/rotatable_widget_hover_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/widgets/draggable_widgets/ability/rotatable_widget.dart';
+import 'package:icarus/widgets/draggable_widgets/utilities/shape_indicator_fade.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    CoordinateSystem(playAreaSize: const Size(800, 600));
+  });
+
+  testWidgets(
+    'rotation handle only accepts input while the target is hovered',
+    (tester) async {
+      var handleDragStarted = false;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RotatableWidget(
+                  rotation: 0,
+                  origin: const Offset(50, 100),
+                  isDragging: false,
+                  onPanStart: (_) => handleDragStarted = true,
+                  onPanUpdate: (_) {},
+                  onPanEnd: (_) {},
+                  child: const SizedBox(
+                    key: ValueKey('rotation-target'),
+                    width: 100,
+                    height: 120,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      ShapeIndicatorFade indicator() =>
+          tester.widget<ShapeIndicatorFade>(find.byType(ShapeIndicatorFade));
+
+      expect(indicator().visible, isFalse);
+      expect(
+        tester
+            .widget<IgnorePointer>(
+              find.descendant(
+                of: find.byType(ShapeIndicatorFade),
+                matching: find.byType(IgnorePointer),
+              ),
+            )
+            .ignoring,
+        isTrue,
+      );
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(
+        location: tester.getCenter(
+          find.byKey(const ValueKey('rotation-target')),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(indicator().visible, isTrue);
+
+      final handleCenter = tester.getCenter(find.byType(ShapeIndicatorFade));
+      await mouse.moveTo(handleCenter);
+      await mouse.down(handleCenter);
+      await mouse.moveBy(const Offset(10, 0));
+      await tester.pump();
+
+      expect(handleDragStarted, isTrue);
+
+      await mouse.up();
+      await mouse.moveTo(const Offset(10, 10));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(indicator().visible, isFalse);
+    },
+  );
+
+  testWidgets('hover listener does not block target dragging', (tester) async {
+    var targetDragStarted = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RotatableWidget(
+                rotation: 0,
+                origin: const Offset(50, 100),
+                isDragging: false,
+                onPanStart: (_) {},
+                onPanUpdate: (_) {},
+                onPanEnd: (_) {},
+                child: GestureDetector(
+                  key: const ValueKey('draggable-rotation-target'),
+                  behavior: HitTestBehavior.opaque,
+                  onPanStart: (_) => targetDragStarted = true,
+                  child: const SizedBox(width: 100, height: 120),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.dragFrom(
+      tester.getCenter(find.byKey(const ValueKey('draggable-rotation-target'))),
+      const Offset(20, 0),
+    );
+
+    expect(targetDragStarted, isTrue);
+  });
+}

--- a/test/rotatable_widget_hover_test.dart
+++ b/test/rotatable_widget_hover_test.dart
@@ -121,4 +121,82 @@ void main() {
 
     expect(targetDragStarted, isTrue);
   });
+
+  testWidgets(
+    'transparent gap keeps a separated rotation handle reachable',
+    (tester) async {
+      var handleDragStarted = false;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RotatableWidget(
+                  rotation: 0,
+                  origin: const Offset(100, 120),
+                  buttonLeft: 92.5,
+                  buttonTop: 0,
+                  isDragging: false,
+                  onPanStart: (_) => handleDragStarted = true,
+                  onPanUpdate: (_) {},
+                  onPanEnd: (_) {},
+                  child: const SizedBox(
+                    key: ValueKey('separated-control-bounds'),
+                    width: 200,
+                    height: 140,
+                    child: Stack(
+                      children: [
+                        Positioned(
+                          left: 92.5,
+                          bottom: 0,
+                          child: SizedBox(
+                            key: ValueKey('separated-control-target'),
+                            width: 15,
+                            height: 15,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      ShapeIndicatorFade indicator() =>
+          tester.widget<ShapeIndicatorFade>(find.byType(ShapeIndicatorFade));
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(
+        location: tester.getCenter(
+          find.byKey(const ValueKey('separated-control-target')),
+        ),
+      );
+      await tester.pump();
+
+      expect(indicator().visible, isTrue);
+
+      await mouse.moveTo(
+        tester.getCenter(
+          find.byKey(const ValueKey('separated-control-bounds')),
+        ),
+      );
+      await tester.pump();
+
+      expect(indicator().visible, isTrue);
+
+      final handleCenter = tester.getCenter(find.byType(ShapeIndicatorFade));
+      await mouse.moveTo(handleCenter);
+      await mouse.down(handleCenter);
+      await mouse.moveBy(const Offset(10, 0));
+      await tester.pump();
+
+      expect(handleDragStarted, isTrue);
+
+      await mouse.up();
+    },
+  );
 }

--- a/test/rotatable_widget_hover_test.dart
+++ b/test/rotatable_widget_hover_test.dart
@@ -80,6 +80,9 @@ void main() {
       await mouse.up();
       await mouse.moveTo(const Offset(10, 10));
       await tester.pump();
+
+      expect(indicator().visible, isTrue);
+
       await tester.pump(const Duration(milliseconds: 200));
 
       expect(indicator().visible, isFalse);


### PR DESCRIPTION
## What changed

- Hide shared rotation handles until the ability or view cone is hovered.
- Keep the handle visible and interactive while it is hovered or being dragged.
- Reuse the same fade and pointer-suppression behavior as custom-shape controls.
- Add regression coverage for handle visibility, interaction, and body dragging.

## Why

Always-visible adjustment handles add visual noise to the map while the user is working on a strategy. Custom shapes already reveal their controls on hover, so abilities and view cones should behave consistently.

## User impact

The map stays visually quieter. Rotation and length adjustments remain immediately available on hover, and hidden handles no longer intercept pointer input.

## Validation

- `flutter analyze lib/widgets/draggable_widgets/ability/rotatable_widget.dart test/rotatable_widget_hover_test.dart`
- `flutter test test/rotatable_widget_hover_test.dart test/ability_visibility_widgets_test.dart test/view_cone_agent_drag_feedback_test.dart test/custom_shape_indicator_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved rotation-handle visibility and hover behavior.
  * The handle remains visible while hovering over the widget or handle, across transparent gaps, and during dragging.
  * Added smoother visual transitions for handle interactions.

* **Bug Fixes**
  * Preserved target-widget dragging while using hover-sensitive rotation controls.
  * Prevented the handle from disappearing during brief pointer movements between the widget and handle.

* **Tests**
  * Added coverage for handle hover behavior, transparent gaps, and draggable target interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->