### PR TITLE
Show inactive Viper utility states

### DIFF
--- a/lib/const/abilities.dart
+++ b/lib/const/abilities.dart
@@ -118,8 +118,15 @@ class BaseAbility extends Ability {
 class ImageAbility extends Ability {
   final String imagePath;
   final double size;
+  final Color? inactiveTraceColor;
 
-  ImageAbility({required this.imagePath, required this.size});
+  ImageAbility({
+    required this.imagePath,
+    required this.size,
+    this.inactiveTraceColor,
+  });
+
+  bool get supportsInactiveState => inactiveTraceColor != null;
 
   @override
   Widget createWidget({
@@ -141,6 +148,10 @@ class ImageAbility extends Ability {
       imagePath: imagePath,
       size: size * mapScale,
       id: id,
+      visualState: visualState,
+      inactiveTraceColor: inactiveTraceColor,
+      watchMouse: watchMouse,
+      contextMenuItems: contextMenuItems,
     );
   }
 
@@ -343,6 +354,7 @@ class SquareAbility extends Ability {
   final bool hasTopborder;
   final bool hasSideBorders;
   final bool isTransparent;
+  final bool supportsInactiveState;
 
   SquareAbility({
     required this.width,
@@ -354,8 +366,12 @@ class SquareAbility extends Ability {
     this.hasTopborder = false,
     this.hasSideBorders = false,
     this.isTransparent = false,
+    this.supportsInactiveState = false,
     double? minHeight,
-  });
+  }) : assert(
+          !supportsInactiveState || isWall,
+          'Inactive square traces are only supported for walls',
+        );
 
   @override
   Offset getAnchorPoint({
@@ -430,6 +446,7 @@ class SquareAbility extends Ability {
       hasSideBorders: hasSideBorders,
       isWall: isWall,
       isTransparent: isTransparent,
+      supportsInactiveState: supportsInactiveState,
       visualState: visualState,
       watchMouse: watchMouse,
       contextMenuItems: contextMenuItems,

--- a/lib/const/agents.dart
+++ b/lib/const/agents.dart
@@ -366,6 +366,7 @@ class AgentData implements DraggableData {
           abilityData: ImageAbility(
             imagePath: 'assets/agents/Viper/Smoke.webp',
             size: 4.5 * inGameMetersDiameter,
+            inactiveTraceColor: Colors.greenAccent,
           ),
         );
 
@@ -380,6 +381,7 @@ class AgentData implements DraggableData {
         width: 5,
         height: 60 * inGameMeters,
         isWall: true,
+        supportsInactiveState: true,
         iconPath: agent.abilities[2].iconPath,
         color: Colors.greenAccent,
       );

--- a/lib/widgets/draggable_widgets/ability/ability_visibility_context_menu.dart
+++ b/lib/widgets/draggable_widgets/ability/ability_visibility_context_menu.dart
@@ -10,11 +10,20 @@ import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 bool supportsAbilityVisibilityMenu(Ability? ability) {
-  return ability is SquareAbility ||
+  return supportsAbilityInactiveState(ability) ||
+      ability is SquareAbility ||
       ability is CenterSquareAbility ||
       ability is CircleAbility ||
       ability is SectorCircleAbility ||
       ability is DeadlockBarrierMeshAbility;
+}
+
+bool supportsAbilityInactiveState(Ability? ability) {
+  return switch (ability) {
+    ImageAbility() => ability.supportsInactiveState,
+    SquareAbility() => ability.supportsInactiveState,
+    _ => false,
+  };
 }
 
 List<ShadContextMenuItem>? buildAbilityContextMenuItems(
@@ -77,6 +86,18 @@ List<_AbilityVisibilityControl> _buildVisibilityControls(
   Ability? abilityData,
   AbilityVisualState visualState,
 ) {
+  if (supportsAbilityInactiveState(abilityData)) {
+    return [
+      _AbilityVisibilityControl(
+        label: 'Active',
+        isEnabled: visualState.showRangeFill,
+        toggle: (state) => state.copyWith(
+          showRangeFill: !state.showRangeFill,
+        ),
+      ),
+    ];
+  }
+
   if (abilityData is CircleAbility || abilityData is SectorCircleAbility) {
     if (_hasInnerRange(abilityData)) {
       return [

--- a/lib/widgets/draggable_widgets/ability/custom_square_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/custom_square_widget.dart
@@ -75,7 +75,7 @@ class CustomSquareWidget extends ConsumerWidget {
       child: Container(
         width: width,
         height: scaledHeight,
-        color: color.withAlpha(100),
+        color: abilityWallDisplayColor(color),
       ),
     );
 

--- a/lib/widgets/draggable_widgets/ability/custom_square_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/custom_square_widget.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
 import 'package:icarus/widgets/custom_border_container.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/ability_widget.dart';
+import 'package:icarus/widgets/draggable_widgets/ability/inactive_ability_trace.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class CustomSquareWidget extends ConsumerWidget {
@@ -24,6 +25,7 @@ class CustomSquareWidget extends ConsumerWidget {
     required this.hasSideBorders,
     required this.isWall,
     required this.isTransparent,
+    this.supportsInactiveState = false,
     this.visualState,
     this.watchMouse = true,
     this.contextMenuItems,
@@ -43,6 +45,7 @@ class CustomSquareWidget extends ConsumerWidget {
   final bool hasSideBorders;
   final bool isWall;
   final bool isTransparent;
+  final bool supportsInactiveState;
   final AbilityVisualState? visualState;
   final bool watchMouse;
   final List<ShadContextMenuItem>? contextMenuItems;
@@ -67,6 +70,14 @@ class CustomSquareWidget extends ConsumerWidget {
         (scaledAbilitySize / 2) +
         resizeButtonOffset;
     final showRangeFill = visualState?.showRangeFill ?? true;
+    final inactiveTraceWidth = coordinateSystem.scale(12);
+    final wallBody = IgnorePointer(
+      child: Container(
+        width: width,
+        height: scaledHeight,
+        color: color.withAlpha(100),
+      ),
+    );
 
     return SizedBox(
       width: scaledWidth,
@@ -111,14 +122,32 @@ class CustomSquareWidget extends ConsumerWidget {
             Positioned(
               top: resizeButtonOffset,
               left: (scaledWidth / 2) - width / 2,
-              child: Opacity(
-                key: const ValueKey('square-range-body'),
-                opacity: showRangeFill ? 1 : 0,
+              child: supportsInactiveState
+                  ? AnimatedOpacity(
+                      key: const ValueKey('square-range-body-transition'),
+                      opacity: showRangeFill ? 1 : 0,
+                      duration: abilityStateTransitionDuration,
+                      child: wallBody,
+                    )
+                  : Opacity(
+                      key: const ValueKey('square-range-body'),
+                      opacity: showRangeFill ? 1 : 0,
+                      child: wallBody,
+                    ),
+            ),
+          if (isWall && supportsInactiveState)
+            Positioned(
+              top: resizeButtonOffset,
+              left: (scaledWidth - inactiveTraceWidth) / 2,
+              child: AnimatedOpacity(
+                key: const ValueKey('inactive-wall-trace-transition'),
+                opacity: showRangeFill ? 0 : 1,
+                duration: abilityStateTransitionDuration,
                 child: IgnorePointer(
-                  child: Container(
-                    width: width,
+                  child: SizedBox(
+                    width: inactiveTraceWidth,
                     height: scaledHeight,
-                    color: color.withAlpha(100),
+                    child: InactiveWallAbilityTrace(color: color),
                   ),
                 ),
               ),

--- a/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
+++ b/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
@@ -86,25 +86,20 @@ class InactiveWallAbilityTracePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    const endpointRadius = 3.0;
-    final start = Offset(size.width / 2, endpointRadius);
-    final end = Offset(size.width / 2, size.height - endpointRadius);
+    const strokeWidth = 2.0;
+    const inset = strokeWidth / 2;
+    final start = Offset(size.width / 2, inset);
+    final end = Offset(size.width / 2, size.height - inset);
     final path = Path()
       ..moveTo(start.dx, start.dy)
       ..lineTo(end.dx, end.dy);
     final tracePaint = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
+      ..strokeWidth = strokeWidth
       ..strokeCap = StrokeCap.round;
 
     _drawDashedPath(canvas, path, tracePaint);
-
-    final endpointPaint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(start, endpointRadius, endpointPaint);
-    canvas.drawCircle(end, endpointRadius, endpointPaint);
   }
 
   @override

--- a/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
+++ b/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
@@ -4,13 +4,7 @@ import 'package:flutter/material.dart';
 
 const abilityStateTransitionDuration = Duration(milliseconds: 180);
 
-Color inactiveAbilityTraceColor(Color activeColor) {
-  final hsl = HSLColor.fromColor(activeColor);
-  return hsl
-      .withSaturation((hsl.saturation * 0.7).clamp(0.0, 1.0))
-      .toColor()
-      .withValues(alpha: 1);
-}
+Color abilityWallDisplayColor(Color color) => color.withAlpha(100);
 
 class InactiveCircleAbilityTrace extends StatelessWidget {
   const InactiveCircleAbilityTrace({super.key, required this.color});
@@ -22,7 +16,7 @@ class InactiveCircleAbilityTrace extends StatelessWidget {
     return CustomPaint(
       key: const ValueKey('inactive-circle-trace'),
       painter: InactiveCircleAbilityTracePainter(
-        color: inactiveAbilityTraceColor(color),
+        color: abilityWallDisplayColor(color),
       ),
     );
   }
@@ -38,7 +32,7 @@ class InactiveWallAbilityTrace extends StatelessWidget {
     return CustomPaint(
       key: const ValueKey('inactive-wall-trace'),
       painter: InactiveWallAbilityTracePainter(
-        color: inactiveAbilityTraceColor(color),
+        color: abilityWallDisplayColor(color),
       ),
     );
   }

--- a/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
+++ b/lib/widgets/draggable_widgets/ability/inactive_ability_trace.dart
@@ -1,0 +1,137 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+const abilityStateTransitionDuration = Duration(milliseconds: 180);
+
+Color inactiveAbilityTraceColor(Color activeColor) {
+  final hsl = HSLColor.fromColor(activeColor);
+  return hsl
+      .withSaturation((hsl.saturation * 0.7).clamp(0.0, 1.0))
+      .toColor()
+      .withValues(alpha: 1);
+}
+
+class InactiveCircleAbilityTrace extends StatelessWidget {
+  const InactiveCircleAbilityTrace({super.key, required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      key: const ValueKey('inactive-circle-trace'),
+      painter: InactiveCircleAbilityTracePainter(
+        color: inactiveAbilityTraceColor(color),
+      ),
+    );
+  }
+}
+
+class InactiveWallAbilityTrace extends StatelessWidget {
+  const InactiveWallAbilityTrace({super.key, required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      key: const ValueKey('inactive-wall-trace'),
+      painter: InactiveWallAbilityTracePainter(
+        color: inactiveAbilityTraceColor(color),
+      ),
+    );
+  }
+}
+
+class InactiveCircleAbilityTracePainter extends CustomPainter {
+  const InactiveCircleAbilityTracePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const strokeWidth = 2.0;
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+    const inset = strokeWidth / 2;
+    final boundary = Path()
+      ..addOval(
+        Rect.fromLTWH(
+          inset,
+          inset,
+          math.max(0, size.width - strokeWidth),
+          math.max(0, size.height - strokeWidth),
+        ),
+      );
+
+    _drawDashedPath(canvas, boundary, paint);
+
+    canvas.drawCircle(
+      size.center(Offset.zero),
+      3,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.fill,
+    );
+  }
+
+  @override
+  bool shouldRepaint(InactiveCircleAbilityTracePainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+class InactiveWallAbilityTracePainter extends CustomPainter {
+  const InactiveWallAbilityTracePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const endpointRadius = 3.0;
+    final start = Offset(size.width / 2, endpointRadius);
+    final end = Offset(size.width / 2, size.height - endpointRadius);
+    final path = Path()
+      ..moveTo(start.dx, start.dy)
+      ..lineTo(end.dx, end.dy);
+    final tracePaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2
+      ..strokeCap = StrokeCap.round;
+
+    _drawDashedPath(canvas, path, tracePaint);
+
+    final endpointPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(start, endpointRadius, endpointPaint);
+    canvas.drawCircle(end, endpointRadius, endpointPaint);
+  }
+
+  @override
+  bool shouldRepaint(InactiveWallAbilityTracePainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+void _drawDashedPath(
+  Canvas canvas,
+  Path path,
+  Paint paint, {
+  double dashLength = 8,
+  double gapLength = 5,
+}) {
+  for (final metric in path.computeMetrics()) {
+    double distance = 0;
+    while (distance < metric.length) {
+      final end = math.min(distance + dashLength, metric.length);
+      canvas.drawPath(metric.extractPath(distance, end), paint);
+      distance = end + gapLength;
+    }
+  }
+}

--- a/lib/widgets/draggable_widgets/ability/simple_image_ability_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/simple_image_ability_widget.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/ability/inactive_ability_trace.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 class SimpleImageAbilityWidget extends ConsumerWidget {
   const SimpleImageAbilityWidget({
@@ -13,6 +16,10 @@ class SimpleImageAbilityWidget extends ConsumerWidget {
     required this.id,
     this.lineUpId,
     this.lineUpItemId,
+    this.visualState,
+    this.inactiveTraceColor,
+    this.watchMouse = true,
+    this.contextMenuItems,
   });
 
   final double size;
@@ -21,6 +28,11 @@ class SimpleImageAbilityWidget extends ConsumerWidget {
   final String? id;
   final String? lineUpId;
   final String? lineUpItemId;
+  final AbilityVisualState? visualState;
+  final Color? inactiveTraceColor;
+  final bool watchMouse;
+  final List<ShadContextMenuItem>? contextMenuItems;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final coordinateSystem = CoordinateSystem.instance;
@@ -29,17 +41,45 @@ class SimpleImageAbilityWidget extends ConsumerWidget {
         : (id?.isNotEmpty ?? false)
             ? HoveredDeleteTarget.ability(id: id!, ownerToken: Object())
             : null;
+    final supportsInactiveState = inactiveTraceColor != null;
+    final isActive =
+        !supportsInactiveState || (visualState?.showRangeFill ?? true);
+    final content = SizedBox(
+      width: coordinateSystem.scale(size),
+      height: coordinateSystem.scale(size),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          AnimatedOpacity(
+            key: const ValueKey('image-ability-active-layer'),
+            opacity: isActive ? 1 : 0,
+            duration: abilityStateTransitionDuration,
+            child: Image.asset(imagePath),
+          ),
+          if (supportsInactiveState)
+            AnimatedOpacity(
+              key: const ValueKey('image-ability-inactive-layer'),
+              opacity: isActive ? 0 : 1,
+              duration: abilityStateTransitionDuration,
+              child: InactiveCircleAbilityTrace(
+                color: inactiveTraceColor!,
+              ),
+            ),
+        ],
+      ),
+    );
+
+    if (!watchMouse) {
+      return content;
+    }
 
     return MouseWatch(
       lineUpId: lineUpId,
       lineUpItemId: lineUpItemId,
       cursor: SystemMouseCursors.click,
       deleteTarget: deleteTarget,
-      child: SizedBox(
-        width: coordinateSystem.scale(size),
-        height: coordinateSystem.scale(size),
-        child: Image.asset(imagePath),
-      ),
+      contextMenuItems: contextMenuItems,
+      child: content,
     );
   }
 }

--- a/test/ability_visibility_widgets_test.dart
+++ b/test/ability_visibility_widgets_test.dart
@@ -16,6 +16,7 @@ import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/ability_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/custom_square_widget.dart';
+import 'package:icarus/widgets/draggable_widgets/ability/inactive_ability_trace.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/placed_ability_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/resizable_square_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/ability/rotatable_widget.dart';
@@ -104,6 +105,130 @@ void main() {
       expect(rangeBody.opacity, 0);
       expect(rotatable.showHandle, isFalse);
       expect(find.byType(AbilityWidget), findsOneWidget);
+    });
+
+    testWidgets('inactive Viper cloud keeps its footprint as a dashed trace',
+        (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          actionProvider.overrideWith(_TestActionProvider.new),
+          mapProvider.overrideWith(_FixedMapProvider.new),
+        ],
+      );
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        container.dispose();
+      });
+
+      final ability = PlacedAbility(
+        id: 'viper-cloud-inactive',
+        data: AgentData.agents[AgentType.viper]!.abilities[1],
+        position: const Offset(100, 120),
+        visualState: const AbilityVisualState(showRangeFill: false),
+      );
+      container.read(abilityProvider.notifier).fromHive([ability]);
+
+      await tester.pumpWidget(
+        _buildHarness(
+          container: container,
+          child: Stack(
+            children: [
+              PlacedAbilityWidget(
+                ability: ability,
+                onDragEnd: (_, __) {},
+                id: ability.id,
+                data: ability,
+                rotation: ability.rotation,
+                length: ability.length,
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<AnimatedOpacity>(
+              find.byKey(const ValueKey('image-ability-active-layer')),
+            )
+            .opacity,
+        0,
+      );
+      expect(
+        tester
+            .widget<AnimatedOpacity>(
+              find.byKey(const ValueKey('image-ability-inactive-layer')),
+            )
+            .opacity,
+        1,
+      );
+      expect(find.byType(InactiveCircleAbilityTrace), findsOneWidget);
+      expect(find.byKey(const ValueKey('inactive-circle-trace')), findsOneWidget);
+    });
+
+    testWidgets('inactive Viper wall keeps its path and hides its handle',
+        (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          actionProvider.overrideWith(_TestActionProvider.new),
+          mapProvider.overrideWith(_FixedMapProvider.new),
+        ],
+      );
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        container.dispose();
+      });
+
+      final ability = PlacedAbility(
+        id: 'viper-wall-inactive',
+        data: AgentData.agents[AgentType.viper]!.abilities[2],
+        position: const Offset(100, 120),
+        visualState: const AbilityVisualState(showRangeFill: false),
+      );
+      container.read(abilityProvider.notifier).fromHive([ability]);
+
+      await tester.pumpWidget(
+        _buildHarness(
+          container: container,
+          child: Stack(
+            children: [
+              PlacedAbilityWidget(
+                ability: ability,
+                onDragEnd: (_, __) {},
+                id: ability.id,
+                data: ability,
+                rotation: ability.rotation,
+                length: ability.length,
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<AnimatedOpacity>(
+              find.byKey(const ValueKey('square-range-body-transition')),
+            )
+            .opacity,
+        0,
+      );
+      expect(
+        tester
+            .widget<AnimatedOpacity>(
+              find.byKey(const ValueKey('inactive-wall-trace-transition')),
+            )
+            .opacity,
+        1,
+      );
+      expect(find.byType(InactiveWallAbilityTrace), findsOneWidget);
+      expect(find.byKey(const ValueKey('inactive-wall-trace')), findsOneWidget);
+      expect(
+        tester.widget<RotatableWidget>(find.byType(RotatableWidget)).showHandle,
+        isFalse,
+      );
     });
 
     testWidgets('circle visibility toggles preserve icon and target layers',
@@ -338,6 +463,76 @@ void main() {
       expect(find.text('Range'), findsOneWidget);
       expect(find.text('Range Outline'), findsNothing);
       expect(find.text('Mesh'), findsNothing);
+    });
+
+    testWidgets('Viper cloud exposes an Active toggle and applies it',
+        (tester) async {
+      final ability = PlacedAbility(
+        id: 'viper-cloud-menu',
+        data: AgentData.agents[AgentType.viper]!.abilities[1],
+        position: Offset.zero,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          actionProvider.overrideWith(_TestActionProvider.new),
+          mapProvider.overrideWith(_FixedMapProvider.new),
+        ],
+      );
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        container.dispose();
+      });
+      container.read(abilityProvider.notifier).fromHive([ability]);
+
+      await tester.pumpWidget(
+        _buildHarness(
+          container: container,
+          child: Stack(
+            children: [
+              PlacedAbilityWidget(
+                ability: ability,
+                onDragEnd: (_, __) {},
+                id: ability.id,
+                data: ability,
+                rotation: ability.rotation,
+                length: ability.length,
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await _openContextMenu(
+        tester,
+        find.byKey(const ValueKey('image-ability-active-layer')),
+      );
+
+      expect(find.text('Active'), findsOneWidget);
+      expect(find.text('Range'), findsNothing);
+
+      await tester.tap(find.text('Active'));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(abilityProvider).single.visualState.showRangeFill,
+        isFalse,
+      );
+    });
+
+    testWidgets('Viper wall uses Active instead of a generic Range toggle',
+        (tester) async {
+      final ability = PlacedAbility(
+        id: 'viper-wall-menu',
+        data: AgentData.agents[AgentType.viper]!.abilities[2],
+        position: Offset.zero,
+      );
+
+      await _pumpPlacedAbility(tester, ability: ability);
+      await _openContextMenu(tester, find.byType(AbilityWidget));
+
+      expect(find.text('Active'), findsOneWidget);
+      expect(find.text('Range'), findsNothing);
     });
 
     testWidgets('placed circle ability shows range and inner layer toggles',

--- a/test/ability_visibility_widgets_test.dart
+++ b/test/ability_visibility_widgets_test.dart
@@ -165,6 +165,13 @@ void main() {
       );
       expect(find.byType(InactiveCircleAbilityTrace), findsOneWidget);
       expect(find.byKey(const ValueKey('inactive-circle-trace')), findsOneWidget);
+      final trace = tester.widget<CustomPaint>(
+        find.byKey(const ValueKey('inactive-circle-trace')),
+      );
+      expect(
+        (trace.painter! as InactiveCircleAbilityTracePainter).color,
+        Colors.greenAccent.withAlpha(100),
+      );
     });
 
     testWidgets('inactive Viper wall keeps its path and hides its handle',
@@ -225,6 +232,13 @@ void main() {
       );
       expect(find.byType(InactiveWallAbilityTrace), findsOneWidget);
       expect(find.byKey(const ValueKey('inactive-wall-trace')), findsOneWidget);
+      final trace = tester.widget<CustomPaint>(
+        find.byKey(const ValueKey('inactive-wall-trace')),
+      );
+      expect(
+        (trace.painter! as InactiveWallAbilityTracePainter).color,
+        Colors.greenAccent.withAlpha(100),
+      );
       expect(
         tester.widget<RotatableWidget>(find.byType(RotatableWidget)).showHandle,
         isFalse,


### PR DESCRIPTION
## What
- Adds a right-click `Active` toggle for Viper's Poison Cloud and Toxic Screen.
- Crossfades active utility into a badge-free inactive trace: dashed cloud footprint with a solid center point, or a clean dashed full-length wall path.
- Uses the exact regular Toxic Screen wall color and opacity for both inactive traces (`Colors.greenAccent` at alpha `100`).
- Keeps the placed icon and existing spatial footprint so inactive utility remains legible on the map.
- Reuses the existing `AbilityVisualState`, preserving strategy saves, undo/redo, lineups, and `.ica` round-trips without a schema migration.

## Why
An icon-only or faded state loses spatial truth. The dashed geometry keeps the planned placement visible while clearly separating inactive utility from active gas.

## Deactivated state
![Viper Poison Cloud and Toxic Screen in their deactivated state](https://codex-file-host.shawnadedeji.workers.dev/files/icarus-pr/ad1c4485e285-viper-deactivated-no-dots.png)

## Demo
[▶ Watch the updated 13-second Viper inactive-state demo](https://codex-file-host.shawnadedeji.workers.dev/files/icarus-pr/099eb77a3b32-viper-no-endpoint-dots-87402fcae7404ebdad73218fd3d120cc.mp4)

The screenshot and recording use the production widgets and context menus in an isolated, non-persisting demo surface; no local strategy library data was read or written.

## Checks
- `flutter test` — all tests passed
- `flutter test test/ability_visibility_widgets_test.dart` — 29 passed after the visual adjustments
- `flutter build windows --debug` — passed
- `flutter analyze` — only the pre-existing `pages_bar.dart:534` `onReorder` deprecation remains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inactive-state visualization for supported abilities, including Viper’s Poison Cloud and Toxic Screen.
  * Added animated inactive traces for circular and wall abilities.
  * Added an **Active** visibility toggle for abilities that support inactive states.
  * Preserved wall paths and updated visual transitions when abilities are activated or hidden.

* **Bug Fixes**
  * Improved ability visibility behavior and context-menu actions for inactive-state abilities.

* **Tests**
  * Added coverage for inactive rendering, trace colors, visibility toggles, activation behavior, and rotation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->