### PR TITLE
Add sponsors and a one-time support prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Icarus is completely free and open source. If it helps your team, you can [buy D
 
 ## Sponsors
 
-[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
+<a href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source">
+  <img src="https://www.greptile.com/badge.svg" alt="Greptile: The War on Bugs" width="600">
+</a>
 
 [Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
 

--- a/README.md
+++ b/README.md
@@ -76,4 +76,14 @@ If you would like to contribute, please fork the repository and submit a pull re
 
 ## Support
 
-This project is completely free and open source. Your support helps maintain it.
+Icarus is completely free and open source. If it helps your team, you can [buy Dara a coffee](https://www.buymeacoffee.com/daradoescode) to support its continued development.
+
+## Sponsors
+
+<a href="https://www.greptile.com/open-source">
+  <img src="https://www.greptile.com/wordmark-logo-green.svg" alt="Greptile" height="32">
+</a>
+
+[Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
+
+**[OpenAI — Codex for Open Source](https://openai.com/form/codex-for-oss/)** provides tooling and credits for open-source maintenance.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ Icarus is completely free and open source. If it helps your team, you can [buy D
 
 ## Sponsors
 
-<a href="https://www.greptile.com/open-source">
-  <img src="https://www.greptile.com/wordmark-logo-green.svg" alt="Greptile" height="32">
-</a>
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 [Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
 

--- a/lib/const/hive_boxes.dart
+++ b/lib/const/hive_boxes.dart
@@ -5,4 +5,8 @@ class HiveBoxNames {
   static const appPreferencesBox = "app_preferences_box";
   static const favoriteAgentsBox = "favorite_agents_box";
   static const pinnedItemsBox = "pinned_items_box";
+  static const appFlagsBox = "app_flags_box";
+
+  static const appLaunchCountKey = "app_launch_count";
+  static const supportPromptShownKey = "support_prompt_shown";
 }

--- a/lib/const/settings.dart
+++ b/lib/const/settings.dart
@@ -98,6 +98,12 @@ class Settings {
   }
 
   static final Uri dicordLink = Uri.parse("https://discord.gg/PN2uKwCqYB");
+  static final Uri buyMeACoffeeLink =
+      Uri.parse("https://www.buymeacoffee.com/daradoescode");
+  static final Uri greptileOpenSourceLink =
+      Uri.parse("https://www.greptile.com/open-source");
+  static final Uri openAICodexForOssLink =
+      Uri.parse("https://openai.com/form/codex-for-oss/");
 
   static const Duration autoSaveOffset = Duration(seconds: 15);
   static const int versionNumber = 95;
@@ -227,9 +233,10 @@ class Settings {
     required Color backgroundColor,
     String? actionLabel,
     VoidCallback? onActionPressed,
+    Duration autoCloseDuration = const Duration(seconds: 3),
   }) {
     toastification.showCustom(
-      autoCloseDuration: const Duration(seconds: 3),
+      autoCloseDuration: autoCloseDuration,
       alignment: Alignment.bottomCenter,
       builder: (context, holder) {
         final actionIsVisible = actionLabel != null &&

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,6 +89,10 @@ Future<void> main(List<String> args) async {
       await Hive.openBox<AppPreferences>(HiveBoxNames.appPreferencesBox);
       await Hive.openBox<bool>(HiveBoxNames.favoriteAgentsBox);
       await Hive.openBox<int>(HiveBoxNames.pinnedItemsBox);
+      final appFlagsBox = await Hive.openBox<int>(HiveBoxNames.appFlagsBox);
+      final launchCount =
+          appFlagsBox.get(HiveBoxNames.appLaunchCountKey, defaultValue: 0) ?? 0;
+      await appFlagsBox.put(HiveBoxNames.appLaunchCountKey, launchCount + 1);
       await Hive.openBox<dynamic>(AnalyticsService.storageBoxName);
 
       await MapThemeProfilesProvider.bootstrap();

--- a/lib/widgets/folder_navigator.dart
+++ b/lib/widgets/folder_navigator.dart
@@ -96,7 +96,6 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
 
   Future<void> _maybeShowSupportPrompt() async {
     if (kIsWeb) return;
-    if (Platform.isWindows && !isWebViewInitialized) return;
     if (!Hive.isBoxOpen(HiveBoxNames.appFlagsBox)) return;
 
     final flags = Hive.box<int>(HiveBoxNames.appFlagsBox);
@@ -109,6 +108,8 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
     // Claim the prompt before the delay so a route change or quick exit never
     // turns a one-time invitation into a recurring interruption.
     await flags.put(HiveBoxNames.supportPromptShownKey, 1);
+    if (Platform.isWindows && !isWebViewInitialized) return;
+
     await Future<void>.delayed(const Duration(seconds: 6));
     if (!mounted) return;
 

--- a/lib/widgets/folder_navigator.dart
+++ b/lib/widgets/folder_navigator.dart
@@ -4,7 +4,9 @@ import 'package:desktop_updater/desktop_updater.dart';
 import 'package:flutter/foundation.dart' show debugPrint, kDebugMode, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/routes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/update_checker.dart';
@@ -25,6 +27,7 @@ import 'package:icarus/widgets/folder_content.dart';
 import 'package:icarus/widgets/folder_edit_dialog.dart';
 import 'package:icarus/widgets/ica_drop_target.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 
 class FolderNavigator extends ConsumerStatefulWidget {
   const FolderNavigator({super.key});
@@ -85,8 +88,40 @@ class _FolderNavigatorState extends ConsumerState<FolderNavigator> {
         _warnWebView();
 
         _warnDemo();
+
+        _maybeShowSupportPrompt();
       }
     });
+  }
+
+  Future<void> _maybeShowSupportPrompt() async {
+    if (kIsWeb) return;
+    if (Platform.isWindows && !isWebViewInitialized) return;
+    if (!Hive.isBoxOpen(HiveBoxNames.appFlagsBox)) return;
+
+    final flags = Hive.box<int>(HiveBoxNames.appFlagsBox);
+    final launchCount =
+        flags.get(HiveBoxNames.appLaunchCountKey, defaultValue: 0) ?? 0;
+    final hasShownPrompt =
+        flags.get(HiveBoxNames.supportPromptShownKey, defaultValue: 0) == 1;
+    if (launchCount < 3 || hasShownPrompt) return;
+
+    // Claim the prompt before the delay so a route change or quick exit never
+    // turns a one-time invitation into a recurring interruption.
+    await flags.put(HiveBoxNames.supportPromptShownKey, 1);
+    await Future<void>.delayed(const Duration(seconds: 6));
+    if (!mounted) return;
+
+    Settings.showToast(
+      message:
+          'Icarus is free and open source. If it helps your team, you can help keep it going.',
+      backgroundColor: Settings.tacticalVioletTheme.card,
+      actionLabel: 'Buy me a coffee',
+      onActionPressed: () {
+        launchUrl(Settings.buyMeACoffeeLink);
+      },
+      autoCloseDuration: const Duration(seconds: 8),
+    );
   }
 
   void _warnWebView() async {

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -16,6 +16,7 @@ import 'package:icarus/widgets/map_theme_settings_section.dart';
 import 'package:icarus/widgets/settings_scope_card.dart';
 import 'package:icarus/widgets/text_editing_shortcut_scope.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl;
 
 enum _SettingsMode {
   strategy,
@@ -31,6 +32,7 @@ enum _SettingsSection {
   globalMapVisibility,
   globalMapProfiles,
   globalPrivacy,
+  globalSupport,
   shortcuts,
 }
 
@@ -72,7 +74,10 @@ class _SettingsTabState extends ConsumerState<SettingsTab> {
     };
     final scopeValue = switch (_mode) {
       _SettingsMode.strategy => activeStrategyName,
-      _SettingsMode.global => 'Defaults',
+      _SettingsMode.global =>
+        _selectedSection == _SettingsSection.globalSupport
+            ? 'About & sponsors'
+            : 'Defaults',
       _SettingsMode.shortcuts => 'Keybinds',
     };
 
@@ -193,6 +198,7 @@ class _SettingsTabState extends ConsumerState<SettingsTab> {
       case _SettingsSection.globalMapVisibility:
       case _SettingsSection.globalMapProfiles:
       case _SettingsSection.globalPrivacy:
+      case _SettingsSection.globalSupport:
         return _SettingsMode.global;
       case _SettingsSection.shortcuts:
         return _SettingsMode.shortcuts;
@@ -560,6 +566,51 @@ class _GlobalSettingsSections extends ConsumerWidget {
           key: sectionKeys[_SettingsSection.globalMapProfiles],
           child: const MapThemeSettingsSection(
             scope: MapThemeSettingsScope.global,
+          ),
+        ),
+        const SizedBox(height: 20),
+        const _SectionDivider(),
+        const SizedBox(height: 20),
+        SettingsScopeCard(
+          key: sectionKeys[_SettingsSection.globalSupport],
+          title: "Sponsors & support",
+          description:
+              "Icarus stays free through open-source programs and support from its users.",
+          child: Column(
+            children: [
+              _SupportLinkTile(
+                icon: Icons.bug_report_outlined,
+                title: "Greptile",
+                description:
+                    "AI code review through Greptile's Open Source Program.",
+                actionLabel: "View program",
+                onPressed: () {
+                  launchUrl(Settings.greptileOpenSourceLink);
+                },
+              ),
+              const _SettingsItemDivider(),
+              _SupportLinkTile(
+                icon: Icons.code_outlined,
+                title: "OpenAI",
+                description:
+                    "Tooling and credits through Codex for Open Source.",
+                actionLabel: "View program",
+                onPressed: () {
+                  launchUrl(Settings.openAICodexForOssLink);
+                },
+              ),
+              const _SettingsItemDivider(),
+              _SupportLinkTile(
+                icon: Icons.local_cafe_outlined,
+                title: "Support Icarus",
+                description:
+                    "If Icarus helps your team, you can help keep development going.",
+                actionLabel: "Buy me a coffee",
+                onPressed: () {
+                  launchUrl(Settings.buyMeACoffeeLink);
+                },
+              ),
+            ],
           ),
         ),
         const SizedBox(height: 24),
@@ -1218,6 +1269,12 @@ class _SettingsNavigationRail extends StatelessWidget {
             isSelected: selectedSection == _SettingsSection.shortcuts,
             onTap: () => onSectionSelected(_SettingsSection.shortcuts),
           ),
+          _SettingsNavItem(
+            icon: Icons.favorite_border_outlined,
+            label: "Sponsors",
+            isSelected: selectedSection == _SettingsSection.globalSupport,
+            onTap: () => onSectionSelected(_SettingsSection.globalSupport),
+          ),
         ],
       ),
     );
@@ -1501,6 +1558,64 @@ class _SettingsToggleTile extends StatelessWidget {
               value: value,
               onChanged: onChanged,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SupportLinkTile extends StatelessWidget {
+  const _SupportLinkTile({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.actionLabel,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final String actionLabel;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _SettingLeadingIcon(
+            icon: icon,
+            accentColor: Settings.tacticalVioletTheme.mutedForeground,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  description,
+                  style: ShadTheme.of(context).textTheme.small.copyWith(
+                        color: Settings.tacticalVioletTheme.mutedForeground,
+                        height: 1.3,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          ShadButton.secondary(
+            size: ShadButtonSize.sm,
+            onPressed: onPressed,
+            child: Text(actionLabel),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary

- credit Greptile's Open Source Program and OpenAI's Codex for Open Source program in the README and app settings
- add a permanent, low-key Buy Me a Coffee entry to Settings
- show a non-modal support toast only once, on the third app launch, after a six-second delay
- persist the one-time flag before displaying the toast so navigation or an early exit cannot make it recur

## Validation

- `flutter test --concurrency=4` — 398 tests passed, 1 skipped
- `flutter analyze --no-fatal-infos` — no new findings; one existing deprecation info remains in `lib/widgets/pages_bar.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Sponsors and Support section in Settings with links to Buy Me a Coffee, Greptile, and OpenAI Codex for Open Source.
  - Added a one-time “Buy me a coffee” prompt after repeated app launches.
  - Added launch tracking to support the prompt experience.
  - Toast notifications can now use customized display durations.

- **Documentation**
  - Updated the README with support and sponsor acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->