### PR TITLE
Hide view cone elevation controls

### DIFF
--- a/lib/widgets/draggable_widgets/agents/agent_widget.dart
+++ b/lib/widgets/draggable_widgets/agents/agent_widget.dart
@@ -14,11 +14,8 @@ import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/screen_zoom_provider.dart';
 import 'package:icarus/providers/screenshot_provider.dart';
 import 'package:icarus/providers/strategy_settings_provider.dart';
-import 'package:icarus/providers/view_cone_debug_provider.dart';
-import 'package:icarus/providers/view_cone_geometry_provider.dart';
 import 'package:icarus/widgets/draggable_widgets/adjacent_page_copy_menu.dart';
 import 'package:icarus/widgets/draggable_widgets/zoom_transform.dart';
-import 'package:icarus/widgets/draggable_widgets/utilities/view_cone_elevation_menu.dart';
 import 'package:icarus/widgets/mouse_watch.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -76,6 +73,8 @@ const Color _mutedEnemyBGColor = Color.fromARGB(255, 70, 50, 50);
 /// Muted outline colors for dead agents
 const Color _mutedAllyOutlineColor = Color.fromARGB(100, 100, 100, 100);
 const Color _mutedEnemyOutlineColor = Color.fromARGB(100, 120, 80, 80);
+const double _agentQuickActionSize = 36;
+const double _agentQuickActionGap = 4;
 
 class AgentWidget extends ConsumerWidget {
   const AgentWidget({
@@ -210,25 +209,24 @@ class AgentWidget extends ConsumerWidget {
               )
             : null;
     final plainAgent = placedAgentNode is PlacedAgent ? placedAgentNode : null;
-    final viewConeAgent =
-        placedAgentNode is PlacedViewConeAgent ? placedAgentNode : null;
-    final visionGeometry = viewConeAgent == null || mapState == null
-        ? null
-        : ref
-            .watch(viewConeGeometryProvider(mapState.currentMap))
-            .asData
-            ?.value;
-    final viewConeDebugEnabled =
-        viewConeAgent == null ? false : ref.watch(viewConeDebugProvider);
-
+    final adjacentPageCopyItems =
+        canInteract && lineUpId == null && placedAgentNode != null
+            ? buildAdjacentPageCopyMenuItems(ref, placedAgentNode.id)
+            : const <ShadContextMenuItem>[];
+    final hasContextMenuItemsBelow = canInteract &&
+        (lineUpId != null ||
+            (plainAgent != null && plainAgent.id.isNotEmpty) ||
+            adjacentPageCopyItems.isNotEmpty);
     final contextMenuItems = <ShadContextMenuItem>[
       if (canInteract)
         ShadContextMenuItem.raw(
           variant: ShadContextMenuItemVariant.primary,
-          height: 36,
+          height: _agentQuickActionSize,
           closeOnTap: false,
-          padding: const EdgeInsets.only(bottom: 4),
-          insetPadding: const EdgeInsets.only(left: 4, right: 4),
+          padding: hasContextMenuItemsBelow
+              ? const EdgeInsets.only(bottom: _agentQuickActionGap)
+              : EdgeInsets.zero,
+          insetPadding: EdgeInsets.zero,
           backgroundColor: Colors.transparent,
           selectedBackgroundColor: Colors.transparent,
           child: _AgentAbilityContextMenuRow(
@@ -236,32 +234,6 @@ class AgentWidget extends ConsumerWidget {
             isAlly: isAlly,
             mapScale: mapScale,
           ),
-        ),
-      if (canInteract && viewConeAgent != null && visionGeometry != null)
-        buildViewConeElevationMenuItem(
-          geometry: visionGeometry,
-          selectedElevation: viewConeAgent.visionElevation,
-          automaticElevation: visionGeometry
-              .layerForPosition(
-                isAttack: mapState!.isAttack,
-                position: viewConeAgent.position +
-                    coordinateSystem.virtualOffsetToWorld(
-                      Offset(agentSize / 2, agentSize / 2),
-                    ),
-              )
-              .elevation,
-          onChanged: (elevation) {
-            ref.read(agentProvider.notifier).updateViewConeElevation(
-                  id: viewConeAgent.id,
-                  elevation: elevation,
-                );
-          },
-        ),
-      if (canInteract && viewConeAgent != null && visionGeometry != null)
-        buildViewConeDebugMenuItem(
-          enabled: viewConeDebugEnabled,
-          onChanged: (enabled) =>
-              ref.read(viewConeDebugProvider.notifier).state = enabled,
         ),
       if (canInteract && lineUpId != null)
         ShadContextMenuItem(
@@ -305,8 +277,7 @@ class AgentWidget extends ConsumerWidget {
             ref.read(lineUpProvider.notifier).startNewGroup(plainAgent);
           },
         ),
-      if (canInteract && lineUpId == null && placedAgentNode != null)
-        ...buildAdjacentPageCopyMenuItems(ref, placedAgentNode.id),
+      ...adjacentPageCopyItems,
     ];
 
     Widget agentCard;
@@ -368,20 +339,24 @@ class _AgentAbilityContextMenuRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Row(
-      spacing: 4,
-      // crossAxisAlignment: CrossAxisAlignment.start,
-      //
-      mainAxisSize: MainAxisSize.max,
-      // mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        for (final ability in agent.abilities)
-          _AgentAbilityContextMenuButton(
-            ability: ability,
-            isAlly: isAlly,
-            mapScale: mapScale,
-          ),
-      ],
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minWidth: (agent.abilities.length * _agentQuickActionSize) +
+            ((agent.abilities.length + 1) * _agentQuickActionGap),
+      ),
+      child: Row(
+        spacing: _agentQuickActionGap,
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          for (final ability in agent.abilities)
+            _AgentAbilityContextMenuButton(
+              ability: ability,
+              isAlly: isAlly,
+              mapScale: mapScale,
+            ),
+        ],
+      ),
     );
   }
 }
@@ -471,8 +446,8 @@ class _AgentAbilityContextMenuButtonState
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 120),
             curve: Curves.easeOutCubic,
-            width: 36,
-            height: 36,
+            width: _agentQuickActionSize,
+            height: _agentQuickActionSize,
             padding: const EdgeInsets.all(5),
             decoration: BoxDecoration(
               color: background,

--- a/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
+++ b/lib/widgets/draggable_widgets/utilities/view_cone_widget.dart
@@ -214,31 +214,9 @@ class ViewConeWidget extends ConsumerWidget {
       }
     }
 
-    final elevationMenuItems = placedUtility == null
+    final contextMenuItems = placedUtility == null
         ? null
         : [
-            if (geometry != null)
-              buildViewConeElevationMenuItem(
-                geometry: geometry,
-                selectedElevation: placedUtility.visionElevation,
-                automaticElevation: geometry
-                    .layerForPosition(
-                      isAttack: ref.read(mapProvider).isAttack,
-                      position: resolvedWorldOrigin!,
-                    )
-                    .elevation,
-                onChanged: (elevation) {
-                  ref
-                      .read(utilityProvider.notifier)
-                      .updateViewConeElevation(placedUtility!.id, elevation);
-                },
-              ),
-            if (geometry != null)
-              buildViewConeDebugMenuItem(
-                enabled: debugEnabled,
-                onChanged: (enabled) =>
-                    ref.read(viewConeDebugProvider.notifier).state = enabled,
-              ),
             ...buildAdjacentPageCopyMenuItems(ref, placedUtility.id),
           ];
 
@@ -279,7 +257,7 @@ class ViewConeWidget extends ConsumerWidget {
                 deleteTarget: (id?.isNotEmpty ?? false)
                     ? HoveredDeleteTarget.utility(id: id!, ownerToken: Object())
                     : null,
-                contextMenuItems: elevationMenuItems,
+                contextMenuItems: contextMenuItems,
                 cursor: SystemMouseCursors.click,
                 child: Container(
                   decoration: BoxDecoration(

--- a/test/lineup_add_item_interaction_test.dart
+++ b/test/lineup_add_item_interaction_test.dart
@@ -200,6 +200,62 @@ void main() {
     );
   });
 
+  testWidgets('agent quick actions span the width of longer menu rows',
+      (tester) async {
+    final container = _createContainer();
+    final group = _breachGroup();
+    container.read(lineUpProvider.notifier).addGroup(group);
+
+    await _pumpHarness(
+      tester,
+      container: container,
+      child: Center(
+        child: AgentWidget(
+          lineUpId: group.id,
+          id: group.agent.id,
+          isAlly: group.agent.isAlly,
+          agent: AgentData.agents[group.agent.type]!,
+        ),
+      ),
+    );
+
+    await tester.tapAt(
+      tester.getCenter(find.byType(AgentWidget)),
+      buttons: kSecondaryButton,
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pumpAndSettle();
+
+    final menuItemRect = tester.getRect(
+      find.byType(ShadContextMenuItem).first,
+    );
+    final abilityButtons = find.byWidgetPredicate(
+      (widget) => widget is Draggable<DraggedAbilityData>,
+    );
+    expect(
+      abilityButtons,
+      findsNWidgets(AgentData.agents[group.agent.type]!.abilities.length),
+    );
+
+    final buttonRects = [
+      for (final element in abilityButtons.evaluate())
+        tester.getRect(
+          find.byElementPredicate((candidate) => candidate == element),
+        ),
+    ];
+    final leadingSpace = buttonRects.first.left - menuItemRect.left;
+    final trailingSpace = menuItemRect.right - buttonRects.last.right;
+    for (var index = 1; index < buttonRects.length; index++) {
+      final gap = buttonRects[index].left - buttonRects[index - 1].right;
+      expect(gap, closeTo(4, 0.1));
+    }
+    expect(trailingSpace, closeTo(leadingSpace, 0.1));
+    for (final buttonRect in buttonRects) {
+      expect(buttonRect.width, 36);
+      expect(buttonRect.height, 36);
+    }
+  });
+
   testWidgets('locked add-item mode renders a non-draggable preview agent',
       (tester) async {
     final container = _createContainer();

--- a/test/view_cone_agent_drag_feedback_test.dart
+++ b/test/view_cone_agent_drag_feedback_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,9 +9,14 @@ import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/utilities.dart';
 import 'package:icarus/providers/agent_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
+import 'package:icarus/providers/utility_provider.dart';
+import 'package:icarus/providers/view_cone_geometry_provider.dart';
+import 'package:icarus/widgets/draggable_widgets/agents/agent_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/agents/placed_view_cone_agent_widget.dart';
 import 'package:icarus/widgets/draggable_widgets/utilities/view_cone_widget.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+
+import 'vision_geometry_test_support.dart';
 
 class _FixedMapProvider extends MapProvider {
   @override
@@ -71,5 +77,124 @@ void main() {
     final feedbackCone =
         tester.widget<ViewConeWidget>(find.byType(ViewConeWidget));
     expect(feedbackCone.worldOrigin, isNull);
+  });
+
+  testWidgets('view-cone agent menu hides elevation controls', (tester) async {
+    CoordinateSystem(playAreaSize: const Size(1920, 1080));
+    final container = ProviderContainer(
+      overrides: [
+        mapProvider.overrideWith(_FixedMapProvider.new),
+        viewConeGeometryProvider.overrideWith(
+          (ref, map) async => twoLayerAscentGeometry(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final agent = PlacedViewConeAgent(
+      id: 'view-cone-agent',
+      type: AgentType.sova,
+      presetType: UtilityType.viewCone90,
+      position: const Offset(200, 300),
+      rotation: 0.5,
+      length: 75,
+    );
+    container.read(agentProvider.notifier).fromHive([agent]);
+    await container.read(viewConeGeometryProvider(MapValue.ascent).future);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: ShadApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                PlacedViewConeAgentWidget(
+                  agent: agent,
+                  onDragEnd: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tapAt(
+      tester.getCenter(find.byType(AgentWidget)),
+      buttons: kSecondaryButton,
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.byType(ShadContextMenuItem), findsOneWidget);
+    expect(tester.getSize(find.byType(ShadContextMenuItem)).height, 36);
+    final menuItemRect = tester.getRect(find.byType(ShadContextMenuItem));
+    final abilityButtons = find.byWidgetPredicate(
+      (widget) => widget is Draggable<DraggedAbilityData>,
+    );
+    final buttonRects = [
+      for (final element in abilityButtons.evaluate())
+        tester.getRect(
+          find.byElementPredicate((candidate) => candidate == element),
+        ),
+    ];
+    final spaces = [
+      buttonRects.first.left - menuItemRect.left,
+      for (var index = 1; index < buttonRects.length; index++)
+        buttonRects[index].left - buttonRects[index - 1].right,
+      menuItemRect.right - buttonRects.last.right,
+    ];
+    for (final space in spaces) {
+      expect(space, closeTo(4, 0.1));
+    }
+    expect(find.text('View elevation'), findsNothing);
+    expect(find.text('Vision calibration'), findsNothing);
+  });
+
+  testWidgets('free view-cone menu hides elevation controls', (tester) async {
+    CoordinateSystem(playAreaSize: const Size(1920, 1080));
+    final container = ProviderContainer(
+      overrides: [
+        mapProvider.overrideWith(_FixedMapProvider.new),
+        viewConeGeometryProvider.overrideWith(
+          (ref, map) async => twoLayerAscentGeometry(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final utility = PlacedUtility(
+      id: 'view-cone-utility',
+      type: UtilityType.viewCone90,
+      position: const Offset(200, 300),
+      angle: 60,
+    );
+    utility.updateRotation(0.5, 75);
+    container.read(utilityProvider.notifier).fromHive([utility]);
+    await container.read(viewConeGeometryProvider(MapValue.ascent).future);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: ShadApp(
+          home: Scaffold(
+            body: ViewConeWidget(
+              id: utility.id,
+              angle: utility.angle,
+              rotation: utility.rotation,
+              length: utility.length,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(ShadContextMenuRegion), findsNothing);
+    expect(find.text('View elevation'), findsNothing);
+    expect(find.text('Vision calibration'), findsNothing);
   });
 }


### PR DESCRIPTION
## What changed

- remove the user-facing view elevation and vision calibration controls from attached and standalone view cones
- keep adjacent-page actions available where applicable
- normalize the agent quick-action row so ability buttons remain evenly spaced across wider context-menu rows
- add widget coverage for the hidden controls and menu sizing

## Why

The elevation and calibration controls are internal implementation details and should not appear in the user-facing tactical workflow. Removing them keeps the context menu focused while preserving the existing view-cone behavior.

## User impact

View-cone context menus are smaller and clearer. Agent ability shortcuts remain consistently sized and centered.

## Validation

- `dart format --output=none --set-exit-if-changed` on the four changed Dart files
- `flutter test test/lineup_add_item_interaction_test.dart test/view_cone_agent_drag_feedback_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified view-cone context menus to focus on adjacent-page copy actions.
  - Added context-menu actions for navigating adjacent pages when available.
  - Improved agent quick-action layouts with consistent sizing, spacing, and alignment.

- **Bug Fixes**
  - Removed elevation and calibration controls from view-cone menus.
  - Ensured quick-action buttons consistently render at the intended size and width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->