### PR TITLE
Track rotation with the hover region on rotatable widgets

### DIFF
--- a/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
+++ b/lib/widgets/draggable_widgets/ability/rotatable_widget.dart
@@ -107,17 +107,19 @@ class _RotatableWidgetState extends ConsumerState<RotatableWidget>
         _isHandleHovered ||
         _isHandleDragging;
 
-    return MouseRegion(
-      opaque: false,
-      // Keep spatially separated handles reachable across transparent parts
-      // of a view cone without blocking pointer targets underneath.
-      hitTestBehavior: HitTestBehavior.translucent,
-      onEnter: (_) => _showTargetHandle(),
-      onExit: (_) => _scheduleTargetHandleHide(),
-      child: Transform.rotate(
-        angle: widget.rotation,
-        alignment: Alignment.topLeft,
-        origin: rotationOrigin,
+    // The hover region lives inside the rotation so it tracks the visual;
+    // outside the Transform it would stay pinned to the unrotated footprint.
+    return Transform.rotate(
+      angle: widget.rotation,
+      alignment: Alignment.topLeft,
+      origin: rotationOrigin,
+      child: MouseRegion(
+        opaque: false,
+        // Keep spatially separated handles reachable across transparent parts
+        // of a view cone without blocking pointer targets underneath.
+        hitTestBehavior: HitTestBehavior.translucent,
+        onEnter: (_) => _showTargetHandle(),
+        onExit: (_) => _scheduleTargetHandleHide(),
         child: Stack(
           clipBehavior: Clip.none,
           children: [


### PR DESCRIPTION
## What

Moves the handle-revealing `MouseRegion` inside `Transform.rotate` on `RotatableWidget`.

## Why

The hover region previously wrapped the rotation transform, so its hit area never rotated with the visual. On a rotated ability (e.g. a view cone), hovering the drawn widget could fail to reveal the rotation handles, while hovering the empty space of the *unrotated* footprint revealed them — hover felt detached from what's on screen.

With the region inside the transform, the pointer hit area is the same shape the user sees. The `translucent`/non-opaque behavior is preserved so spatially separated handles stay reachable and pointer targets underneath aren't blocked.

## Testing

- `flutter analyze` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover detection for rotated widgets so it accurately follows their visible bounds.
  * Preserved translucent hit testing and consistent pointer enter/exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->