### PR TITLE
Fix cloud sync concurrency data loss

### DIFF
--- a/lib/providers/collab/active_page_live_sync_models.dart
+++ b/lib/providers/collab/active_page_live_sync_models.dart
@@ -137,6 +137,7 @@ class ActivePageOverlayEntry {
     required this.desiredSortIndex,
     required this.deletion,
     required this.baseRevision,
+    required this.baseDeleted,
     required this.dirtyAt,
   });
 
@@ -145,7 +146,8 @@ class ActivePageOverlayEntry {
   final Object? desiredPayload;
   final int? desiredSortIndex;
   final bool deletion;
-  final int baseRevision;
+  final int? baseRevision;
+  final bool baseDeleted;
   final DateTime dirtyAt;
 
   ActivePageOverlayEntry copyWith({
@@ -153,6 +155,7 @@ class ActivePageOverlayEntry {
     int? desiredSortIndex,
     bool? deletion,
     int? baseRevision,
+    bool? baseDeleted,
     DateTime? dirtyAt,
   }) {
     return ActivePageOverlayEntry(
@@ -162,6 +165,7 @@ class ActivePageOverlayEntry {
       desiredSortIndex: desiredSortIndex ?? this.desiredSortIndex,
       deletion: deletion ?? this.deletion,
       baseRevision: baseRevision ?? this.baseRevision,
+      baseDeleted: baseDeleted ?? this.baseDeleted,
       dirtyAt: dirtyAt ?? this.dirtyAt,
     );
   }

--- a/lib/providers/collab/active_page_live_sync_provider.dart
+++ b/lib/providers/collab/active_page_live_sync_provider.dart
@@ -199,6 +199,7 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     final nextOverlay = Map<EntitySyncKey, ActivePageOverlayEntry>.from(
       state.overlayByEntityKey,
     );
+    final retainedDesiredOps = <EntitySyncKey, StrategyOp>{};
 
     for (final key in pageKeys) {
       final remote = remoteEntities[key];
@@ -208,10 +209,28 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
       final hasInFlight = queueState.inFlightByEntityKey.containsKey(key);
       final hasSuccessor = queueState.successorByEntityKey.containsKey(key);
       final existingOverlay = state.overlayByEntityKey[key];
+      final retainedOp = queueState.successorByEntityKey[key]?.pending.op ??
+          queueState.inFlightByEntityKey[key]?.pending.op ??
+          queueState.queuedByEntityKey[key]?.pending.op;
 
       final shouldPreserveTouched = hasQueued || hasInFlight || hasSuccessor;
       final matchesRemote = _entitiesEquivalent(local, remote);
       final matchesHydratedBase = _entitiesEquivalent(local, hydratedBase);
+      final shouldUseRetainedIntent = hasQueued ||
+          (!hasInFlight && hasSuccessor) ||
+          (local == null && hydratedBase == null);
+
+      // A restored queue entry has no in-memory overlay. If the canvas still
+      // matches its hydrated base, the durable op is the only local intent and
+      // must remain desired until it lands or the user changes that entity.
+      if (existingOverlay == null &&
+          retainedOp != null &&
+          shouldUseRetainedIntent &&
+          matchesHydratedBase) {
+        retainedDesiredOps[key] = retainedOp;
+        _debugLog('overlay.keep $key reason=durable_queue_only');
+        continue;
+      }
 
       if (matchesHydratedBase && !shouldPreserveTouched) {
         if (nextOverlay.remove(key) != null) {
@@ -261,11 +280,17 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
           );
           continue;
         }
+        final entityType = existingOverlay?.entityType ??
+            hydratedBase?.overlayEntityType ??
+            remote?.overlayEntityType ??
+            key.overlayType;
+        if (entityType == null) {
+          _debugLog('overlay.skip $key reason=unsupported_entity_key');
+          continue;
+        }
         final overlay = ActivePageOverlayEntry(
           entityKey: key,
-          entityType: existingOverlay?.entityType ??
-              hydratedBase?.overlayEntityType ??
-              remote!.overlayEntityType,
+          entityType: entityType,
           desiredPayload: null,
           desiredSortIndex: null,
           deletion: true,
@@ -292,7 +317,9 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
       );
     }
 
-    final desiredOpsByEntityKey = <EntitySyncKey, StrategyOp>{};
+    final desiredOpsByEntityKey = <EntitySyncKey, StrategyOp>{
+      ...retainedDesiredOps,
+    };
     for (final entry in nextOverlay.entries) {
       final key = entry.key;
       if (key.pageId != pageId) {

--- a/lib/providers/collab/active_page_live_sync_provider.dart
+++ b/lib/providers/collab/active_page_live_sync_provider.dart
@@ -70,12 +70,17 @@ final activePageLiveSyncProvider =
 );
 
 class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
+  // Live reads can advance while local work blocks rehydration. Outbound diffs
+  // must stay based on the server state that was actually loaded into canvas.
+  final Map<EntitySyncKey, _NormalizedEntity> _hydratedBaseByEntityKey = {};
+
   @override
   ActivePageLiveSyncState build() {
     return const ActivePageLiveSyncState();
   }
 
   void reset() {
+    _hydratedBaseByEntityKey.clear();
     state = const ActivePageLiveSyncState();
   }
 
@@ -87,8 +92,12 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     required String? strategyPublicId,
     required String? activePageId,
   }) {
+    final strategyChanged = strategyPublicId != state.strategyPublicId;
     final contextChanged = strategyPublicId != state.strategyPublicId ||
         activePageId != state.activePageId;
+    if (strategyChanged) {
+      _hydratedBaseByEntityKey.clear();
+    }
     state = state.copyWith(
       strategyPublicId: strategyPublicId,
       activePageId: activePageId,
@@ -121,9 +130,24 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     required String pageId,
   }) {
     setContext(strategyPublicId: strategyPublicId, activePageId: pageId);
+    final snapshot = ref.read(remoteEditorSnapshotProvider).valueOrNull;
+    final remoteEntities = snapshot == null ||
+            snapshot.header.publicId != strategyPublicId ||
+            snapshot.activePage?.page.publicId != pageId
+        ? const <EntitySyncKey, _NormalizedEntity>{}
+        : _normalizedRemoteEntities(snapshot, pageId);
+    _hydratedBaseByEntityKey.removeWhere((key, _) => key.pageId == pageId);
+    _hydratedBaseByEntityKey.addAll(remoteEntities);
+    final remoteRevisions = Map<EntitySyncKey, int>.from(
+      state.remoteBaseRevisionByEntity,
+    )..removeWhere((key, _) => key.pageId == pageId);
+    for (final entry in remoteEntities.entries) {
+      remoteRevisions[entry.key] = entry.value.revision;
+    }
     state = state.copyWith(
       hydratedPageId: pageId,
       hydratedEntityKeys: _normalizedLocalEntities(pageId).keys.toSet(),
+      remoteBaseRevisionByEntity: remoteRevisions,
     );
   }
 
@@ -159,17 +183,11 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     final queueState = ref.read(strategyOpQueueProvider);
     final remoteEntities = _normalizedRemoteEntities(snapshot, pageId);
     final localEntities = _normalizedLocalEntities(pageId);
-    final remoteRevisions = Map<EntitySyncKey, int>.from(
-      state.remoteBaseRevisionByEntity,
-    );
-
-    for (final entry in remoteEntities.entries) {
-      remoteRevisions[entry.key] = entry.value.revision;
-    }
 
     final pageKeys = <EntitySyncKey>{
       ...remoteEntities.keys,
       ...localEntities.keys,
+      ..._hydratedBaseByEntityKey.keys.where((key) => key.pageId == pageId),
       ...state.overlayByEntityKey.keys.where((key) => key.pageId == pageId),
       ...queueState.queuedByEntityKey.keys.where((key) => key.pageId == pageId),
       ...queueState.inFlightByEntityKey.keys
@@ -185,14 +203,24 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     for (final key in pageKeys) {
       final remote = remoteEntities[key];
       final local = localEntities[key];
+      final hydratedBase = _hydratedBaseByEntityKey[key];
       final hasQueued = queueState.queuedByEntityKey.containsKey(key);
       final hasInFlight = queueState.inFlightByEntityKey.containsKey(key);
+      final hasSuccessor = queueState.successorByEntityKey.containsKey(key);
       final existingOverlay = state.overlayByEntityKey[key];
 
-      final shouldPreserveTouched = hasQueued || hasInFlight;
+      final shouldPreserveTouched = hasQueued || hasInFlight || hasSuccessor;
       final matchesRemote = _entitiesEquivalent(local, remote);
+      final matchesHydratedBase = _entitiesEquivalent(local, hydratedBase);
 
-      if (matchesRemote && !hasQueued && !hasInFlight) {
+      if (matchesHydratedBase && !shouldPreserveTouched) {
+        if (nextOverlay.remove(key) != null) {
+          _debugLog('overlay.remove $key reason=unchanged_since_hydration');
+        }
+        continue;
+      }
+
+      if (matchesRemote && !shouldPreserveTouched) {
         if (nextOverlay.remove(key) != null) {
           _debugLog('overlay.remove $key reason=matched_remote');
         }
@@ -210,7 +238,8 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
         final overlay = _overlayFromDesiredEntity(
           key: key,
           desired: local,
-          baseRevision: remote?.revision ?? existingOverlay?.baseRevision ?? 0,
+          hydratedBase: hydratedBase,
+          existingOverlay: existingOverlay,
         );
         nextOverlay[key] = overlay;
         _debugLog('overlay.keep $key reason=pending_reconciliation');
@@ -223,23 +252,27 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
         continue;
       }
 
-      if (local == null && remote != null) {
-        final wasHydratedLocally = state.hydratedEntityKeys.contains(key);
-        if (!wasHydratedLocally &&
+      if (local == null) {
+        if (hydratedBase == null &&
             existingOverlay == null &&
             !shouldPreserveTouched) {
           _debugLog(
-            'overlay.skip $key reason=remote_not_yet_hydrated_locally',
+            'overlay.skip $key reason=not_in_hydrated_base',
           );
           continue;
         }
         final overlay = ActivePageOverlayEntry(
           entityKey: key,
-          entityType: remote.overlayEntityType,
+          entityType: existingOverlay?.entityType ??
+              hydratedBase?.overlayEntityType ??
+              remote!.overlayEntityType,
           desiredPayload: null,
           desiredSortIndex: null,
           deletion: true,
-          baseRevision: remote.revision,
+          baseRevision:
+              existingOverlay?.baseRevision ?? hydratedBase?.revision,
+          baseDeleted:
+              existingOverlay?.baseDeleted ?? hydratedBase?.deleted ?? false,
           dirtyAt: DateTime.now(),
         );
         nextOverlay[key] = overlay;
@@ -247,17 +280,16 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
         continue;
       }
 
-      if (local != null) {
-        final overlay = _overlayFromDesiredEntity(
-          key: key,
-          desired: local,
-          baseRevision: remote?.revision ?? existingOverlay?.baseRevision ?? 0,
-        );
-        nextOverlay[key] = overlay;
-        _debugLog(
-          'overlay.upsert $key deletion=false baseRevision=${overlay.baseRevision}',
-        );
-      }
+      final overlay = _overlayFromDesiredEntity(
+        key: key,
+        desired: local,
+        hydratedBase: hydratedBase,
+        existingOverlay: existingOverlay,
+      );
+      nextOverlay[key] = overlay;
+      _debugLog(
+        'overlay.upsert $key deletion=false baseRevision=${overlay.baseRevision}',
+      );
     }
 
     final desiredOpsByEntityKey = <EntitySyncKey, StrategyOp>{};
@@ -269,15 +301,15 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
       final remote = remoteEntities[key];
       final overlay = entry.value;
       if (_overlayMatchesRemote(overlay, remote) &&
-          !_needsPageDescriptorSuccessor(
+          !_needsSuccessor(
+            pageId: pageId,
             key: key,
             overlay: overlay,
             queueState: queueState,
           )) {
         continue;
       }
-      final op = _strategyOpFromOverlay(
-          pageId: pageId, overlay: overlay, remote: remote);
+      final op = _strategyOpFromOverlay(pageId: pageId, overlay: overlay);
       if (op != null) {
         desiredOpsByEntityKey[key] = op;
       }
@@ -286,7 +318,6 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
     state = state.copyWith(
       strategyPublicId: strategyPublicId,
       activePageId: pageId,
-      remoteBaseRevisionByEntity: remoteRevisions,
       overlayByEntityKey: nextOverlay,
     );
 
@@ -639,7 +670,8 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
   ActivePageOverlayEntry _overlayFromDesiredEntity({
     required EntitySyncKey key,
     required _NormalizedEntity desired,
-    required int baseRevision,
+    required _NormalizedEntity? hydratedBase,
+    required ActivePageOverlayEntry? existingOverlay,
   }) {
     return ActivePageOverlayEntry(
       entityKey: key,
@@ -647,7 +679,9 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
       desiredPayload: desired.payload,
       desiredSortIndex: desired.sortIndex,
       deletion: desired.deleted,
-      baseRevision: baseRevision,
+      baseRevision: existingOverlay?.baseRevision ?? hydratedBase?.revision,
+      baseDeleted:
+          existingOverlay?.baseDeleted ?? hydratedBase?.deleted ?? false,
       dirtyAt: DateTime.now(),
     );
   }
@@ -655,18 +689,21 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
   StrategyOp? _strategyOpFromOverlay({
     required String pageId,
     required ActivePageOverlayEntry overlay,
-    required _NormalizedEntity? remote,
   }) {
     final entityId = overlay.entityKey.entityId;
     switch (overlay.entityType) {
       case ActivePageOverlayEntityType.pageDescriptor:
+        final baseRevision = overlay.baseRevision;
+        if (baseRevision == null) return null;
         return PagePatchOp(
           opId: const Uuid().v4(),
           pagePublicId: pageId,
           payload: Map<String, dynamic>.from(overlay.desiredPayload as Map),
-          expectedPageRevision: remote?.revision ?? overlay.baseRevision,
+          expectedPageRevision: baseRevision,
         );
       case ActivePageOverlayEntityType.pageContent:
+        final baseRevision = overlay.baseRevision;
+        if (baseRevision == null) return null;
         final payload = Map<String, dynamic>.from(
           overlay.desiredPayload as Map,
         );
@@ -674,30 +711,32 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
           opId: const Uuid().v4(),
           pagePublicId: pageId,
           settings: Map<String, dynamic>.from(payload['settings'] as Map),
-          expectedPageContentRevision: remote?.revision ?? overlay.baseRevision,
+          expectedPageContentRevision: baseRevision,
         );
       case ActivePageOverlayEntityType.element:
         if (entityId == null) {
           return null;
         }
         if (overlay.deletion) {
+          final baseRevision = overlay.baseRevision;
+          if (baseRevision == null) return null;
           return ElementDeleteOp(
             opId: const Uuid().v4(),
             elementPublicId: entityId,
             pagePublicId: pageId,
-            expectedElementRevision: remote?.revision ?? overlay.baseRevision,
+            expectedElementRevision: baseRevision,
           );
         }
         final payload =
             Map<String, dynamic>.from(overlay.desiredPayload as Map);
-        return remote == null || remote.deleted
+        return overlay.baseRevision == null || overlay.baseDeleted
             ? ElementAddOp(
                 opId: const Uuid().v4(),
                 elementPublicId: entityId,
                 pagePublicId: pageId,
                 payload: payload,
                 sortIndex: overlay.desiredSortIndex ?? 0,
-                expectedElementRevision: remote?.revision,
+                expectedElementRevision: overlay.baseRevision,
               )
             : ElementPatchOp(
                 opId: const Uuid().v4(),
@@ -705,30 +744,32 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
                 pagePublicId: pageId,
                 payload: payload,
                 sortIndex: overlay.desiredSortIndex,
-                expectedElementRevision: remote.revision,
+                expectedElementRevision: overlay.baseRevision!,
               );
       case ActivePageOverlayEntityType.lineup:
         if (entityId == null) {
           return null;
         }
         if (overlay.deletion) {
+          final baseRevision = overlay.baseRevision;
+          if (baseRevision == null) return null;
           return LineupDeleteOp(
             opId: const Uuid().v4(),
             lineupPublicId: entityId,
             pagePublicId: pageId,
-            expectedLineupRevision: remote?.revision ?? overlay.baseRevision,
+            expectedLineupRevision: baseRevision,
           );
         }
         final payload =
             Map<String, dynamic>.from(overlay.desiredPayload as Map);
-        return remote == null || remote.deleted
+        return overlay.baseRevision == null || overlay.baseDeleted
             ? LineupAddOp(
                 opId: const Uuid().v4(),
                 lineupPublicId: entityId,
                 pagePublicId: pageId,
                 payload: payload,
                 sortIndex: overlay.desiredSortIndex ?? 0,
-                expectedLineupRevision: remote?.revision,
+                expectedLineupRevision: overlay.baseRevision,
               )
             : LineupPatchOp(
                 opId: const Uuid().v4(),
@@ -736,7 +777,7 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
                 pagePublicId: pageId,
                 payload: payload,
                 sortIndex: overlay.desiredSortIndex,
-                expectedLineupRevision: remote.revision,
+                expectedLineupRevision: overlay.baseRevision!,
               );
     }
   }
@@ -755,24 +796,31 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
         overlay.desiredSortIndex == remote.sortIndex;
   }
 
-  bool _needsPageDescriptorSuccessor({
+  bool _needsSuccessor({
+    required String pageId,
     required EntitySyncKey key,
     required ActivePageOverlayEntry overlay,
     required StrategyOpQueueState queueState,
   }) {
-    if (key.kind != EntitySyncKeyKind.pageDescriptor ||
-        queueState.successorByEntityKey.containsKey(key)) {
+    if (queueState.successorByEntityKey.containsKey(key)) {
       return false;
     }
-    final desiredPayload = overlay.desiredPayload;
-    if (desiredPayload is! Map) return false;
-    final desiredSide = desiredPayload['isAttack'];
-    if (desiredSide is! bool) return false;
 
     final predecessor = queueState.inFlightByEntityKey[key]?.pending.op ??
         queueState.queuedByEntityKey[key]?.pending.op;
-    if (predecessor is! PagePatchOp) return false;
-    return predecessor.payload['isAttack'] != desiredSide;
+    if (predecessor == null) return false;
+    final desired = _strategyOpFromOverlay(pageId: pageId, overlay: overlay);
+    return desired != null && !_opsEquivalent(predecessor, desired);
+  }
+
+  bool _opsEquivalent(StrategyOp left, StrategyOp right) {
+    return left.kind == right.kind &&
+        left.entityType == right.entityType &&
+        left.entityPublicId == right.entityPublicId &&
+        left.pagePublicId == right.pagePublicId &&
+        cloudJsonEquivalent(left.payload, right.payload) &&
+        left.sortIndex == right.sortIndex &&
+        left.expectedRevision == right.expectedRevision;
   }
 
   bool _entitiesEquivalent(

--- a/lib/providers/collab/active_page_live_sync_provider.dart
+++ b/lib/providers/collab/active_page_live_sync_provider.dart
@@ -718,8 +718,10 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
           return null;
         }
         if (overlay.deletion) {
-          final baseRevision = overlay.baseRevision;
-          if (baseRevision == null) return null;
+          // A delete after a local add has no revision until that add lands.
+          // Zero cannot land early; the outbox rebases the successor from the
+          // accepted add acknowledgment.
+          final baseRevision = overlay.baseRevision ?? 0;
           return ElementDeleteOp(
             opId: const Uuid().v4(),
             elementPublicId: entityId,
@@ -751,8 +753,7 @@ class ActivePageLiveSyncNotifier extends Notifier<ActivePageLiveSyncState> {
           return null;
         }
         if (overlay.deletion) {
-          final baseRevision = overlay.baseRevision;
-          if (baseRevision == null) return null;
+          final baseRevision = overlay.baseRevision ?? 0;
           return LineupDeleteOp(
             opId: const Uuid().v4(),
             lineupPublicId: entityId,

--- a/lib/providers/collab/strategy_op_queue_provider.dart
+++ b/lib/providers/collab/strategy_op_queue_provider.dart
@@ -749,11 +749,13 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
       // promotion. A rejected predecessor leaves both intents in attention.
       final successorRevision = ack.appliedRevision;
       if (successor != null && ack.isAck && successorRevision != null) {
+        final predecessorCreatedEntity = sent.pending.op is ElementAddOp ||
+            sent.pending.op is LineupAddOp;
         final promoted = PendingOp(
           op: _rebaseRejectedOp(
             successor.op,
             successorRevision,
-            preserveAdd: true,
+            preserveAdd: !predecessorCreatedEntity,
           ),
           clientId: successor.clientId,
         );

--- a/lib/providers/collab/strategy_op_queue_provider.dart
+++ b/lib/providers/collab/strategy_op_queue_provider.dart
@@ -360,8 +360,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
           continue;
         }
 
-        if (inFlightIntent != null &&
-            key.kind == EntitySyncKeyKind.pageDescriptor) {
+        if (inFlightIntent != null) {
           if (successorIntent != null &&
               _sameIntent(successorIntent.pending.op, desired)) {
             continue;
@@ -387,9 +386,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
           continue;
         }
 
-        if (existing != null &&
-            successorIntent != null &&
-            key.kind == EntitySyncKeyKind.pageDescriptor) {
+        if (existing != null && successorIntent != null) {
           if (_sameIntent(existing.pending.op, desired)) {
             await _putRecord(_recordFor(
               key: key,
@@ -746,8 +743,10 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
       final current = _recordForActiveKey(sent.entityKey);
       if (current?.pending.op.opId != ack.opId) continue;
       final successor = current!.successorPending;
-      final successorRevision = ack.appliedRevision ?? ack.latestRevision;
-      if (successor != null && successorRevision != null) {
+      // Only an accepted predecessor establishes a revision for automatic
+      // promotion. A rejected predecessor leaves both intents in attention.
+      final successorRevision = ack.appliedRevision;
+      if (successor != null && ack.isAck && successorRevision != null) {
         final promoted = PendingOp(
           op: _rebaseRejectedOp(
             successor.op,
@@ -775,7 +774,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
           status: DurableOutboxStatus.attention,
           updatedAt: DateTime.now(),
           lastError: ack.reason ??
-              'The final Page change is waiting for a server revision.',
+              'The final change is waiting for conflict resolution.',
           latestServerRevision: ack.latestRevision,
         );
         await _putRecord(retained);

--- a/lib/providers/collab/strategy_op_queue_provider.dart
+++ b/lib/providers/collab/strategy_op_queue_provider.dart
@@ -331,11 +331,56 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
         final pausedIntent = paused[key];
         final attentionIntent = attention[key];
 
+        // A rejected op remains the durable authority until the user
+        // explicitly retries it. Reconciliation may update its successor, but
+        // it must never make rejected work eligible for an automatic flush.
+        if (attentionIntent != null) {
+          if (desired == null) continue;
+          final current = _recordForActiveKey(key);
+          if (current == null) {
+            throw StateError('Durable attention record is missing for $key.');
+          }
+          if (_sameIntent(attentionIntent.pending.op, desired)) {
+            if (successorIntent != null) {
+              await _putRecord(current.copyWith(
+                clearSuccessorPending: true,
+                updatedAt: DateTime.now(),
+              ));
+              successors.remove(key);
+              changed = true;
+            }
+            continue;
+          }
+          if (successorIntent != null &&
+              _sameIntent(successorIntent.pending.op, desired)) {
+            continue;
+          }
+          final pending = PendingOp(
+            op: successorIntent == null
+                ? desired
+                : _mergeQueuedIntent(successorIntent.pending.op, desired) ??
+                    desired,
+            clientId: successorIntent?.pending.clientId ??
+                attentionIntent.pending.clientId,
+          );
+          await _putRecord(current.copyWith(
+            status: DurableOutboxStatus.attention,
+            successorPending: pending,
+            updatedAt: DateTime.now(),
+          ));
+          successors[key] = QueuedEntityIntent(
+            entityKey: key,
+            pending: pending,
+          );
+          changed = true;
+          continue;
+        }
+
         if (desired == null) {
           if (inFlight != null || successorIntent != null) {
             continue;
           }
-          final current = existing ?? pausedIntent ?? attentionIntent;
+          final current = existing ?? pausedIntent;
           if (current != null) {
             await _removeRecordIfCurrent(key, current.pending.op.opId);
             queued.remove(key);
@@ -425,14 +470,10 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
           continue;
         }
 
-        // A rejected opId is an immutable server event. Reconciliation must
-        // replace it with the newly based op instead of replaying the reject.
-        final base = attentionIntent ?? pausedIntent ?? existing;
-        final merged = attentionIntent != null
+        final base = pausedIntent ?? existing;
+        final merged = base == null
             ? desired
-            : (base == null
-                ? desired
-                : _mergeQueuedIntent(base.pending.op, desired));
+            : _mergeQueuedIntent(base.pending.op, desired);
         if (merged == null) {
           if (base != null) {
             await _removeRecordIfCurrent(key, base.pending.op.opId);
@@ -447,9 +488,8 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
         final pending = PendingOp(
           op: merged,
           clientId: base?.pending.clientId ?? state.clientId!,
-          attempts: attentionIntent != null ? 0 : (base?.pending.attempts ?? 0),
-          lastAttemptAt:
-              attentionIntent != null ? null : base?.pending.lastAttemptAt,
+          attempts: base?.pending.attempts ?? 0,
+          lastAttemptAt: base?.pending.lastAttemptAt,
         );
         final record = _recordFor(
           key: key,

--- a/lib/providers/collab/strategy_op_queue_provider.dart
+++ b/lib/providers/collab/strategy_op_queue_provider.dart
@@ -368,7 +368,8 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
           final pending = PendingOp(
             op: successorIntent == null
                 ? desired
-                : _mergeQueuedIntent(successorIntent.pending.op, desired)!,
+                : _mergeQueuedIntent(successorIntent.pending.op, desired) ??
+                    desired,
             clientId: successorIntent?.pending.clientId ?? state.clientId!,
           );
           await _putRecord(_recordFor(
@@ -402,7 +403,8 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
             continue;
           }
           final pending = PendingOp(
-            op: _mergeQueuedIntent(successorIntent.pending.op, desired)!,
+            op: _mergeQueuedIntent(successorIntent.pending.op, desired) ??
+                desired,
             clientId: successorIntent.pending.clientId,
           );
           await _putRecord(_recordFor(

--- a/test/strategy_op_queue_provider_test.dart
+++ b/test/strategy_op_queue_provider_test.dart
@@ -967,6 +967,142 @@ void main() {
       expect(durable.successorPending!.op.payload, {'value': 'second'});
       expect(durable.latestServerRevision, 2);
     });
+
+    test('keeps a final element delete behind an in-flight add', () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(const ElementAddOp(
+        opId: 'element-add-in-flight',
+        elementPublicId: 'element-1',
+        pagePublicId: 'page-1',
+        payload: {'value': 'first'},
+        sortIndex: 0,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const ElementAddOp(
+            opId: 'element-add-successor',
+            elementPublicId: 'element-1',
+            pagePublicId: 'page-1',
+            payload: {'value': 'second'},
+            sortIndex: 0,
+          ),
+        },
+      );
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const ElementDeleteOp(
+            opId: 'element-delete-successor',
+            elementPublicId: 'element-1',
+            pagePublicId: 'page-1',
+            expectedElementRevision: 0,
+          ),
+        },
+      );
+
+      final durableBeforeAck = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durableBeforeAck.pending.op.opId, 'element-add-in-flight');
+      expect(durableBeforeAck.successorPending!.op, isA<ElementDeleteOp>());
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'element-add-in-flight',
+        revision: 1,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final finalDelete = repository.calls[1].single as ElementDeleteOp;
+      expect(finalDelete.expectedElementRevision, 1);
+      repository.completeSecond(AppliedOpAck(
+        opId: finalDelete.opId,
+        revision: 2,
+      ));
+      await repository.secondCompleted.future;
+    });
+
+    test('keeps a final lineup delete behind an in-flight add', () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.lineup('page-1', 'lineup-1');
+
+      await notifier.enqueue(const LineupAddOp(
+        opId: 'lineup-add-in-flight',
+        lineupPublicId: 'lineup-1',
+        pagePublicId: 'page-1',
+        payload: {'value': 'first'},
+        sortIndex: 0,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const LineupAddOp(
+            opId: 'lineup-add-successor',
+            lineupPublicId: 'lineup-1',
+            pagePublicId: 'page-1',
+            payload: {'value': 'second'},
+            sortIndex: 0,
+          ),
+        },
+      );
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const LineupDeleteOp(
+            opId: 'lineup-delete-successor',
+            lineupPublicId: 'lineup-1',
+            pagePublicId: 'page-1',
+            expectedLineupRevision: 0,
+          ),
+        },
+      );
+
+      final durableBeforeAck = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durableBeforeAck.pending.op.opId, 'lineup-add-in-flight');
+      expect(durableBeforeAck.successorPending!.op, isA<LineupDeleteOp>());
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'lineup-add-in-flight',
+        revision: 1,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final finalDelete = repository.calls[1].single as LineupDeleteOp;
+      expect(finalDelete.expectedLineupRevision, 1);
+      repository.completeSecond(AppliedOpAck(
+        opId: finalDelete.opId,
+        revision: 2,
+      ));
+      await repository.secondCompleted.future;
+    });
   });
 }
 

--- a/test/strategy_op_queue_provider_test.dart
+++ b/test/strategy_op_queue_provider_test.dart
@@ -250,11 +250,14 @@ void main() {
       );
     });
 
-    test('reconciliation replaces rejected immutable opId before removal',
+    test('reconciliation retains rejected work and updates its successor',
         () async {
-      final saved = record(status: DurableOutboxStatus.attention);
+      final saved = record(status: DurableOutboxStatus.attention).copyWith(
+        latestServerRevision: 7,
+        lastError: 'revision_mismatch',
+      );
       await store.put(saved);
-      final notifier = start();
+      var notifier = start();
       await notifier.syncDesiredOpsForPage(
         pageId: 'page-1',
         desiredOpsByEntityKey: {
@@ -263,14 +266,58 @@ void main() {
         },
         flushImmediately: false,
       );
-      final current = container!.read(strategyOpQueueProvider);
-      expect(current.attentionByEntityKey, isEmpty);
-      expect(current.queuedByEntityKey.values.single.pending.op.opId,
-          'replacement');
+      var current = container!.read(strategyOpQueueProvider);
       expect(
-        (store.values.values.single as Map)['opId'],
-        'replacement',
+          current.attentionByEntityKey.values.single.pending.op.opId, 'op-1');
+      expect(current.queuedByEntityKey, isEmpty);
+      expect(
+        current.successorByEntityKey.values.single.pending.op.payload,
+        {'value': 'new'},
       );
+
+      notifier = start();
+      current = container!.read(strategyOpQueueProvider);
+      expect(current.attentionByEntityKey, hasLength(1));
+      expect(current.successorByEntityKey, hasLength(1));
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          const EntitySyncKey.element('page-1', 'element-1'):
+              elementOp(opId: 'newer-replacement', value: 'newest'),
+        },
+        flushImmediately: false,
+      );
+
+      current = container!.read(strategyOpQueueProvider);
+      expect(
+          current.attentionByEntityKey.values.single.pending.op.opId, 'op-1');
+      expect(current.queuedByEntityKey, isEmpty);
+      expect(
+        current.successorByEntityKey.values.single.pending.op.payload,
+        {'value': 'newest'},
+      );
+      var durable = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durable.status, DurableOutboxStatus.attention);
+      expect(durable.pending.op.opId, 'op-1');
+      expect(durable.successorPending!.op.payload, {'value': 'newest'});
+      expect(durable.latestServerRevision, 7);
+      expect(durable.lastError, 'revision_mismatch');
+
+      await notifier.retryRejected(flushImmediately: false);
+      current = container!.read(strategyOpQueueProvider);
+      expect(current.attentionByEntityKey, isEmpty);
+      expect(current.successorByEntityKey, isEmpty);
+      final retry = current.queuedByEntityKey.values.single.pending.op;
+      expect(retry.opId, isNot(anyOf('op-1', 'newer-replacement')));
+      expect(retry.payload, {'value': 'newest'});
+      expect(retry.expectedRevision, 7);
+      durable = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durable.status, DurableOutboxStatus.queued);
+      expect(durable.successorPending, isNull);
     });
 
     test('ordinary reconciliation does not discard attention work', () async {
@@ -966,6 +1013,50 @@ void main() {
       expect(durable.pending.op.opId, 'conflicting-first');
       expect(durable.successorPending!.op.payload, {'value': 'second'});
       expect(durable.latestServerRevision, 2);
+
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: _elementPatch(
+            opId: 'retained-second-again',
+            value: 'second',
+            expectedRevision: 1,
+          ),
+        },
+        flushImmediately: true,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final reconciled = container.read(strategyOpQueueProvider);
+      expect(repository.calls, hasLength(1));
+      expect(reconciled.attentionByEntityKey, contains(key));
+      expect(reconciled.queuedByEntityKey, isEmpty);
+      expect(
+        reconciled.successorByEntityKey[key]!.pending.op.payload,
+        {'value': 'second'},
+      );
+      final durableAfterReconcile = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durableAfterReconcile.status, DurableOutboxStatus.attention);
+      expect(durableAfterReconcile.pending.op.opId, 'conflicting-first');
+      expect(
+        durableAfterReconcile.successorPending!.op.payload,
+        {'value': 'second'},
+      );
+      expect(durableAfterReconcile.latestServerRevision, 2);
+
+      await notifier.retryRejected(flushImmediately: true);
+      await repository.secondStarted.future;
+      final retried = repository.calls[1].single as ElementPatchOp;
+      expect(retried.opId, isNot('retained-second'));
+      expect(retried.payload, {'value': 'second'});
+      expect(retried.expectedElementRevision, 2);
+      repository.completeSecond(AppliedOpAck(
+        opId: retried.opId,
+        revision: 3,
+      ));
+      await repository.secondCompleted.future;
     });
 
     test('promotes an edit after an element add as a patch', () async {

--- a/test/strategy_op_queue_provider_test.dart
+++ b/test/strategy_op_queue_provider_test.dart
@@ -770,6 +770,204 @@ void main() {
       await replayRepository.secondCompleted.future;
     });
   });
+
+  group('same-entity final intent', () {
+    test('keeps an element successor behind its in-flight predecessor',
+        () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(_elementPatch(
+        opId: 'first-edit',
+        value: 'first',
+        expectedRevision: 1,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: _elementPatch(
+            opId: 'second-edit',
+            value: 'second',
+            expectedRevision: 1,
+          ),
+        },
+      );
+
+      final duringFirst = container.read(strategyOpQueueProvider);
+      expect(
+        duringFirst.inFlightByEntityKey[key]!.pending.op.opId,
+        'first-edit',
+      );
+      expect(
+        duringFirst.successorByEntityKey[key]!.pending.op.payload,
+        {'value': 'second'},
+      );
+      final durableDuringFirst = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durableDuringFirst.pending.op.opId, 'first-edit');
+      expect(
+        durableDuringFirst.successorPending!.op.payload,
+        {'value': 'second'},
+      );
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'first-edit',
+        revision: 2,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final promoted = repository.calls[1].single as ElementPatchOp;
+      expect(promoted.payload, {'value': 'second'});
+      expect(promoted.expectedElementRevision, 2);
+      expect(promoted.opId, isNot('second-edit'));
+
+      repository.completeSecond(AppliedOpAck(
+        opId: promoted.opId,
+        revision: 3,
+      ));
+      await repository.secondCompleted.future;
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(strategyOpQueueProvider).pending, isEmpty);
+      expect(store.values, isEmpty);
+    });
+
+    test('restart replays an element predecessor before its successor',
+        () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final firstRepository = _SequencedAckRepository();
+      var container = _cloudQueueContainer(
+        store: store,
+        repository: firstRepository,
+      );
+      var notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(_elementPatch(
+        opId: 'first-before-restart',
+        value: 'first',
+        expectedRevision: 4,
+      ));
+      unawaited(notifier.flushNow());
+      await firstRepository.firstStarted.future;
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: _elementPatch(
+            opId: 'second-after-restart',
+            value: 'second',
+            expectedRevision: 4,
+          ),
+        },
+      );
+      container.dispose();
+
+      final replayRepository = _SequencedAckRepository();
+      container = _cloudQueueContainer(
+        store: store,
+        repository: replayRepository,
+      );
+      addTearDown(container.dispose);
+      notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      await replayRepository.firstStarted.future;
+
+      final replayed = replayRepository.calls.first.single as ElementPatchOp;
+      expect(replayed.opId, 'first-before-restart');
+      expect(replayed.payload, {'value': 'first'});
+      expect(
+        container
+            .read(strategyOpQueueProvider)
+            .successorByEntityKey[key]!
+            .pending
+            .op
+            .payload,
+        {'value': 'second'},
+      );
+
+      replayRepository.completeFirst(const AppliedOpAck(
+        opId: 'first-before-restart',
+        revision: 5,
+      ));
+      await replayRepository.secondStarted.future;
+      final finalEdit = replayRepository.calls[1].single as ElementPatchOp;
+      expect(finalEdit.payload, {'value': 'second'});
+      expect(finalEdit.expectedElementRevision, 5);
+      replayRepository.completeSecond(AppliedOpAck(
+        opId: finalEdit.opId,
+        revision: 6,
+      ));
+      await replayRepository.secondCompleted.future;
+    });
+
+    test('rejected predecessor leaves its element successor in attention',
+        () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(_elementPatch(
+        opId: 'conflicting-first',
+        value: 'first',
+        expectedRevision: 1,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: _elementPatch(
+            opId: 'retained-second',
+            value: 'second',
+            expectedRevision: 1,
+          ),
+        },
+      );
+
+      repository.completeFirst(const RejectedOpAck(
+        opId: 'conflicting-first',
+        rejectionReason: OpRejectionReason.revisionMismatch,
+        current: ElementCurrentSnapshot(revision: 2, value: {'value': 'peer'}),
+      ));
+      await firstFlush;
+      await Future<void>.delayed(Duration.zero);
+
+      final conflicted = container.read(strategyOpQueueProvider);
+      expect(repository.calls, hasLength(1));
+      expect(conflicted.attentionByEntityKey, contains(key));
+      expect(
+        conflicted.successorByEntityKey[key]!.pending.op.payload,
+        {'value': 'second'},
+      );
+      final durable = DurableOutboxRecord.fromJson(
+        Map<String, dynamic>.from(store.values.values.single as Map),
+      );
+      expect(durable.status, DurableOutboxStatus.attention);
+      expect(durable.pending.op.opId, 'conflicting-first');
+      expect(durable.successorPending!.op.payload, {'value': 'second'});
+      expect(durable.latestServerRevision, 2);
+    });
+  });
 }
 
 ProviderContainer _cloudQueueContainer({
@@ -804,6 +1002,20 @@ PagePatchOp _pageSideOp({
     pagePublicId: 'page-1',
     payload: {'isAttack': isAttack},
     expectedPageRevision: expectedRevision,
+  );
+}
+
+ElementPatchOp _elementPatch({
+  required String opId,
+  required String value,
+  required int expectedRevision,
+}) {
+  return ElementPatchOp(
+    opId: opId,
+    elementPublicId: 'element-1',
+    pagePublicId: 'page-1',
+    payload: {'value': value},
+    expectedElementRevision: expectedRevision,
   );
 }
 

--- a/test/strategy_op_queue_provider_test.dart
+++ b/test/strategy_op_queue_provider_test.dart
@@ -968,6 +968,159 @@ void main() {
       expect(durable.latestServerRevision, 2);
     });
 
+    test('promotes an edit after an element add as a patch', () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(const ElementAddOp(
+        opId: 'element-add-in-flight',
+        elementPublicId: 'element-1',
+        pagePublicId: 'page-1',
+        payload: {'value': 'first'},
+        sortIndex: 0,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const ElementAddOp(
+            opId: 'element-add-successor',
+            elementPublicId: 'element-1',
+            pagePublicId: 'page-1',
+            payload: {'value': 'second'},
+            sortIndex: 0,
+          ),
+        },
+      );
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'element-add-in-flight',
+        revision: 1,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final finalEdit = repository.calls[1].single as ElementPatchOp;
+      expect(finalEdit.payload, {'value': 'second'});
+      expect(finalEdit.expectedElementRevision, 1);
+      repository.completeSecond(AppliedOpAck(
+        opId: finalEdit.opId,
+        revision: 2,
+      ));
+      await repository.secondCompleted.future;
+    });
+
+    test('promotes an edit after a lineup add as a patch', () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.lineup('page-1', 'lineup-1');
+
+      await notifier.enqueue(const LineupAddOp(
+        opId: 'lineup-add-in-flight',
+        lineupPublicId: 'lineup-1',
+        pagePublicId: 'page-1',
+        payload: {'value': 'first'},
+        sortIndex: 0,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const LineupAddOp(
+            opId: 'lineup-add-successor',
+            lineupPublicId: 'lineup-1',
+            pagePublicId: 'page-1',
+            payload: {'value': 'second'},
+            sortIndex: 0,
+          ),
+        },
+      );
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'lineup-add-in-flight',
+        revision: 1,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final finalEdit = repository.calls[1].single as LineupPatchOp;
+      expect(finalEdit.payload, {'value': 'second'});
+      expect(finalEdit.expectedLineupRevision, 1);
+      repository.completeSecond(AppliedOpAck(
+        opId: finalEdit.opId,
+        revision: 2,
+      ));
+      await repository.secondCompleted.future;
+    });
+
+    test('keeps a restore add after an accepted element delete', () async {
+      final store = MemoryDurableStrategyOutboxStore();
+      final repository = _SequencedAckRepository();
+      final container = _cloudQueueContainer(
+        store: store,
+        repository: repository,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(strategyOpQueueProvider.notifier)
+        ..setActiveStrategy('strategy-1', accountId: 'account-a');
+      const key = EntitySyncKey.element('page-1', 'element-1');
+
+      await notifier.enqueue(const ElementDeleteOp(
+        opId: 'element-delete-in-flight',
+        elementPublicId: 'element-1',
+        pagePublicId: 'page-1',
+        expectedElementRevision: 1,
+      ));
+      final firstFlush = notifier.flushNow();
+      await repository.firstStarted.future;
+      await notifier.syncDesiredOpsForPage(
+        pageId: 'page-1',
+        desiredOpsByEntityKey: {
+          key: const ElementAddOp(
+            opId: 'element-restore-successor',
+            elementPublicId: 'element-1',
+            pagePublicId: 'page-1',
+            payload: {'value': 'restored'},
+            sortIndex: 0,
+            expectedElementRevision: 1,
+          ),
+        },
+      );
+
+      repository.completeFirst(const AppliedOpAck(
+        opId: 'element-delete-in-flight',
+        revision: 2,
+      ));
+      await firstFlush;
+      await repository.secondStarted.future;
+
+      final restore = repository.calls[1].single as ElementAddOp;
+      expect(restore.payload, {'value': 'restored'});
+      expect(restore.expectedElementRevision, 2);
+      repository.completeSecond(AppliedOpAck(
+        opId: restore.opId,
+        revision: 3,
+      ));
+      await repository.secondCompleted.future;
+    });
+
     test('keeps a final element delete behind an in-flight add', () async {
       final store = MemoryDurableStrategyOutboxStore();
       final repository = _SequencedAckRepository();

--- a/test/strategy_page_session_provider_test.dart
+++ b/test/strategy_page_session_provider_test.dart
@@ -948,6 +948,46 @@ void main() {
     expect(finalEdit.expectedElementRevision, 1);
   });
 
+  test('a final delete is emitted behind an in-flight local add', () async {
+    final page = _page('page-1', 0);
+    const textId = 'new-local-text';
+    const key = EntitySyncKey.element('page-1', textId);
+    final queue = _FakeStrategyOpQueueNotifier();
+    final container = await _syncContainer(
+      remote: _FakeRemoteEditorNotifier(_editorSnapshot(
+        pages: [page],
+        activePage: _pageSnapshot(page),
+      )),
+      queue: queue,
+    );
+    final sync = container.read(activePageLiveSyncProvider.notifier);
+    sync.markPageHydrated(
+      strategyPublicId: 'cloud-strategy',
+      pageId: page.publicId,
+    );
+    container.read(textProvider.notifier).fromHive([
+      PlacedText(id: textId, position: const Offset(10, 20))
+        ..text = 'first'
+        ..markSizeAsWorld(),
+    ]);
+
+    final firstDesired = sync.syncLocalPage(
+      strategyPublicId: 'cloud-strategy',
+      pageId: page.publicId,
+    );
+    final add = firstDesired![key] as ElementAddOp;
+    queue.holdInFlight(key, add);
+    container.read(textProvider.notifier).removeText(textId);
+
+    final finalDesired = sync.syncLocalPage(
+      strategyPublicId: 'cloud-strategy',
+      pageId: page.publicId,
+    );
+
+    final delete = finalDesired![key] as ElementDeleteOp;
+    expect(delete.expectedElementRevision, 0);
+  });
+
   test('side switch authors exactly one Page descriptor operation', () async {
     final page = _page('page-1', 0, revision: 11);
     final container = await _syncContainer(

--- a/test/strategy_page_session_provider_test.dart
+++ b/test/strategy_page_session_provider_test.dart
@@ -210,9 +210,12 @@ RemoteElement _textElement(
   String id,
   String value, {
   int revision = 1,
+  int sortIndex = 0,
+  bool worldSized = false,
   bool deleted = false,
 }) {
   final text = PlacedText(id: id, position: const Offset(10, 20))..text = value;
+  if (worldSized) text.markSizeAsWorld();
   final payload = Map<String, dynamic>.from(text.toJson())
     ..['elementType'] = 'text';
   return RemoteElement(
@@ -221,7 +224,7 @@ RemoteElement _textElement(
     pagePublicId: pageId,
     elementType: 'text',
     payload: cloudElementPayload(kind: 'text', data: payload),
-    sortIndex: 0,
+    sortIndex: sortIndex,
     revision: revision,
     deleted: deleted,
   );
@@ -892,6 +895,59 @@ void main() {
     );
   });
 
+  test('final text is emitted while an earlier edit is in flight', () async {
+    final page = _page('page-1', 0);
+    const textId = 'text-page-1';
+    final remoteText = _textElement(
+      page.publicId,
+      textId,
+      'before',
+      worldSized: true,
+    );
+    final queue = _FakeStrategyOpQueueNotifier();
+    final container = await _cloudContainer(
+      remote: _FakeRemoteEditorNotifier(_editorSnapshot(
+        pages: [page],
+        activePage: _pageSnapshot(page, elements: [remoteText]),
+      )),
+      queue: queue,
+    );
+    await container
+        .read(strategyPageSessionProvider.notifier)
+        .initializeForStrategy(
+          strategyId: 'cloud-strategy',
+          source: StrategySource.cloud,
+          selectFirstPageIfNeeded: true,
+        );
+    const key = EntitySyncKey.element('page-1', textId);
+    queue.holdInFlight(
+      key,
+      ElementPatchOp(
+        opId: 'first-edit-in-flight',
+        elementPublicId: textId,
+        pagePublicId: page.publicId,
+        payload: _textElement(
+          page.publicId,
+          textId,
+          'first-edit',
+          worldSized: true,
+        ).payload,
+        sortIndex: 0,
+        expectedElementRevision: 1,
+      ),
+    );
+
+    final desired =
+        container.read(activePageLiveSyncProvider.notifier).syncLocalPage(
+              strategyPublicId: 'cloud-strategy',
+              pageId: page.publicId,
+            );
+
+    final finalEdit = desired![key] as ElementPatchOp;
+    expect(finalEdit.payload.toString(), contains('before'));
+    expect(finalEdit.expectedElementRevision, 1);
+  });
+
   test('side switch authors exactly one Page descriptor operation', () async {
     final page = _page('page-1', 0, revision: 11);
     final container = await _syncContainer(
@@ -1098,6 +1154,98 @@ void main() {
     await _settle();
     expect(container.read(textProvider).single.text, 'local-intent');
     expect(container.read(strategyOpQueueProvider).pending, isNotEmpty);
+  });
+
+  test(
+      'collaborator edits stay based on the page this client actually hydrated',
+      () async {
+    final page = _page('page-1', 0);
+    const localTextId = 'local-text';
+    const collaboratorTextId = 'collaborator-text';
+    final remote = _FakeRemoteEditorNotifier(_editorSnapshot(
+      pages: [page],
+      activePage: _pageSnapshot(
+        page,
+        elements: [
+          _textElement(
+            page.publicId,
+            localTextId,
+            'shared-before',
+            worldSized: true,
+          ),
+          _textElement(
+            page.publicId,
+            collaboratorTextId,
+            'collaborator-before',
+            sortIndex: 1,
+            worldSized: true,
+          ),
+        ],
+      ),
+    ));
+    final queue = _FakeStrategyOpQueueNotifier();
+    final container = await _cloudContainer(remote: remote, queue: queue);
+    final session = container.read(strategyPageSessionProvider.notifier);
+    await session.initializeForStrategy(
+      strategyId: 'cloud-strategy',
+      source: StrategySource.cloud,
+      selectFirstPageIfNeeded: true,
+    );
+
+    container.read(textProvider.notifier).commitText(
+          localTextId,
+          'this-client-edit',
+        );
+    await _settle();
+
+    remote.setSnapshot(_editorSnapshot(
+      pages: [page],
+      activePage: _pageSnapshot(
+        page,
+        elements: [
+          _textElement(
+            page.publicId,
+            localTextId,
+            'collaborator-winner',
+            revision: 2,
+            worldSized: true,
+          ),
+          _textElement(
+            page.publicId,
+            collaboratorTextId,
+            'collaborator-after',
+            revision: 2,
+            sortIndex: 1,
+            worldSized: true,
+          ),
+        ],
+      ),
+    ));
+    await _settle();
+
+    expect(
+      container
+          .read(textProvider)
+          .firstWhere((text) => text.id == collaboratorTextId)
+          .text,
+      'collaborator-before',
+    );
+
+    await session.flushCurrentPage();
+
+    final elementOps = container
+        .read(strategyOpQueueProvider)
+        .queuedByEntityKey
+        .entries
+        .where((entry) => entry.key.kind == EntitySyncKeyKind.element)
+        .toList(growable: false);
+    expect(elementOps, hasLength(1));
+    expect(elementOps.single.key.entityId, localTextId);
+    expect(elementOps.single.value.pending.op.expectedRevision, 1);
+    expect(
+      elementOps.single.value.pending.op.payload.toString(),
+      contains('this-client-edit'),
+    );
   });
 
   test('local mode page switching keeps its shipped Hive shape', () async {

--- a/test/strategy_page_session_provider_test.dart
+++ b/test/strategy_page_session_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:icarus/collab/collab_models.dart';
+import 'package:icarus/collab/durable_strategy_outbox.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/line_provider.dart';
@@ -15,6 +16,7 @@ import 'package:icarus/const/transition_data.dart';
 import 'package:icarus/hive/hive_registration.dart';
 import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
 import 'package:icarus/providers/collab/active_page_live_sync_provider.dart';
+import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/remote_strategy_snapshot_provider.dart';
 import 'package:icarus/providers/collab/strategy_conflict_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
@@ -986,6 +988,78 @@ void main() {
 
     final delete = finalDesired![key] as ElementDeleteOp;
     expect(delete.expectedElementRevision, 0);
+  });
+
+  test('restart retains a queued add missing from canvas and remote', () async {
+    final page = _page('page-1', 0);
+    const textId = 'queued-before-restart';
+    const key = EntitySyncKey.element('page-1', textId);
+    final add = ElementAddOp(
+      opId: 'add-before-restart',
+      elementPublicId: textId,
+      pagePublicId: page.publicId,
+      payload: _textElement(page.publicId, textId, 'unsent').payload,
+      sortIndex: 0,
+    );
+    final store = MemoryDurableStrategyOutboxStore();
+    final firstContainer = ProviderContainer(overrides: [
+      durableStrategyOutboxStoreProvider.overrideWithValue(store),
+    ]);
+    firstContainer
+        .read(cloudCollabModeProvider.notifier)
+        .setForceLocalFallback(true);
+    final firstQueue = firstContainer.read(strategyOpQueueProvider.notifier)
+      ..setActiveStrategy('cloud-strategy', accountId: 'account-a');
+    await firstQueue.enqueue(add, flushImmediately: false);
+    expect(store.load().records.single.pending.op.opId, 'add-before-restart');
+    firstContainer.dispose();
+
+    final remote = _FakeRemoteEditorNotifier(_editorSnapshot(
+      pages: [page],
+      activePage: _pageSnapshot(page),
+    ));
+    final restarted = ProviderContainer(overrides: [
+      durableStrategyOutboxStoreProvider.overrideWithValue(store),
+      remoteEditorSnapshotProvider.overrideWith(() => remote),
+    ]);
+    addTearDown(restarted.dispose);
+    restarted
+        .read(cloudCollabModeProvider.notifier)
+        .setForceLocalFallback(true);
+    final restartedQueue = restarted.read(strategyOpQueueProvider.notifier)
+      ..setActiveStrategy('cloud-strategy', accountId: 'account-a');
+    await restarted.read(remoteEditorSnapshotProvider.future);
+    final sync = restarted.read(activePageLiveSyncProvider.notifier);
+    sync.markPageHydrated(
+      strategyPublicId: 'cloud-strategy',
+      pageId: page.publicId,
+    );
+
+    final desired = sync.syncLocalPage(
+      strategyPublicId: 'cloud-strategy',
+      pageId: page.publicId,
+    );
+
+    final retained = desired![key] as ElementAddOp;
+    expect(retained.opId, 'add-before-restart');
+    expect(retained.payload, add.payload);
+    await restartedQueue.syncDesiredOpsForPage(
+      pageId: page.publicId,
+      desiredOpsByEntityKey: desired,
+      flushImmediately: false,
+    );
+    expect(
+      restarted
+          .read(strategyOpQueueProvider)
+          .queuedByEntityKey[key]!
+          .pending
+          .op,
+      isA<ElementAddOp>(),
+    );
+    final durable = store.load().records.singleWhere(
+          (record) => record.entityKey == key,
+        );
+    expect(durable.pending.op.opId, 'add-before-restart');
   });
 
   test('side switch authors exactly one Page descriptor operation', () async {


### PR DESCRIPTION
## Summary

- Diff active-page changes from the remote state that was actually hydrated into the canvas, so deferred live reads cannot turn untouched or stale local values into accepted writes.
- Keep a durable successor for every entity kind while its predecessor is in flight. Promote that successor only after the predecessor is accepted and supplies a new revision.
- Cover collaborator changes, rapid element edits, restart recovery, and rejected predecessors with deterministic regressions.

## Behavioral invariant

Every local operation is based on the server revision the user actually edited. A newer remote revision is never borrowed to make stale local state acceptable. While an operation is in flight, later same-entity intent is durably retained as a successor and can only be rebased from an accepted predecessor.

## Verification

- `flutter test test/strategy_page_session_provider_test.dart test/strategy_op_queue_provider_test.dart`
- 95 focused collab, cloud, provider, and cloud UI tests
- `flutter test` (610 passed, 2 expected skips)
- `flutter analyze` (no errors or warnings; 35 existing info findings)