### PR TITLE
Allow recoloring placed custom shapes

### DIFF
--- a/lib/const/placed_classes.dart
+++ b/lib/const/placed_classes.dart
@@ -1165,6 +1165,12 @@ class CustomShapeGeometryAction extends WidgetAction {
   }
 }
 
+class CustomShapeColorAction extends WidgetAction {
+  final int? customColorValue;
+
+  CustomShapeColorAction({required this.customColorValue});
+}
+
 class TextContentAction extends WidgetAction {
   final String text;
 
@@ -1396,6 +1402,33 @@ class PlacedUtility extends PlacedWidget {
     _poppedAction.removeLast();
   }
 
+  void updateCustomShapeColor(int newColorValue) {
+    _actionHistory.add(
+      CustomShapeColorAction(customColorValue: customColorValue),
+    );
+    customColorValue = newColorValue;
+  }
+
+  void _undoCustomShapeColor() {
+    _poppedAction.add(
+      CustomShapeColorAction(customColorValue: customColorValue),
+    );
+    customColorValue =
+        (_actionHistory.last as CustomShapeColorAction).customColorValue;
+    _actionHistory.removeLast();
+  }
+
+  void _redoCustomShapeColor() {
+    if (_poppedAction.isEmpty) return;
+
+    _actionHistory.add(
+      CustomShapeColorAction(customColorValue: customColorValue),
+    );
+    customColorValue =
+        (_poppedAction.last as CustomShapeColorAction).customColorValue;
+    _poppedAction.removeLast();
+  }
+
   @override
   void undoAction() {
     if (_actionHistory.isEmpty) return;
@@ -1406,6 +1439,8 @@ class PlacedUtility extends PlacedWidget {
       _undoRotation();
     } else if (_actionHistory.last is CustomShapeGeometryAction) {
       _undoCustomShapeGeometry();
+    } else if (_actionHistory.last is CustomShapeColorAction) {
+      _undoCustomShapeColor();
     }
   }
 
@@ -1419,6 +1454,8 @@ class PlacedUtility extends PlacedWidget {
       _redoRotation();
     } else if (_poppedAction.last is CustomShapeGeometryAction) {
       _redoCustomShapeGeometry();
+    } else if (_poppedAction.last is CustomShapeColorAction) {
+      _redoCustomShapeColor();
     }
   }
 
@@ -1598,6 +1635,8 @@ extension PlacedWidgetCopy on PlacedWidget {
         customWidth: action.customWidth,
         customLength: action.customLength,
       );
+    } else if (action is CustomShapeColorAction) {
+      return CustomShapeColorAction(customColorValue: action.customColorValue);
     }
 
     throw UnsupportedError(

--- a/lib/providers/utility_provider.dart
+++ b/lib/providers/utility_provider.dart
@@ -153,6 +153,26 @@ class UtilityProvider extends Notifier<List<PlacedUtility>> {
     state = newState;
   }
 
+  void updateCustomShapeColor({required String id, required int colorValue}) {
+    final newState = [...state];
+    final index = PlacedWidget.getIndexByID(id, newState);
+    if (index < 0) return;
+
+    final utility = newState[index];
+    if (!UtilityData.isCustomShape(utility.type) ||
+        utility.customColorValue == colorValue) {
+      return;
+    }
+
+    utility.updateCustomShapeColor(colorValue);
+    ref
+        .read(actionProvider.notifier)
+        .addAction(
+          UserAction(type: ActionType.edit, id: id, group: ActionGroup.utility),
+        );
+    state = newState;
+  }
+
   void updateRotationHistory(int index) {
     final newState = [...state];
 

--- a/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
@@ -6,7 +6,7 @@ import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
-import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
+import 'package:icarus/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
 class CustomCircleUtilityWidget extends ConsumerWidget {
@@ -92,8 +92,8 @@ class CustomCircleUtilityWidget extends ConsumerWidget {
                 deleteTarget: (id?.isNotEmpty ?? false)
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
                     : null,
-                contextMenuItems: (id?.isNotEmpty ?? false)
-                    ? buildAdjacentPageCopyMenuItems(ref, id!)
+                contextMenuItems: (id?.isNotEmpty ?? false) && utility != null
+                    ? buildCustomShapeContextMenuItems(context, ref, utility)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_circle_utility_widget.dart
@@ -93,7 +93,7 @@ class CustomCircleUtilityWidget extends ConsumerWidget {
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
                     : null,
                 contextMenuItems: (id?.isNotEmpty ?? false) && utility != null
-                    ? buildCustomShapeContextMenuItems(context, ref, utility)
+                    ? buildCustomShapeContextMenuItems(ref, utility)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
@@ -93,7 +93,7 @@ class CustomRectangleUtilityWidget extends ConsumerWidget {
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
                     : null,
                 contextMenuItems: (id?.isNotEmpty ?? false) && utility != null
-                    ? buildCustomShapeContextMenuItems(context, ref, utility)
+                    ? buildCustomShapeContextMenuItems(ref, utility)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_rectangle_utility_widget.dart
@@ -6,7 +6,7 @@ import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
-import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
+import 'package:icarus/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 
 class CustomRectangleUtilityWidget extends ConsumerWidget {
@@ -92,8 +92,8 @@ class CustomRectangleUtilityWidget extends ConsumerWidget {
                 deleteTarget: (id?.isNotEmpty ?? false)
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
                     : null,
-                contextMenuItems: (id?.isNotEmpty ?? false)
-                    ? buildAdjacentPageCopyMenuItems(ref, id!)
+                contextMenuItems: (id?.isNotEmpty ?? false) && utility != null
+                    ? buildCustomShapeContextMenuItems(context, ref, utility)
                     : null,
                 child: AnimatedOpacity(
                   opacity: centerMarkerVisible ? 1.0 : 0.0,

--- a/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/providers/color_library_provider.dart';
+import 'package:icarus/providers/utility_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
+import 'package:icarus/widgets/sidebar_widgets/color_library.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+List<ShadContextMenuItem> buildCustomShapeContextMenuItems(
+  BuildContext context,
+  WidgetRef ref,
+  PlacedUtility utility,
+) {
+  final currentColorValue = utility.customColorValue;
+  final colors = ref.watch(colorLibraryProvider);
+
+  return [
+    ShadContextMenuItem(
+      leading: _ColorSwatch(
+        color: currentColorValue == null
+            ? Colors.transparent
+            : Color(currentColorValue),
+      ),
+      items: [
+        for (final entry in colors)
+          ShadContextMenuItem(
+            leading: _ColorSwatch(color: entry.color),
+            trailing: currentColorValue == entry.color.toARGB32()
+                ? const Icon(LucideIcons.check, size: 14)
+                : null,
+            onPressed: () {
+              ref.read(utilityProvider.notifier).updateCustomShapeColor(
+                    id: utility.id,
+                    colorValue: entry.color.toARGB32(),
+                  );
+            },
+            child: Text(_colorLabel(entry)),
+          ),
+        ShadContextMenuItem(
+          leading: const Icon(LucideIcons.palette, size: 14),
+          onPressed: () async {
+            final picked = await showIcarusColorPickerDialog(
+              context: context,
+              initialColor: currentColorValue == null
+                  ? Colors.white
+                  : Color(currentColorValue),
+              title: 'Custom color',
+            );
+            if (picked == null || !context.mounted) return;
+            ref.read(utilityProvider.notifier).updateCustomShapeColor(
+                  id: utility.id,
+                  colorValue: picked.toARGB32(),
+                );
+          },
+          child: const Text('Custom color…'),
+        ),
+      ],
+      child: const Text('Color'),
+    ),
+    ...buildAdjacentPageCopyMenuItems(ref, utility.id),
+  ];
+}
+
+String _colorLabel(ColorLibraryEntry entry) {
+  if (!entry.isCustom) {
+    if (entry.color.toARGB32() == Colors.white.toARGB32()) return 'White';
+    if (entry.color.toARGB32() == Colors.red.toARGB32()) return 'Red';
+    if (entry.color.toARGB32() == Colors.blue.toARGB32()) return 'Blue';
+    if (entry.color.toARGB32() == Colors.yellow.toARGB32()) return 'Yellow';
+    if (entry.color.toARGB32() == Colors.green.toARGB32()) return 'Green';
+  }
+
+  final hex = (entry.color.toARGB32() & 0x00FFFFFF)
+      .toRadixString(16)
+      .padLeft(6, '0')
+      .toUpperCase();
+  return entry.isCustom ? 'Saved #$hex' : '#$hex';
+}
+
+class _ColorSwatch extends StatelessWidget {
+  const _ColorSwatch({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 12,
+      height: 12,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white54),
+      ),
+    );
+  }
+}

--- a/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
@@ -8,12 +8,10 @@ import 'package:icarus/widgets/sidebar_widgets/color_library.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 List<ShadContextMenuItem> buildCustomShapeContextMenuItems(
-  BuildContext context,
   WidgetRef ref,
   PlacedUtility utility,
 ) {
   final currentColorValue = utility.customColorValue;
-  final colors = ref.watch(colorLibraryProvider);
 
   return [
     ShadContextMenuItem(
@@ -22,7 +20,26 @@ List<ShadContextMenuItem> buildCustomShapeContextMenuItems(
             ? Colors.transparent
             : Color(currentColorValue),
       ),
-      items: [
+      items: [_CustomShapeColorItems(utility: utility)],
+      child: const Text('Color'),
+    ),
+    ...buildAdjacentPageCopyMenuItems(ref, utility.id),
+  ];
+}
+
+class _CustomShapeColorItems extends ConsumerWidget {
+  const _CustomShapeColorItems({required this.utility});
+
+  final PlacedUtility utility;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentColorValue = utility.customColorValue;
+    final colors = ref.watch(colorLibraryProvider);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
         for (final entry in colors)
           ShadContextMenuItem(
             leading: _ColorSwatch(color: entry.color),
@@ -56,10 +73,8 @@ List<ShadContextMenuItem> buildCustomShapeContextMenuItems(
           child: const Text('Custom color…'),
         ),
       ],
-      child: const Text('Color'),
-    ),
-    ...buildAdjacentPageCopyMenuItems(ref, utility.id),
-  ];
+    );
+  }
 }
 
 String _colorLabel(ColorLibraryEntry entry) {

--- a/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
+++ b/lib/widgets/draggable_widgets/utilities/custom_shape_context_menu.dart
@@ -57,6 +57,7 @@ class _CustomShapeColorItems extends ConsumerWidget {
         ShadContextMenuItem(
           leading: const Icon(LucideIcons.palette, size: 14),
           onPressed: () async {
+            final utilityNotifier = ref.read(utilityProvider.notifier);
             final picked = await showIcarusColorPickerDialog(
               context: context,
               initialColor: currentColorValue == null
@@ -64,11 +65,11 @@ class _CustomShapeColorItems extends ConsumerWidget {
                   : Color(currentColorValue),
               title: 'Custom color',
             );
-            if (picked == null || !context.mounted) return;
-            ref.read(utilityProvider.notifier).updateCustomShapeColor(
-                  id: utility.id,
-                  colorValue: picked.toARGB32(),
-                );
+            if (picked == null) return;
+            utilityNotifier.updateCustomShapeColor(
+              id: utility.id,
+              colorValue: picked.toARGB32(),
+            );
           },
           child: const Text('Custom color…'),
         ),

--- a/lib/widgets/sidebar_widgets/color_library.dart
+++ b/lib/widgets/sidebar_widgets/color_library.dart
@@ -96,7 +96,7 @@ class ColorLibrary extends ConsumerWidget {
   }
 
   Future<void> _addColor(BuildContext context, WidgetRef ref) async {
-    final picked = await _showColorLibraryDialog(
+    final picked = await showIcarusColorPickerDialog(
       context: context,
       initialColor: Colors.white,
       title: 'Add color',
@@ -111,7 +111,7 @@ class ColorLibrary extends ConsumerWidget {
     WidgetRef ref,
     ColorLibraryEntry entry,
   ) async {
-    final picked = await _showColorLibraryDialog(
+    final picked = await showIcarusColorPickerDialog(
       context: context,
       initialColor: entry.color,
       title: 'Edit color',
@@ -124,7 +124,7 @@ class ColorLibrary extends ConsumerWidget {
   }
 }
 
-Future<Color?> _showColorLibraryDialog({
+Future<Color?> showIcarusColorPickerDialog({
   required BuildContext context,
   required Color initialColor,
   required String title,

--- a/test/custom_shape_color_test.dart
+++ b/test/custom_shape_color_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/placed_classes.dart';
+import 'package:icarus/const/utilities.dart';
+import 'package:icarus/providers/action_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/utility_provider.dart';
+
+class _NoopStrategyProvider extends StrategyProvider {
+  @override
+  StrategyState build() {
+    return StrategyState(
+      isSaved: true,
+      stratName: null,
+      id: 'shape-color-test',
+      storageDirectory: null,
+      activePageId: null,
+    );
+  }
+
+  @override
+  void setUnsaved() {
+    state = state.copyWith(isSaved: false);
+  }
+}
+
+void main() {
+  test('custom shape color changes support undo, redo, and snapshots', () {
+    final container = ProviderContainer(
+      overrides: [
+        strategyProvider.overrideWith(_NoopStrategyProvider.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    final utility = PlacedUtility(
+      type: UtilityType.customCircle,
+      position: const Offset(100, 120),
+      id: 'circle',
+      customDiameter: 12,
+      customColorValue: 0xff8b5cf6,
+      customOpacityPercent: 40,
+    );
+    container.read(utilityProvider.notifier).fromHive([utility]);
+
+    container.read(utilityProvider.notifier).updateCustomShapeColor(
+          id: utility.id,
+          colorValue: 0xffff0000,
+        );
+
+    expect(
+      container.read(utilityProvider).single.customColorValue,
+      0xffff0000,
+    );
+    expect(container.read(actionProvider), hasLength(1));
+    expect(container.read(strategyProvider).isSaved, isFalse);
+
+    final snapshot = container.read(utilityProvider.notifier).takeSnapshot();
+    container.read(utilityProvider.notifier).restoreSnapshot(snapshot);
+
+    container.read(actionProvider.notifier).undoAction();
+    expect(
+      container.read(utilityProvider).single.customColorValue,
+      0xff8b5cf6,
+    );
+
+    container.read(actionProvider.notifier).redoAction();
+    expect(
+      container.read(utilityProvider).single.customColorValue,
+      0xffff0000,
+    );
+
+    container.read(utilityProvider.notifier).updateCustomShapeColor(
+          id: utility.id,
+          colorValue: 0xffff0000,
+        );
+    expect(container.read(actionProvider), hasLength(1));
+  });
+}

--- a/test/custom_shape_indicator_test.dart
+++ b/test/custom_shape_indicator_test.dart
@@ -8,6 +8,8 @@ import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/utilities.dart';
+import 'package:icarus/providers/action_provider.dart';
+import 'package:icarus/providers/color_library_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/screenshot_provider.dart';
 import 'package:icarus/providers/utility_provider.dart';
@@ -16,6 +18,7 @@ import 'package:icarus/widgets/draggable_widgets/utilities/custom_rectangle_util
 import 'package:icarus/widgets/draggable_widgets/utilities/placed_custom_circle_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/placed_custom_rectangle_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/shape_indicator_fade.dart';
+import 'package:icarus/widgets/mouse_watch.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class _FixedMapProvider extends MapProvider {
@@ -228,11 +231,78 @@ void main() {
 
     expect(container.read(utilityProvider).single.rotation, greaterThan(0));
   });
+
+  testWidgets('shape center menu changes the placed shape color',
+      (tester) async {
+    final utility = _circle();
+    final container = _containerWith(utility);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      _harness(
+        container: container,
+        child: PlacedCustomCircleWidget(
+          utility: utility,
+          id: utility.id,
+          onDragEnd: (_) {},
+        ),
+      ),
+    );
+
+    final mouseWatch = tester.widget<MouseWatch>(find.byType(MouseWatch));
+    final colorItem = mouseWatch.contextMenuItems!.first;
+    expect((colorItem.child as Text).data, 'Color');
+
+    final redItem = colorItem.items.firstWhere(
+      (item) =>
+          item is ShadContextMenuItem &&
+          (item.child as Text).data == 'Red',
+    ) as ShadContextMenuItem;
+    redItem.onPressed!();
+    await tester.pump();
+
+    expect(
+      container.read(utilityProvider).single.customColorValue,
+      Colors.red.toARGB32(),
+    );
+    expect(container.read(actionProvider), hasLength(1));
+
+    final updatedMouseWatch =
+        tester.widget<MouseWatch>(find.byType(MouseWatch));
+    final updatedColorItem = updatedMouseWatch.contextMenuItems!.first;
+    final selectedRedItem = updatedColorItem.items.firstWhere(
+      (item) =>
+          item is ShadContextMenuItem &&
+          (item.child as Text).data == 'Red',
+    ) as ShadContextMenuItem;
+    expect(selectedRedItem.trailing, isA<Icon>());
+
+    final customColorItem = updatedColorItem.items.firstWhere(
+      (item) =>
+          item is ShadContextMenuItem &&
+          (item.child as Text).data == 'Custom color…',
+    ) as ShadContextMenuItem;
+    customColorItem.onPressed!();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Custom color'), findsOneWidget);
+    expect(find.text('Apply'), findsOneWidget);
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+  });
 }
 
 ProviderContainer _containerWith(PlacedUtility utility) {
   final container = ProviderContainer(
-    overrides: [mapProvider.overrideWith(_FixedMapProvider.new)],
+    overrides: [
+      mapProvider.overrideWith(_FixedMapProvider.new),
+      colorLibraryProvider.overrideWith(
+        (ref) => const [
+          ColorLibraryEntry(color: Colors.white, isCustom: false),
+          ColorLibraryEntry(color: Colors.red, isCustom: false),
+        ],
+      ),
+    ],
   );
   container.read(utilityProvider.notifier).fromHive([utility]);
   return container;

--- a/test/custom_shape_indicator_test.dart
+++ b/test/custom_shape_indicator_test.dart
@@ -249,17 +249,9 @@ void main() {
       ),
     );
 
-    final mouseWatch = tester.widget<MouseWatch>(find.byType(MouseWatch));
-    final colorItem = mouseWatch.contextMenuItems!.first;
-    expect((colorItem.child as Text).data, 'Color');
-
-    final redItem = colorItem.items.firstWhere(
-      (item) =>
-          item is ShadContextMenuItem &&
-          (item.child as Text).data == 'Red',
-    ) as ShadContextMenuItem;
-    redItem.onPressed!();
-    await tester.pump();
+    await _openShapeColorSubmenu(tester);
+    await tester.tap(find.text('Red'));
+    await tester.pumpAndSettle();
 
     expect(
       container.read(utilityProvider).single.customColorValue,
@@ -267,22 +259,15 @@ void main() {
     );
     expect(container.read(actionProvider), hasLength(1));
 
-    final updatedMouseWatch =
-        tester.widget<MouseWatch>(find.byType(MouseWatch));
-    final updatedColorItem = updatedMouseWatch.contextMenuItems!.first;
-    final selectedRedItem = updatedColorItem.items.firstWhere(
-      (item) =>
-          item is ShadContextMenuItem &&
-          (item.child as Text).data == 'Red',
-    ) as ShadContextMenuItem;
+    await _openShapeColorSubmenu(tester);
+    final selectedRedItem = tester
+        .widgetList<ShadContextMenuItem>(find.byType(ShadContextMenuItem))
+        .firstWhere(
+          (item) => item.child is Text && (item.child as Text).data == 'Red',
+        );
     expect(selectedRedItem.trailing, isA<Icon>());
 
-    final customColorItem = updatedColorItem.items.firstWhere(
-      (item) =>
-          item is ShadContextMenuItem &&
-          (item.child as Text).data == 'Custom color…',
-    ) as ShadContextMenuItem;
-    customColorItem.onPressed!();
+    await tester.tap(find.text('Custom color…'));
     await tester.pumpAndSettle();
 
     expect(find.text('Custom color'), findsOneWidget);
@@ -290,6 +275,23 @@ void main() {
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
   });
+}
+
+Future<void> _openShapeColorSubmenu(WidgetTester tester) async {
+  final centerHandle = find.byType(MouseWatch).first;
+  await tester.tapAt(
+    tester.getCenter(centerHandle),
+    buttons: kSecondaryMouseButton,
+  );
+  await tester.pumpAndSettle();
+
+  final colorItem = find.text('Color');
+  expect(colorItem, findsOneWidget);
+  await tester.sendEventToBinding(
+    PointerHoverEvent(position: tester.getCenter(colorItem)),
+  );
+  await tester.pump(const Duration(milliseconds: 150));
+  await tester.pumpAndSettle();
 }
 
 ProviderContainer _containerWith(PlacedUtility utility) {

--- a/test/custom_shape_indicator_test.dart
+++ b/test/custom_shape_indicator_test.dart
@@ -272,8 +272,18 @@ void main() {
 
     expect(find.text('Custom color'), findsOneWidget);
     expect(find.text('Apply'), findsOneWidget);
-    await tester.tap(find.text('Cancel'));
+    await tester.enterText(find.byType(TextField).at(0), '120');
+    await tester.enterText(find.byType(TextField).at(1), '100');
+    await tester.enterText(find.byType(TextField).at(2), '100');
+    await tester.pump();
+    await tester.tap(find.text('Apply'));
     await tester.pumpAndSettle();
+
+    expect(
+      container.read(utilityProvider).single.customColorValue,
+      const Color(0xFF00FF00).toARGB32(),
+    );
+    expect(container.read(actionProvider), hasLength(2));
   });
 }
 


### PR DESCRIPTION
## What changed

- add a Color submenu to the center-handle context menu for placed custom circles and rectangles
- expose saved library colors and a Custom color… action that opens the full picker
- make color changes undoable/redoable and preserve them through provider snapshots
- retain adjacent-page copy actions in the same context menu

## Why

Players should be able to refine a tactical idea without deleting and recreating an already placed shape just to change its color.

## User impact

Right-clicking a custom shape’s center drag handle now allows immediate recoloring. Saved colors apply in one click; Custom color… opens the picker initialized to the shape’s current color.

## Validation

- `flutter test test/custom_shape_color_test.dart test/custom_shape_indicator_test.dart`
- `flutter test test/strategy_integrity_test.dart`
- targeted `flutter analyze` on the changed production and test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context menus for custom shapes with built-in, saved, and custom color selection.
  * Added visual indicators for the currently selected color.
  * Added support for copying custom shapes between adjacent pages.
  * Added a reusable custom color picker for shape color updates.

* **Bug Fixes**
  * Custom shape color changes now support undo and redo.
  * Color updates are saved and restored correctly with snapshots.

* **Tests**
  * Added coverage for color selection, persistence, snapshot restoration, undo, redo, and custom color dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->