### PR TITLE
Make cloud sync exits and media durable

### DIFF
--- a/lib/collab/cloud_media_models.dart
+++ b/lib/collab/cloud_media_models.dart
@@ -33,6 +33,7 @@ String mimeTypeForImageExtension(String extension) {
 class CloudMediaUploadJob {
   CloudMediaUploadJob({
     required this.jobId,
+    required this.accountId,
     required this.strategyPublicId,
     required this.assetPublicId,
     required this.fileExtension,
@@ -54,6 +55,7 @@ class CloudMediaUploadJob {
   });
 
   final String jobId;
+  final String? accountId;
   final String strategyPublicId;
   final String assetPublicId;
   final String fileExtension;
@@ -84,6 +86,7 @@ class CloudMediaUploadJob {
 
   CloudMediaUploadJob copyWith({
     String? jobId,
+    String? accountId,
     String? strategyPublicId,
     String? assetPublicId,
     String? fileExtension,
@@ -105,6 +108,7 @@ class CloudMediaUploadJob {
   }) {
     return CloudMediaUploadJob(
       jobId: jobId ?? this.jobId,
+      accountId: accountId ?? this.accountId,
       strategyPublicId: strategyPublicId ?? this.strategyPublicId,
       assetPublicId: assetPublicId ?? this.assetPublicId,
       fileExtension: fileExtension ?? this.fileExtension,

--- a/lib/collab/cloud_media_models.dart
+++ b/lib/collab/cloud_media_models.dart
@@ -40,6 +40,7 @@ class CloudMediaUploadJob {
     required this.state,
     required this.attempts,
     required this.updatedAt,
+    this.referenceDurable = true,
     this.width,
     this.height,
     this.byteSize,
@@ -67,6 +68,7 @@ class CloudMediaUploadJob {
   final String? etag;
   final DateTime? uploadUrlExpiresAt;
   final CloudMediaJobState state;
+  final bool referenceDurable;
   final int attempts;
   final String? lastError;
   final DateTime updatedAt;
@@ -96,6 +98,7 @@ class CloudMediaUploadJob {
     Object? etag = _noChange,
     Object? uploadUrlExpiresAt = _noChange,
     CloudMediaJobState? state,
+    bool? referenceDurable,
     int? attempts,
     Object? lastError = _noChange,
     DateTime? updatedAt,
@@ -125,6 +128,7 @@ class CloudMediaUploadJob {
           ? this.uploadUrlExpiresAt
           : uploadUrlExpiresAt as DateTime?,
       state: state ?? this.state,
+      referenceDurable: referenceDurable ?? this.referenceDurable,
       attempts: attempts ?? this.attempts,
       lastError: identical(lastError, _noChange)
           ? this.lastError

--- a/lib/collab/durable_cloud_media_outbox.dart
+++ b/lib/collab/durable_cloud_media_outbox.dart
@@ -1,0 +1,236 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce_flutter/adapters.dart';
+import 'package:icarus/collab/cloud_media_models.dart';
+import 'package:icarus/const/hive_boxes.dart';
+
+const durableCloudMediaOutboxRecordVersion = 1;
+const durableCloudMediaOutboxVersionKey = '__media_outbox_record_version__';
+
+Future<void> prepareDurableCloudMediaOutbox() async {
+  final box = Hive.box<dynamic>(HiveBoxNames.cloudMediaOutboxBox);
+  if (box.get(durableCloudMediaOutboxVersionKey) ==
+      durableCloudMediaOutboxRecordVersion) {
+    return;
+  }
+  if (box.isNotEmpty) {
+    throw StateError(
+      'The media outbox has an unsupported record version. '
+      'Refusing to discard pending media work.',
+    );
+  }
+  await box.put(
+    durableCloudMediaOutboxVersionKey,
+    durableCloudMediaOutboxRecordVersion,
+  );
+}
+
+class DurableCloudMediaOutboxLoadIssue {
+  const DurableCloudMediaOutboxLoadIssue({
+    required this.storageKey,
+    required this.error,
+  });
+
+  final String storageKey;
+  final String error;
+}
+
+class DurableCloudMediaOutboxLoadResult {
+  const DurableCloudMediaOutboxLoadResult({
+    required this.jobs,
+    required this.issues,
+  });
+
+  final List<CloudMediaUploadJob> jobs;
+  final List<DurableCloudMediaOutboxLoadIssue> issues;
+}
+
+abstract class DurableCloudMediaOutboxStore {
+  DurableCloudMediaOutboxLoadResult load();
+  Future<void> put(CloudMediaUploadJob job);
+  Future<void> remove(String jobId);
+}
+
+class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
+  Box<dynamic> get _box => Hive.box<dynamic>(HiveBoxNames.cloudMediaOutboxBox);
+
+  @override
+  DurableCloudMediaOutboxLoadResult load() {
+    final jobs = <CloudMediaUploadJob>[];
+    final issues = <DurableCloudMediaOutboxLoadIssue>[];
+    for (final key in _box.keys) {
+      final storageKey = key.toString();
+      if (storageKey == durableCloudMediaOutboxVersionKey) {
+        continue;
+      }
+      try {
+        final raw = _box.get(key);
+        final decoded = raw is String ? jsonDecode(raw) : raw;
+        final json = decoded is Map<String, dynamic>
+            ? decoded
+            : Map<String, dynamic>.from(decoded as Map);
+        final job = _jobFromJson(json);
+        if (job.jobId != storageKey) {
+          throw const FormatException(
+            'Media outbox storage key does not match job',
+          );
+        }
+        jobs.add(job);
+      } catch (error) {
+        issues.add(
+          DurableCloudMediaOutboxLoadIssue(
+            storageKey: storageKey,
+            error: error.toString(),
+          ),
+        );
+      }
+    }
+    return DurableCloudMediaOutboxLoadResult(jobs: jobs, issues: issues);
+  }
+
+  @override
+  Future<void> put(CloudMediaUploadJob job) {
+    final jsonSafe = Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(_jobToJson(job))) as Map,
+    );
+    return _box.put(job.jobId, jsonSafe);
+  }
+
+  @override
+  Future<void> remove(String jobId) => _box.delete(jobId);
+}
+
+class MemoryDurableCloudMediaOutboxStore
+    implements DurableCloudMediaOutboxStore {
+  MemoryDurableCloudMediaOutboxStore([Map<String, Object?>? initialValues])
+    : values = Map<String, Object?>.from(initialValues ?? const {});
+
+  final Map<String, Object?> values;
+
+  @override
+  DurableCloudMediaOutboxLoadResult load() {
+    final jobs = <CloudMediaUploadJob>[];
+    final issues = <DurableCloudMediaOutboxLoadIssue>[];
+    for (final entry in values.entries) {
+      try {
+        final value = entry.value;
+        final json = value is Map<String, dynamic>
+            ? value
+            : Map<String, dynamic>.from(value as Map);
+        final job = _jobFromJson(json);
+        if (job.jobId != entry.key) {
+          throw const FormatException(
+            'Media outbox storage key does not match job',
+          );
+        }
+        jobs.add(job);
+      } catch (error) {
+        issues.add(
+          DurableCloudMediaOutboxLoadIssue(
+            storageKey: entry.key,
+            error: error.toString(),
+          ),
+        );
+      }
+    }
+    return DurableCloudMediaOutboxLoadResult(jobs: jobs, issues: issues);
+  }
+
+  @override
+  Future<void> put(CloudMediaUploadJob job) async {
+    values[job.jobId] = Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(_jobToJson(job))) as Map,
+    );
+  }
+
+  @override
+  Future<void> remove(String jobId) async {
+    values.remove(jobId);
+  }
+}
+
+final durableCloudMediaOutboxStoreProvider =
+    Provider<DurableCloudMediaOutboxStore>(
+      (ref) => HiveDurableCloudMediaOutboxStore(),
+    );
+
+Map<String, dynamic> _jobToJson(CloudMediaUploadJob job) => <String, dynamic>{
+  'outboxVersion': durableCloudMediaOutboxRecordVersion,
+  'jobId': job.jobId,
+  'strategyPublicId': job.strategyPublicId,
+  'assetPublicId': job.assetPublicId,
+  'fileExtension': job.fileExtension,
+  'mimeType': job.mimeType,
+  if (job.width != null) 'width': job.width,
+  if (job.height != null) 'height': job.height,
+  if (job.byteSize != null) 'byteSize': job.byteSize,
+  if (job.provider != null) 'provider': job.provider,
+  if (job.uploadId != null) 'uploadId': job.uploadId,
+  if (job.objectKey != null) 'objectKey': job.objectKey,
+  if (job.storageId != null) 'storageId': job.storageId,
+  if (job.etag != null) 'etag': job.etag,
+  if (job.uploadUrlExpiresAt != null)
+    'uploadUrlExpiresAt': job.uploadUrlExpiresAt!.toUtc().toIso8601String(),
+  'state': job.state.name,
+  'attempts': job.attempts,
+  if (job.lastError != null) 'lastError': job.lastError,
+  'updatedAt': job.updatedAt.toUtc().toIso8601String(),
+};
+
+CloudMediaUploadJob _jobFromJson(Map<String, dynamic> json) {
+  final version = (json['outboxVersion'] as num?)?.toInt();
+  if (version != durableCloudMediaOutboxRecordVersion) {
+    throw FormatException('Unsupported media outbox record version: $version');
+  }
+  return CloudMediaUploadJob(
+    jobId: _nonEmptyString(json['jobId'], field: 'jobId'),
+    strategyPublicId: _nonEmptyString(
+      json['strategyPublicId'],
+      field: 'strategyPublicId',
+    ),
+    assetPublicId: _nonEmptyString(
+      json['assetPublicId'],
+      field: 'assetPublicId',
+    ),
+    fileExtension: json['fileExtension'] as String? ?? '',
+    mimeType: _nonEmptyString(json['mimeType'], field: 'mimeType'),
+    width: (json['width'] as num?)?.toInt(),
+    height: (json['height'] as num?)?.toInt(),
+    byteSize: (json['byteSize'] as num?)?.toInt(),
+    provider: json['provider'] as String?,
+    uploadId: json['uploadId'] as String?,
+    objectKey: json['objectKey'] as String?,
+    storageId: json['storageId'] as String?,
+    etag: json['etag'] as String?,
+    uploadUrlExpiresAt: _optionalDate(json['uploadUrlExpiresAt']),
+    state: CloudMediaJobState.values.byName(
+      _nonEmptyString(json['state'], field: 'state'),
+    ),
+    attempts: (json['attempts'] as num?)?.toInt() ?? 0,
+    lastError: json['lastError'] as String?,
+    updatedAt: _requiredDate(json['updatedAt'], field: 'updatedAt'),
+  );
+}
+
+String _nonEmptyString(Object? value, {required String field}) {
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Media outbox $field must be a non-empty string');
+}
+
+DateTime _requiredDate(Object? value, {required String field}) {
+  final parsed = _optionalDate(value);
+  if (parsed != null) {
+    return parsed;
+  }
+  throw FormatException('Media outbox $field must be an ISO-8601 date');
+}
+
+DateTime? _optionalDate(Object? value) {
+  if (value is! String) {
+    return null;
+  }
+  return DateTime.tryParse(value)?.toLocal();
+}

--- a/lib/collab/durable_cloud_media_outbox.dart
+++ b/lib/collab/durable_cloud_media_outbox.dart
@@ -49,6 +49,7 @@ class DurableCloudMediaOutboxLoadResult {
 abstract class DurableCloudMediaOutboxStore {
   DurableCloudMediaOutboxLoadResult load();
   Future<void> put(CloudMediaUploadJob job);
+  Future<void> putAll(Iterable<CloudMediaUploadJob> jobs);
   Future<void> remove(String jobId);
 }
 
@@ -95,6 +96,17 @@ class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
       jsonDecode(jsonEncode(_jobToJson(job))) as Map,
     );
     return _box.put(job.jobId, jsonSafe);
+  }
+
+  @override
+  Future<void> putAll(Iterable<CloudMediaUploadJob> jobs) {
+    final values = <String, Map<String, dynamic>>{
+      for (final job in jobs)
+        job.jobId: Map<String, dynamic>.from(
+          jsonDecode(jsonEncode(_jobToJson(job))) as Map,
+        ),
+    };
+    return _box.putAll(values);
   }
 
   @override
@@ -145,6 +157,17 @@ class MemoryDurableCloudMediaOutboxStore
   }
 
   @override
+  Future<void> putAll(Iterable<CloudMediaUploadJob> jobs) async {
+    final encoded = <String, Map<String, dynamic>>{
+      for (final job in jobs)
+        job.jobId: Map<String, dynamic>.from(
+          jsonDecode(jsonEncode(_jobToJson(job))) as Map,
+        ),
+    };
+    values.addAll(encoded);
+  }
+
+  @override
   Future<void> remove(String jobId) async {
     values.remove(jobId);
   }
@@ -173,6 +196,7 @@ Map<String, dynamic> _jobToJson(CloudMediaUploadJob job) => <String, dynamic>{
   if (job.uploadUrlExpiresAt != null)
     'uploadUrlExpiresAt': job.uploadUrlExpiresAt!.toUtc().toIso8601String(),
   'state': job.state.name,
+  'referenceDurable': job.referenceDurable,
   'attempts': job.attempts,
   if (job.lastError != null) 'lastError': job.lastError,
   'updatedAt': job.updatedAt.toUtc().toIso8601String(),
@@ -207,6 +231,7 @@ CloudMediaUploadJob _jobFromJson(Map<String, dynamic> json) {
     state: CloudMediaJobState.values.byName(
       _nonEmptyString(json['state'], field: 'state'),
     ),
+    referenceDurable: json['referenceDurable'] as bool? ?? true,
     attempts: (json['attempts'] as num?)?.toInt() ?? 0,
     lastError: json['lastError'] as String?,
     updatedAt: _requiredDate(json['updatedAt'], field: 'updatedAt'),

--- a/lib/collab/durable_cloud_media_outbox.dart
+++ b/lib/collab/durable_cloud_media_outbox.dart
@@ -5,13 +5,25 @@ import 'package:hive_ce_flutter/adapters.dart';
 import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/const/hive_boxes.dart';
 
-const durableCloudMediaOutboxRecordVersion = 1;
+const durableCloudMediaOutboxRecordVersion = 2;
+const _legacyDurableCloudMediaOutboxRecordVersion = 1;
 const durableCloudMediaOutboxVersionKey = '__media_outbox_record_version__';
 
 Future<void> prepareDurableCloudMediaOutbox() async {
   final box = Hive.box<dynamic>(HiveBoxNames.cloudMediaOutboxBox);
   if (box.get(durableCloudMediaOutboxVersionKey) ==
       durableCloudMediaOutboxRecordVersion) {
+    return;
+  }
+  if (box.get(durableCloudMediaOutboxVersionKey) ==
+      _legacyDurableCloudMediaOutboxRecordVersion) {
+    // Version 1 records predate account ownership. Keep them byte-for-byte so
+    // the queue can surface them as unknown-owner work without ever uploading
+    // or deleting them.
+    await box.put(
+      durableCloudMediaOutboxVersionKey,
+      durableCloudMediaOutboxRecordVersion,
+    );
     return;
   }
   if (box.isNotEmpty) {
@@ -50,7 +62,22 @@ abstract class DurableCloudMediaOutboxStore {
   DurableCloudMediaOutboxLoadResult load();
   Future<void> put(CloudMediaUploadJob job);
   Future<void> putAll(Iterable<CloudMediaUploadJob> jobs);
-  Future<void> remove(String jobId);
+  Future<void> remove(CloudMediaUploadJob job);
+}
+
+String durableCloudMediaOutboxStorageKey(CloudMediaUploadJob job) {
+  return durableCloudMediaOutboxStorageKeyFor(
+    accountId: job.accountId,
+    jobId: job.jobId,
+  );
+}
+
+String durableCloudMediaOutboxStorageKeyFor({
+  required String? accountId,
+  required String jobId,
+}) {
+  if (accountId == null || accountId.isEmpty) return jobId;
+  return '${Uri.encodeComponent(accountId)}|${Uri.encodeComponent(jobId)}';
 }
 
 class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
@@ -72,7 +99,7 @@ class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
             ? decoded
             : Map<String, dynamic>.from(decoded as Map);
         final job = _jobFromJson(json);
-        if (job.jobId != storageKey) {
+        if (durableCloudMediaOutboxStorageKey(job) != storageKey) {
           throw const FormatException(
             'Media outbox storage key does not match job',
           );
@@ -95,14 +122,14 @@ class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
     final jsonSafe = Map<String, dynamic>.from(
       jsonDecode(jsonEncode(_jobToJson(job))) as Map,
     );
-    return _box.put(job.jobId, jsonSafe);
+    return _box.put(durableCloudMediaOutboxStorageKey(job), jsonSafe);
   }
 
   @override
   Future<void> putAll(Iterable<CloudMediaUploadJob> jobs) {
     final values = <String, Map<String, dynamic>>{
       for (final job in jobs)
-        job.jobId: Map<String, dynamic>.from(
+        durableCloudMediaOutboxStorageKey(job): Map<String, dynamic>.from(
           jsonDecode(jsonEncode(_jobToJson(job))) as Map,
         ),
     };
@@ -110,7 +137,8 @@ class HiveDurableCloudMediaOutboxStore implements DurableCloudMediaOutboxStore {
   }
 
   @override
-  Future<void> remove(String jobId) => _box.delete(jobId);
+  Future<void> remove(CloudMediaUploadJob job) =>
+      _box.delete(durableCloudMediaOutboxStorageKey(job));
 }
 
 class MemoryDurableCloudMediaOutboxStore
@@ -131,7 +159,7 @@ class MemoryDurableCloudMediaOutboxStore
             ? value
             : Map<String, dynamic>.from(value as Map);
         final job = _jobFromJson(json);
-        if (job.jobId != entry.key) {
+        if (durableCloudMediaOutboxStorageKey(job) != entry.key) {
           throw const FormatException(
             'Media outbox storage key does not match job',
           );
@@ -151,7 +179,7 @@ class MemoryDurableCloudMediaOutboxStore
 
   @override
   Future<void> put(CloudMediaUploadJob job) async {
-    values[job.jobId] = Map<String, dynamic>.from(
+    values[durableCloudMediaOutboxStorageKey(job)] = Map<String, dynamic>.from(
       jsonDecode(jsonEncode(_jobToJson(job))) as Map,
     );
   }
@@ -160,7 +188,7 @@ class MemoryDurableCloudMediaOutboxStore
   Future<void> putAll(Iterable<CloudMediaUploadJob> jobs) async {
     final encoded = <String, Map<String, dynamic>>{
       for (final job in jobs)
-        job.jobId: Map<String, dynamic>.from(
+        durableCloudMediaOutboxStorageKey(job): Map<String, dynamic>.from(
           jsonDecode(jsonEncode(_jobToJson(job))) as Map,
         ),
     };
@@ -168,8 +196,8 @@ class MemoryDurableCloudMediaOutboxStore
   }
 
   @override
-  Future<void> remove(String jobId) async {
-    values.remove(jobId);
+  Future<void> remove(CloudMediaUploadJob job) async {
+    values.remove(durableCloudMediaOutboxStorageKey(job));
   }
 }
 
@@ -178,37 +206,48 @@ final durableCloudMediaOutboxStoreProvider =
       (ref) => HiveDurableCloudMediaOutboxStore(),
     );
 
-Map<String, dynamic> _jobToJson(CloudMediaUploadJob job) => <String, dynamic>{
-  'outboxVersion': durableCloudMediaOutboxRecordVersion,
-  'jobId': job.jobId,
-  'strategyPublicId': job.strategyPublicId,
-  'assetPublicId': job.assetPublicId,
-  'fileExtension': job.fileExtension,
-  'mimeType': job.mimeType,
-  if (job.width != null) 'width': job.width,
-  if (job.height != null) 'height': job.height,
-  if (job.byteSize != null) 'byteSize': job.byteSize,
-  if (job.provider != null) 'provider': job.provider,
-  if (job.uploadId != null) 'uploadId': job.uploadId,
-  if (job.objectKey != null) 'objectKey': job.objectKey,
-  if (job.storageId != null) 'storageId': job.storageId,
-  if (job.etag != null) 'etag': job.etag,
-  if (job.uploadUrlExpiresAt != null)
-    'uploadUrlExpiresAt': job.uploadUrlExpiresAt!.toUtc().toIso8601String(),
-  'state': job.state.name,
-  'referenceDurable': job.referenceDurable,
-  'attempts': job.attempts,
-  if (job.lastError != null) 'lastError': job.lastError,
-  'updatedAt': job.updatedAt.toUtc().toIso8601String(),
-};
+Map<String, dynamic> _jobToJson(CloudMediaUploadJob job) {
+  final accountId = job.accountId;
+  if (accountId == null || accountId.isEmpty) {
+    throw StateError('New media outbox records require an owning account.');
+  }
+  return <String, dynamic>{
+    'outboxVersion': durableCloudMediaOutboxRecordVersion,
+    'jobId': job.jobId,
+    'accountId': accountId,
+    'strategyPublicId': job.strategyPublicId,
+    'assetPublicId': job.assetPublicId,
+    'fileExtension': job.fileExtension,
+    'mimeType': job.mimeType,
+    if (job.width != null) 'width': job.width,
+    if (job.height != null) 'height': job.height,
+    if (job.byteSize != null) 'byteSize': job.byteSize,
+    if (job.provider != null) 'provider': job.provider,
+    if (job.uploadId != null) 'uploadId': job.uploadId,
+    if (job.objectKey != null) 'objectKey': job.objectKey,
+    if (job.storageId != null) 'storageId': job.storageId,
+    if (job.etag != null) 'etag': job.etag,
+    if (job.uploadUrlExpiresAt != null)
+      'uploadUrlExpiresAt': job.uploadUrlExpiresAt!.toUtc().toIso8601String(),
+    'state': job.state.name,
+    'referenceDurable': job.referenceDurable,
+    'attempts': job.attempts,
+    if (job.lastError != null) 'lastError': job.lastError,
+    'updatedAt': job.updatedAt.toUtc().toIso8601String(),
+  };
+}
 
 CloudMediaUploadJob _jobFromJson(Map<String, dynamic> json) {
   final version = (json['outboxVersion'] as num?)?.toInt();
-  if (version != durableCloudMediaOutboxRecordVersion) {
+  if (version != _legacyDurableCloudMediaOutboxRecordVersion &&
+      version != durableCloudMediaOutboxRecordVersion) {
     throw FormatException('Unsupported media outbox record version: $version');
   }
   return CloudMediaUploadJob(
     jobId: _nonEmptyString(json['jobId'], field: 'jobId'),
+    accountId: version == _legacyDurableCloudMediaOutboxRecordVersion
+        ? _optionalNonEmptyString(json['accountId'], field: 'accountId')
+        : _nonEmptyString(json['accountId'], field: 'accountId'),
     strategyPublicId: _nonEmptyString(
       json['strategyPublicId'],
       field: 'strategyPublicId',
@@ -236,6 +275,11 @@ CloudMediaUploadJob _jobFromJson(Map<String, dynamic> json) {
     lastError: json['lastError'] as String?,
     updatedAt: _requiredDate(json['updatedAt'], field: 'updatedAt'),
   );
+}
+
+String? _optionalNonEmptyString(Object? value, {required String field}) {
+  if (value == null) return null;
+  return _nonEmptyString(value, field: field);
 }
 
 String _nonEmptyString(Object? value, {required String field}) {

--- a/lib/const/hive_boxes.dart
+++ b/lib/const/hive_boxes.dart
@@ -5,5 +5,6 @@ class HiveBoxNames {
   static const appPreferencesBox = "app_preferences_box";
   static const favoriteAgentsBox = "favorite_agents_box";
   static const strategyOutboxBox = "strategy_outbox_box";
+  static const cloudMediaOutboxBox = "cloud_media_outbox_box";
   static const pinnedItemsBox = "pinned_items_box";
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show PlatformDispatcher;
 
 import 'package:app_links/app_links.dart';
 import 'package:icarus/collab/convex_client.dart';
+import 'package:icarus/collab/durable_cloud_media_outbox.dart';
 import 'package:icarus/collab/durable_strategy_outbox.dart';
 import 'package:custom_mouse_cursor/custom_mouse_cursor.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -152,6 +153,8 @@ Future<void> main(List<String> args) async {
       await Hive.openBox<bool>(HiveBoxNames.favoriteAgentsBox);
       await Hive.openBox<dynamic>(HiveBoxNames.strategyOutboxBox);
       await prepareDurableStrategyOutbox();
+      await Hive.openBox<dynamic>(HiveBoxNames.cloudMediaOutboxBox);
+      await prepareDurableCloudMediaOutbox();
       await Hive.openBox<int>(HiveBoxNames.pinnedItemsBox);
       await Hive.openBox<dynamic>(AnalyticsService.storageBoxName);
 

--- a/lib/providers/collab/cloud_media_upload_queue_provider.dart
+++ b/lib/providers/collab/cloud_media_upload_queue_provider.dart
@@ -8,11 +8,13 @@ import 'package:http/http.dart' as http;
 import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/collab/convex_strategy_repository.dart';
+import 'package:icarus/collab/durable_cloud_media_outbox.dart';
 import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/auth_provider.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
+import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/image_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/services/app_error_reporter.dart';
@@ -24,10 +26,19 @@ class CloudMediaUploadQueueState {
   const CloudMediaUploadQueueState({
     required this.jobs,
     required this.isProcessing,
+    this.loadIssues = const <DurableCloudMediaOutboxLoadIssue>[],
+    this.durableLoaded = true,
+    this.durabilityError,
   });
 
   final List<CloudMediaUploadJob> jobs;
   final bool isProcessing;
+  final List<DurableCloudMediaOutboxLoadIssue> loadIssues;
+  final bool durableLoaded;
+  final String? durabilityError;
+
+  bool get outboxIsReliable =>
+      durableLoaded && loadIssues.isEmpty && durabilityError == null;
 
   List<CloudMediaUploadJob> jobsForStrategy(String? strategyPublicId) {
     if (strategyPublicId == null) {
@@ -51,10 +62,17 @@ class CloudMediaUploadQueueState {
   CloudMediaUploadQueueState copyWith({
     List<CloudMediaUploadJob>? jobs,
     bool? isProcessing,
+    String? durabilityError,
+    bool clearDurabilityError = false,
   }) {
     return CloudMediaUploadQueueState(
       jobs: jobs ?? this.jobs,
       isProcessing: isProcessing ?? this.isProcessing,
+      loadIssues: loadIssues,
+      durableLoaded: durableLoaded,
+      durabilityError: clearDurabilityError
+          ? null
+          : (durabilityError ?? this.durabilityError),
     );
   }
 }
@@ -78,6 +96,7 @@ final cloudMediaUploadQueueProvider =
 
 class CloudMediaUploadQueueNotifier
     extends Notifier<CloudMediaUploadQueueState> {
+  static const Duration _blockedRetryDelay = Duration(seconds: 30);
   Timer? _retryTimer;
   Timer? _uploadCompletionDismissTimer;
   ToastificationItem? _uploadProgressToast;
@@ -88,12 +107,18 @@ class CloudMediaUploadQueueNotifier
   final Set<String> _uploadCompletingJobs = {};
   final Set<String> _uploadCompletedJobs = {};
   final Map<String, CloudMediaUploadJob> _jobsById = {};
+  late DurableCloudMediaOutboxStore _store;
 
   ConvexStrategyRepository get _repo =>
       ref.read(convexStrategyRepositoryProvider);
 
   @override
   CloudMediaUploadQueueState build() {
+    _store = ref.read(durableCloudMediaOutboxStoreProvider);
+    final loaded = _store.load();
+    _jobsById.addEntries(
+      loaded.jobs.map((job) => MapEntry(job.jobId, job)),
+    );
     ref.onDispose(() {
       _retryTimer?.cancel();
       _uploadCompletionDismissTimer?.cancel();
@@ -114,9 +139,26 @@ class CloudMediaUploadQueueNotifier
       }
     });
 
-    return const CloudMediaUploadQueueState(
-      jobs: [],
+    ref.listen<AsyncValue<bool>>(convexConnectionProvider, (previous, next) {
+      final reconnected =
+          previous?.valueOrNull != true && next.valueOrNull == true;
+      if (reconnected) {
+        retryNow(ignoreBackoff: true);
+      }
+    });
+
+    if (_jobsById.isNotEmpty) {
+      scheduleMicrotask(() => retryNow(ignoreBackoff: true));
+    }
+
+    return CloudMediaUploadQueueState(
+      jobs: _readJobs(),
       isProcessing: false,
+      loadIssues: loaded.issues,
+      durableLoaded: true,
+      durabilityError: loaded.issues.isEmpty
+          ? null
+          : 'The media outbox contains unreadable saved work.',
     );
   }
 
@@ -220,7 +262,6 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> setActiveStrategy(String? strategyPublicId) async {
-    _retryTimer?.cancel();
     _refreshState();
     if (strategyPublicId != null) {
       await retryNow(ignoreBackoff: true);
@@ -266,47 +307,9 @@ class CloudMediaUploadQueueNotifier
         .where((job) => job.strategyPublicId == strategyPublicId)
         .toList(growable: false);
     for (final job in jobs) {
-      _deleteJob(job.jobId);
+      await _deleteJob(job.jobId);
     }
     _refreshState();
-  }
-
-  Future<void> cancelUpload(String assetPublicId) async {
-    final job = _getJob(assetPublicId);
-    if (job == null) {
-      return;
-    }
-    _deleteJob(job.jobId);
-    _refreshState();
-
-    try {
-      final file = await PlacedImageProvider.getImageFile(
-        strategyID: job.strategyPublicId,
-        imageID: job.assetPublicId,
-        fileExtension: job.fileExtension,
-      );
-      if (await file.exists()) {
-        await file.delete();
-      }
-    } catch (error, stackTrace) {
-      AppErrorReporter.reportError(
-        'Failed to delete canceled media upload file.',
-        error: error,
-        stackTrace: stackTrace,
-        source: 'cloud_media.upload_queue',
-      );
-    }
-
-    ref.read(placedImageProvider.notifier).removeImage(job.assetPublicId);
-  }
-
-  Future<void> cancelUploadsForStrategy(String strategyPublicId) async {
-    final jobs = _readJobs()
-        .where((job) => job.strategyPublicId == strategyPublicId)
-        .toList(growable: false);
-    for (final job in jobs) {
-      await cancelUpload(job.assetPublicId);
-    }
   }
 
   Future<void> _processNextJob({bool ignoreBackoff = false}) async {
@@ -325,14 +328,15 @@ class CloudMediaUploadQueueNotifier
 
     state = state.copyWith(isProcessing: true);
     _logMedia('process.start ${_describeJob(nextJob)}');
+    late final bool madeProgress;
     try {
-      await _processJob(nextJob);
+      madeProgress = await _processJob(nextJob);
     } finally {
       _refreshState(isProcessing: false);
       _logMedia('process.finish jobs=${state.jobs.length}');
     }
 
-    if (_readJobs().isNotEmpty) {
+    if (madeProgress && _readJobs().isNotEmpty) {
       // Only bypass backoff for the initial user-triggered kick. Follow-up
       // attempts must honor retry timing so transient attach failures do not
       // hammer Convex in a tight loop.
@@ -352,7 +356,7 @@ class CloudMediaUploadQueueNotifier
     return null;
   }
 
-  Future<void> _processJob(CloudMediaUploadJob job) async {
+  Future<bool> _processJob(CloudMediaUploadJob job) async {
     final mode = ref.read(cloudCollabModeProvider);
     final auth = ref.read(authProvider);
     if (!mode.featureFlagEnabled || mode.forceLocalFallback) {
@@ -360,8 +364,8 @@ class CloudMediaUploadQueueNotifier
         'process.blocked featureFlag=${mode.featureFlagEnabled} '
         'forceLocalFallback=${mode.forceLocalFallback} ${_describeJob(job)}',
       );
-      _scheduleRetryForNextEligibleJob();
-      return;
+      _scheduleRetryForNextEligibleJob(minimumDelay: _blockedRetryDelay);
+      return false;
     }
     if (!auth.isAuthenticated ||
         !auth.isConvexUserReady ||
@@ -374,16 +378,17 @@ class CloudMediaUploadQueueNotifier
         'connected=${ConvexClient.instance.isConnected} '
         '${_describeJob(job)}',
       );
-      _scheduleRetryForNextEligibleJob();
-      return;
+      _scheduleRetryForNextEligibleJob(minimumDelay: _blockedRetryDelay);
+      return false;
     }
 
     if (!job.hasUploadedRemoteObject) {
       await _uploadJobBlob(job);
-      return;
+      return true;
     }
 
     await _attachUploadedJob(job);
+    return true;
   }
 
   Future<void> _uploadJobBlob(CloudMediaUploadJob job) async {
@@ -456,7 +461,7 @@ class CloudMediaUploadQueueNotifier
         'etag=${response.headers['etag']} ${_describeJob(job)}',
       );
 
-      _putJob(
+      await _putJob(
         job.jobId,
         job.copyWith(
           provider: intent.provider,
@@ -556,7 +561,7 @@ class CloudMediaUploadQueueNotifier
         width: job.width,
         height: job.height,
       );
-      _deleteJob(job.jobId);
+      await _deleteJob(job.jobId);
       if (_uploadProgressToast != null) {
         _markUploadComplete(job.jobId);
       }
@@ -578,7 +583,7 @@ class CloudMediaUploadQueueNotifier
     String errorMessage, {
     required bool showToast,
   }) async {
-    _putJob(
+    await _putJob(
       job.jobId,
       job.copyWith(
         state: CloudMediaJobState.failed,
@@ -609,7 +614,7 @@ class CloudMediaUploadQueueNotifier
     return job.updatedAt.add(Duration(seconds: cappedSeconds));
   }
 
-  void _scheduleRetryForNextEligibleJob() {
+  void _scheduleRetryForNextEligibleJob({Duration? minimumDelay}) {
     _retryTimer?.cancel();
     final jobs = _readJobs();
     if (jobs.isEmpty) {
@@ -629,8 +634,11 @@ class CloudMediaUploadQueueNotifier
       return;
     }
 
-    final delay =
+    var delay =
         earliest.isAfter(now) ? earliest.difference(now) : Duration.zero;
+    if (minimumDelay != null && delay < minimumDelay) {
+      delay = minimumDelay;
+    }
     _logMedia(
         'retry.scheduled delayMs=${delay.inMilliseconds} jobs=${jobs.length}');
     _retryTimer = Timer(delay, () {
@@ -671,9 +679,9 @@ class CloudMediaUploadQueueNotifier
               byteSize: nextJob.byteSize,
               updatedAt: DateTime.now(),
             );
-      _putJob(nextJob.jobId, merged);
+      await _putJob(nextJob.jobId, merged);
     } else {
-      _putJob(nextJob.jobId, nextJob);
+      await _putJob(nextJob.jobId, nextJob);
     }
     _refreshState();
   }
@@ -686,12 +694,37 @@ class CloudMediaUploadQueueNotifier
     return _jobsById[jobId];
   }
 
-  void _putJob(String jobId, CloudMediaUploadJob job) {
-    _jobsById[jobId] = job;
+  Future<void> _putJob(String jobId, CloudMediaUploadJob job) async {
+    try {
+      await _store.put(job);
+      _jobsById[jobId] = job;
+    } catch (error, stackTrace) {
+      _recordDurabilityFailure(error, stackTrace);
+      rethrow;
+    }
   }
 
-  void _deleteJob(String jobId) {
-    _jobsById.remove(jobId);
+  Future<void> _deleteJob(String jobId) async {
+    try {
+      await _store.remove(jobId);
+      _jobsById.remove(jobId);
+    } catch (error, stackTrace) {
+      _recordDurabilityFailure(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  void _recordDurabilityFailure(Object error, StackTrace stackTrace) {
+    AppErrorReporter.reportError(
+      'Failed to update the durable media outbox.',
+      error: error,
+      stackTrace: stackTrace,
+      source: 'cloud_media.upload_queue',
+    );
+    state = state.copyWith(
+      durabilityError: 'Media work could not be saved on this device.',
+      isProcessing: false,
+    );
   }
 
   void _refreshState({bool? isProcessing}) {
@@ -709,6 +742,11 @@ class CloudMediaUploadQueueNotifier
 
     if (activeUploadCount > 0) {
       if (_uploadProgressToast == null) {
+        final uploadHasStarted = _uploadBytesTotalByJob.isNotEmpty ||
+            _uploadCompletingJobs.isNotEmpty;
+        if (!uploadHasStarted) {
+          return;
+        }
         _uploadCompletionDismissTimer?.cancel();
         _uploadProgressTotalJobs = activeUploadCount;
         _uploadProgressToastState = ValueNotifier<_UploadProgressToastState>(
@@ -913,9 +951,13 @@ class CloudMediaUploadQueueNotifier
     final activeUploadCount = state.jobs
         .where((job) => job.state != CloudMediaJobState.failed)
         .length;
-    if (_uploadProgressToastState == null || activeUploadCount <= 0) {
+    if (activeUploadCount <= 0) {
       return;
     }
+    if (_uploadProgressToastState == null) {
+      _syncUploadProgressToast();
+    }
+    if (_uploadProgressToastState == null) return;
     _uploadProgressToastState!.value = _buildUploadToastState(activeUploadCount);
   }
 

--- a/lib/providers/collab/cloud_media_upload_queue_provider.dart
+++ b/lib/providers/collab/cloud_media_upload_queue_provider.dart
@@ -28,12 +28,14 @@ class CloudMediaUploadQueueState {
   const CloudMediaUploadQueueState({
     required this.jobs,
     required this.isProcessing,
+    this.unknownOwnerJobs = const <CloudMediaUploadJob>[],
     this.loadIssues = const <DurableCloudMediaOutboxLoadIssue>[],
     this.durableLoaded = true,
     this.durabilityError,
   });
 
   final List<CloudMediaUploadJob> jobs;
+  final List<CloudMediaUploadJob> unknownOwnerJobs;
   final bool isProcessing;
   final List<DurableCloudMediaOutboxLoadIssue> loadIssues;
   final bool durableLoaded;
@@ -47,6 +49,15 @@ class CloudMediaUploadQueueState {
       return const [];
     }
     return jobs
+        .where((job) => job.strategyPublicId == strategyPublicId)
+        .toList(growable: false);
+  }
+
+  List<CloudMediaUploadJob> unknownOwnerJobsForStrategy(
+    String? strategyPublicId,
+  ) {
+    if (strategyPublicId == null) return const [];
+    return unknownOwnerJobs
         .where((job) => job.strategyPublicId == strategyPublicId)
         .toList(growable: false);
   }
@@ -69,6 +80,7 @@ class CloudMediaUploadQueueState {
   }) {
     return CloudMediaUploadQueueState(
       jobs: jobs ?? this.jobs,
+      unknownOwnerJobs: unknownOwnerJobs,
       isProcessing: isProcessing ?? this.isProcessing,
       loadIssues: loadIssues,
       durableLoaded: durableLoaded,
@@ -104,6 +116,10 @@ final cloudMediaReferenceSnapshotLoaderProvider =
   (ref) => ref.watch(convexStrategyRepositoryProvider).fetchFullSnapshot,
 );
 
+final cloudMediaAccountIdProvider = Provider<String?>(
+  (ref) => ref.watch(authProvider.select((state) => state.user?.id)),
+);
+
 class CloudMediaUploadQueueNotifier
     extends Notifier<CloudMediaUploadQueueState> {
   static const Duration _blockedRetryDelay = Duration(seconds: 30);
@@ -116,8 +132,9 @@ class CloudMediaUploadQueueNotifier
   final Map<String, int> _uploadBytesTotalByJob = {};
   final Set<String> _uploadCompletingJobs = {};
   final Set<String> _uploadCompletedJobs = {};
-  final Map<String, CloudMediaUploadJob> _jobsById = {};
+  final Map<String, CloudMediaUploadJob> _jobsByStorageKey = {};
   final Set<String> _restoredStagedJobIds = {};
+  bool _disposed = false;
   late DurableCloudMediaOutboxStore _store;
 
   ConvexStrategyRepository get _repo =>
@@ -127,15 +144,18 @@ class CloudMediaUploadQueueNotifier
   CloudMediaUploadQueueState build() {
     _store = ref.read(durableCloudMediaOutboxStoreProvider);
     final loaded = _store.load();
-    _jobsById.addEntries(
-      loaded.jobs.map((job) => MapEntry(job.jobId, job)),
+    _jobsByStorageKey.addEntries(
+      loaded.jobs.map(
+        (job) => MapEntry(durableCloudMediaOutboxStorageKey(job), job),
+      ),
     );
     _restoredStagedJobIds.addAll(
       loaded.jobs
           .where((job) => !job.referenceDurable)
-          .map((job) => job.jobId),
+          .map(durableCloudMediaOutboxStorageKey),
     );
     ref.onDispose(() {
+      _disposed = true;
       _retryTimer?.cancel();
       _uploadCompletionDismissTimer?.cancel();
       final toast = _uploadProgressToast;
@@ -155,6 +175,14 @@ class CloudMediaUploadQueueNotifier
       }
     });
 
+    ref.listen<String?>(cloudMediaAccountIdProvider, (previous, next) {
+      if (previous == next) return;
+      _refreshState();
+      if (next != null && next.isNotEmpty) {
+        retryNow(ignoreBackoff: true);
+      }
+    });
+
     ref.listen<AsyncValue<bool>>(convexConnectionProvider, (previous, next) {
       final reconnected =
           previous?.valueOrNull != true && next.valueOrNull == true;
@@ -163,12 +191,18 @@ class CloudMediaUploadQueueNotifier
       }
     });
 
-    if (_jobsById.isNotEmpty) {
-      scheduleMicrotask(() => retryNow(ignoreBackoff: true));
+    if (_jobsByStorageKey.isNotEmpty) {
+      scheduleMicrotask(() {
+        if (!_disposed) retryNow(ignoreBackoff: true);
+      });
     }
 
+    final unknownOwnerJobs = loaded.jobs
+        .where((job) => job.accountId == null)
+        .toList(growable: false);
     return CloudMediaUploadQueueState(
       jobs: _readJobs(),
+      unknownOwnerJobs: unknownOwnerJobs,
       isProcessing: false,
       loadIssues: loaded.issues,
       durableLoaded: true,
@@ -198,10 +232,12 @@ class CloudMediaUploadQueueNotifier
       return;
     }
 
+    final accountId = _requireActiveAccountId();
     final normalizedExtension = normalizeImageExtension(fileExtension ?? '');
     await _upsertJob(
       CloudMediaUploadJob(
         jobId: imagePublicId,
+        accountId: accountId,
         strategyPublicId: resolvedStrategyId,
         assetPublicId: imagePublicId,
         fileExtension: normalizedExtension,
@@ -227,10 +263,12 @@ class CloudMediaUploadQueueNotifier
     int? width,
     int? height,
   }) async {
+    final accountId = _requireActiveAccountId();
     final normalizedExtension = normalizeImageExtension(fileExtension);
     await _upsertJob(
       CloudMediaUploadJob(
         jobId: assetPublicId,
+        accountId: accountId,
         strategyPublicId: strategyPublicId,
         assetPublicId: assetPublicId,
         fileExtension: normalizedExtension,
@@ -250,11 +288,13 @@ class CloudMediaUploadQueueNotifier
     required String strategyPublicId,
     required Iterable<SimpleImageData> images,
   }) async {
+    final accountId = _requireActiveAccountId();
     final imageList = images.toList(growable: false);
     final jobs = <CloudMediaUploadJob>[
       for (final image in imageList)
         CloudMediaUploadJob(
           jobId: image.id,
+          accountId: accountId,
           strategyPublicId: strategyPublicId,
           assetPublicId: image.id,
           fileExtension: normalizeImageExtension(image.fileExtension),
@@ -275,10 +315,12 @@ class CloudMediaUploadQueueNotifier
     required String strategyPublicId,
     required Iterable<String> assetPublicIds,
   }) async {
+    final accountId = _requireActiveAccountId();
     final requestedIds = assetPublicIds.toSet();
     final staged = _readJobs()
         .where(
           (job) =>
+              job.accountId == accountId &&
               job.strategyPublicId == strategyPublicId &&
               requestedIds.contains(job.assetPublicId) &&
               !job.referenceDurable,
@@ -303,7 +345,8 @@ class CloudMediaUploadQueueNotifier
     }
     final pendingOps = <StrategyOp>[
       for (final record in durableOps.records)
-        if (record.strategyPublicId == strategyPublicId) ...[
+        if (record.accountId == accountId &&
+            record.strategyPublicId == strategyPublicId) ...[
           record.pending.op,
           if (record.successorPending case final successor?) successor.op,
         ],
@@ -342,6 +385,10 @@ class CloudMediaUploadQueueNotifier
       }
     }
 
+    if (ref.read(cloudMediaAccountIdProvider) != accountId) {
+      throw StateError('The active account changed before media was queued.');
+    }
+
     await _putJobsAtomically([
       for (final job in staged)
         job.copyWith(
@@ -354,8 +401,10 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> retryNow({bool ignoreBackoff = false}) async {
+    if (_disposed) return;
     _retryTimer?.cancel();
     await _reconcileStagedJobReferences();
+    if (_disposed) return;
     _logMedia(
       'retry_now ignoreBackoff=$ignoreBackoff jobs=${_readJobs().length}',
     );
@@ -408,7 +457,7 @@ class CloudMediaUploadQueueNotifier
         .where((job) => job.strategyPublicId == strategyPublicId)
         .toList(growable: false);
     for (final job in jobs) {
-      await _deleteJob(job.jobId);
+      await _deleteJob(job);
     }
     _refreshState();
   }
@@ -461,6 +510,10 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<bool> _processJob(CloudMediaUploadJob job) async {
+    if (!_belongsToActiveAccount(job)) {
+      _logMedia('process.blocked account_mismatch ${_describeJob(job)}');
+      return false;
+    }
     final mode = ref.read(cloudCollabModeProvider);
     final auth = ref.read(authProvider);
     if (!mode.featureFlagEnabled || mode.forceLocalFallback) {
@@ -496,6 +549,7 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> _uploadJobBlob(CloudMediaUploadJob job) async {
+    if (!_belongsToActiveAccount(job)) return;
     try {
       _logMedia('upload.local_lookup ${_describeJob(job)}');
       final file = await PlacedImageProvider.getImageFile(
@@ -515,6 +569,10 @@ class CloudMediaUploadQueueNotifier
       }
 
       final byteSize = await file.length();
+      if (!_belongsToActiveAccount(job)) {
+        _logMedia('upload.deferred account_changed ${_describeJob(job)}');
+        return;
+      }
       _setUploadByteProgress(
         job.jobId,
         sentBytes: 0,
@@ -547,6 +605,11 @@ class CloudMediaUploadQueueNotifier
         );
       }
 
+      if (!_belongsToActiveAccount(job)) {
+        _logMedia('upload.deferred account_changed ${_describeJob(job)}');
+        return;
+      }
+
       _logMedia('upload.put.start bytes=$byteSize ${_describeJob(job)}');
       final response = await _putFileWithProgress(
         job: job,
@@ -566,7 +629,6 @@ class CloudMediaUploadQueueNotifier
       );
 
       await _putJob(
-        job.jobId,
         job.copyWith(
           provider: intent.provider,
           uploadId: intent.uploadId,
@@ -639,6 +701,7 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> _attachUploadedJob(CloudMediaUploadJob job) async {
+    if (!_belongsToActiveAccount(job)) return;
     try {
       _logMedia('attach.start ${_describeJob(job)}');
       if ((job.provider == 'r2' || job.uploadId != null) &&
@@ -665,7 +728,7 @@ class CloudMediaUploadQueueNotifier
         width: job.width,
         height: job.height,
       );
-      await _deleteJob(job.jobId);
+      await _deleteJob(job);
       if (_uploadProgressToast != null) {
         _markUploadComplete(job.jobId);
       }
@@ -688,7 +751,6 @@ class CloudMediaUploadQueueNotifier
     required bool showToast,
   }) async {
     await _putJob(
-      job.jobId,
       job.copyWith(
         state: CloudMediaJobState.failed,
         attempts: job.attempts + 1,
@@ -758,23 +820,37 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> _reconcileStagedJobReferences() async {
+    final accountId = ref.read(cloudMediaAccountIdProvider);
+    if (accountId == null || accountId.isEmpty) return;
     final staged = _readJobs()
-        .where((job) => !job.referenceDurable)
+        .where(
+          (job) => job.accountId == accountId && !job.referenceDurable,
+        )
         .toList(growable: false);
     if (staged.isEmpty) return;
 
     final durableOps = ref.read(durableStrategyOutboxStoreProvider).load();
-    final pendingOps = <({String strategyPublicId, StrategyOp op})>[
+    final pendingOps =
+        <({String accountId, String strategyPublicId, StrategyOp op})>[
       for (final record in durableOps.records) ...[
-        (strategyPublicId: record.strategyPublicId, op: record.pending.op),
+        (
+          accountId: record.accountId,
+          strategyPublicId: record.strategyPublicId,
+          op: record.pending.op,
+        ),
         if (record.successorPending case final successor?)
-          (strategyPublicId: record.strategyPublicId, op: successor.op),
+          (
+            accountId: record.accountId,
+            strategyPublicId: record.strategyPublicId,
+            op: successor.op,
+          ),
       ],
     ];
     final readyFromDurableOps = staged
         .where(
           (job) => pendingOps.any(
             (pending) =>
+                pending.accountId == accountId &&
                 pending.strategyPublicId == job.strategyPublicId &&
                 _opReferencesAsset(pending.op, job.assetPublicId),
           ),
@@ -787,6 +863,7 @@ class CloudMediaUploadQueueNotifier
         )
         .toList(growable: false);
     if (readyFromDurableOps.isNotEmpty) {
+      if (ref.read(cloudMediaAccountIdProvider) != accountId) return;
       await _putJobsAtomically(readyFromDurableOps);
       _refreshState();
     }
@@ -817,6 +894,8 @@ class CloudMediaUploadQueueNotifier
         continue;
       }
 
+      if (ref.read(cloudMediaAccountIdProvider) != accountId) return;
+
       final referenced = entry.value
           .where(
             (job) => _snapshotReferencesAsset(snapshot, job.assetPublicId),
@@ -829,11 +908,14 @@ class CloudMediaUploadQueueNotifier
           )
           .toList(growable: false);
       await _putJobsAtomically(referenced);
+      if (ref.read(cloudMediaAccountIdProvider) != accountId) return;
       final referencedIds = referenced.map((job) => job.jobId).toSet();
       for (final orphan in entry.value) {
         if (!referencedIds.contains(orphan.jobId) &&
-            _restoredStagedJobIds.contains(orphan.jobId)) {
-          await _deleteJob(orphan.jobId);
+            _restoredStagedJobIds.contains(
+              durableCloudMediaOutboxStorageKey(orphan),
+            )) {
+          await _deleteJob(orphan);
           _logMedia(
             'reference_reconcile.removed_orphan job=${orphan.jobId} '
             'strategy=${orphan.strategyPublicId}',
@@ -902,7 +984,7 @@ class CloudMediaUploadQueueNotifier
   }
 
   Future<void> _upsertJob(CloudMediaUploadJob nextJob) async {
-    await _putJob(nextJob.jobId, _mergeJob(nextJob));
+    await _putJob(_mergeJob(nextJob));
     _refreshState();
   }
 
@@ -918,7 +1000,8 @@ class CloudMediaUploadQueueNotifier
   }
 
   CloudMediaUploadJob _mergeJob(CloudMediaUploadJob nextJob) {
-    final existing = _getJob(nextJob.jobId);
+    final existing =
+        _jobsByStorageKey[durableCloudMediaOutboxStorageKey(nextJob)];
     if (existing == null) return nextJob;
     if (existing.isFailed) {
       return existing.copyWith(
@@ -956,17 +1039,43 @@ class CloudMediaUploadQueueNotifier
   }
 
   List<CloudMediaUploadJob> _readJobs() {
-    return _jobsById.values.toList(growable: false);
+    final accountId = ref.read(cloudMediaAccountIdProvider);
+    if (accountId == null || accountId.isEmpty) return const [];
+    return _jobsByStorageKey.values
+        .where((job) => job.accountId == accountId)
+        .toList(growable: false);
   }
 
   CloudMediaUploadJob? _getJob(String jobId) {
-    return _jobsById[jobId];
+    final accountId = ref.read(cloudMediaAccountIdProvider);
+    final job = _jobsByStorageKey[durableCloudMediaOutboxStorageKeyFor(
+      accountId: accountId,
+      jobId: jobId,
+    )];
+    return job != null && _belongsToActiveAccount(job) ? job : null;
   }
 
-  Future<void> _putJob(String jobId, CloudMediaUploadJob job) async {
+  String _requireActiveAccountId() {
+    final accountId = ref.read(cloudMediaAccountIdProvider);
+    if (accountId == null || accountId.isEmpty) {
+      throw StateError(
+        'Cloud media cannot be queued without an authenticated account.',
+      );
+    }
+    return accountId;
+  }
+
+  bool _belongsToActiveAccount(CloudMediaUploadJob job) {
+    final accountId = ref.read(cloudMediaAccountIdProvider);
+    return accountId != null &&
+        accountId.isNotEmpty &&
+        job.accountId == accountId;
+  }
+
+  Future<void> _putJob(CloudMediaUploadJob job) async {
     try {
       await _store.put(job);
-      _jobsById[jobId] = job;
+      _jobsByStorageKey[durableCloudMediaOutboxStorageKey(job)] = job;
     } catch (error, stackTrace) {
       _recordDurabilityFailure(error, stackTrace);
       rethrow;
@@ -981,9 +1090,10 @@ class CloudMediaUploadQueueNotifier
     try {
       await _store.putAll(jobList);
       for (final job in jobList) {
-        _jobsById[job.jobId] = job;
+        final storageKey = durableCloudMediaOutboxStorageKey(job);
+        _jobsByStorageKey[storageKey] = job;
         if (job.referenceDurable) {
-          _restoredStagedJobIds.remove(job.jobId);
+          _restoredStagedJobIds.remove(storageKey);
         }
       }
     } catch (error, stackTrace) {
@@ -992,11 +1102,12 @@ class CloudMediaUploadQueueNotifier
     }
   }
 
-  Future<void> _deleteJob(String jobId) async {
+  Future<void> _deleteJob(CloudMediaUploadJob job) async {
     try {
-      await _store.remove(jobId);
-      _jobsById.remove(jobId);
-      _restoredStagedJobIds.remove(jobId);
+      await _store.remove(job);
+      final storageKey = durableCloudMediaOutboxStorageKey(job);
+      _jobsByStorageKey.remove(storageKey);
+      _restoredStagedJobIds.remove(storageKey);
     } catch (error, stackTrace) {
       _recordDurabilityFailure(error, stackTrace);
       rethrow;
@@ -1271,6 +1382,7 @@ class CloudMediaUploadQueueNotifier
       return 'job=null';
     }
     return 'job=${job.jobId} image=${job.assetPublicId} '
+        'account=${job.accountId ?? 'unknown'} '
         'strategy=${job.strategyPublicId} state=${job.state.name} '
         'attempts=${job.attempts} provider=${job.provider ?? 'none'} '
         'hasUploadId=${job.uploadId != null} '

--- a/lib/providers/collab/cloud_media_upload_queue_provider.dart
+++ b/lib/providers/collab/cloud_media_upload_queue_provider.dart
@@ -9,12 +9,14 @@ import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/collab/convex_strategy_repository.dart';
 import 'package:icarus/collab/durable_cloud_media_outbox.dart';
+import 'package:icarus/collab/durable_strategy_outbox.dart';
 import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/auth_provider.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
+import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/image_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/services/app_error_reporter.dart';
@@ -94,6 +96,14 @@ final cloudMediaUploadQueueProvider =
   CloudMediaUploadQueueNotifier.new,
 );
 
+typedef CloudMediaReferenceSnapshotLoader =
+    Future<RemoteFullStrategySnapshot> Function(String strategyPublicId);
+
+final cloudMediaReferenceSnapshotLoaderProvider =
+    Provider<CloudMediaReferenceSnapshotLoader>(
+  (ref) => ref.watch(convexStrategyRepositoryProvider).fetchFullSnapshot,
+);
+
 class CloudMediaUploadQueueNotifier
     extends Notifier<CloudMediaUploadQueueState> {
   static const Duration _blockedRetryDelay = Duration(seconds: 30);
@@ -107,6 +117,7 @@ class CloudMediaUploadQueueNotifier
   final Set<String> _uploadCompletingJobs = {};
   final Set<String> _uploadCompletedJobs = {};
   final Map<String, CloudMediaUploadJob> _jobsById = {};
+  final Set<String> _restoredStagedJobIds = {};
   late DurableCloudMediaOutboxStore _store;
 
   ConvexStrategyRepository get _repo =>
@@ -118,6 +129,11 @@ class CloudMediaUploadQueueNotifier
     final loaded = _store.load();
     _jobsById.addEntries(
       loaded.jobs.map((job) => MapEntry(job.jobId, job)),
+    );
+    _restoredStagedJobIds.addAll(
+      loaded.jobs
+          .where((job) => !job.referenceDurable)
+          .map((job) => job.jobId),
     );
     ref.onDispose(() {
       _retryTimer?.cancel();
@@ -193,14 +209,14 @@ class CloudMediaUploadQueueNotifier
         width: width,
         height: height,
         state: CloudMediaJobState.pendingUpload,
+        referenceDurable: false,
         attempts: 0,
         updatedAt: DateTime.now(),
       ),
     );
     _logMedia(
-      'enqueue.placed_image ${_describeJob(_getJob(imagePublicId))}',
+      'enqueue.placed_image_staged ${_describeJob(_getJob(imagePublicId))}',
     );
-    retryNow(ignoreBackoff: true);
   }
 
   Future<void> enqueueJobForLocalFile({
@@ -234,27 +250,112 @@ class CloudMediaUploadQueueNotifier
     required String strategyPublicId,
     required Iterable<SimpleImageData> images,
   }) async {
-    for (final image in images) {
-      final normalizedExtension = normalizeImageExtension(image.fileExtension);
-      await _upsertJob(
+    final imageList = images.toList(growable: false);
+    final jobs = <CloudMediaUploadJob>[
+      for (final image in imageList)
         CloudMediaUploadJob(
           jobId: image.id,
           strategyPublicId: strategyPublicId,
           assetPublicId: image.id,
-          fileExtension: normalizedExtension,
-          mimeType: mimeTypeForImageExtension(normalizedExtension),
+          fileExtension: normalizeImageExtension(image.fileExtension),
+          mimeType: mimeTypeForImageExtension(image.fileExtension),
           state: CloudMediaJobState.pendingUpload,
+          referenceDurable: false,
           attempts: 0,
           updatedAt: DateTime.now(),
         ),
-      );
+    ];
+    await _upsertJobsAtomically(jobs);
+    for (final image in imageList) {
       _logMedia('enqueue.lineup_image ${_describeJob(_getJob(image.id))}');
     }
-    retryNow(ignoreBackoff: true);
+  }
+
+  Future<void> commitStagedMediaReferences({
+    required String strategyPublicId,
+    required Iterable<String> assetPublicIds,
+  }) async {
+    final requestedIds = assetPublicIds.toSet();
+    final staged = _readJobs()
+        .where(
+          (job) =>
+              job.strategyPublicId == strategyPublicId &&
+              requestedIds.contains(job.assetPublicId) &&
+              !job.referenceDurable,
+        )
+        .toList(growable: false);
+    if (staged.isEmpty) return;
+
+    await ref
+        .read(strategyProvider.notifier)
+        .notifyCloudMutation(flushImmediately: false);
+    final opQueueState = ref.read(strategyOpQueueProvider);
+    if (!opQueueState.outboxIsReliable) {
+      throw StateError(
+        'The strategy reference could not be saved to the durable outbox.',
+      );
+    }
+    final durableOps = ref.read(durableStrategyOutboxStoreProvider).load();
+    if (durableOps.issues.isNotEmpty) {
+      throw StateError(
+        'The strategy reference outbox contains unreadable saved work.',
+      );
+    }
+    final pendingOps = <StrategyOp>[
+      for (final record in durableOps.records)
+        if (record.strategyPublicId == strategyPublicId) ...[
+          record.pending.op,
+          if (record.successorPending case final successor?) successor.op,
+        ],
+    ];
+    final missingReferences = staged
+        .where(
+          (job) => !pendingOps.any(
+            (op) => _opReferencesAsset(op, job.assetPublicId),
+          ),
+        )
+        .toList(growable: false);
+    if (missingReferences.isNotEmpty) {
+      RemoteFullStrategySnapshot? serverSnapshot;
+      if (ref.read(authProvider).isConvexUserReady &&
+          ref.read(convexConnectionSnapshotProvider)) {
+        try {
+          serverSnapshot = await ref
+              .read(cloudMediaReferenceSnapshotLoaderProvider)(
+            strategyPublicId,
+          );
+        } catch (_) {
+          serverSnapshot = null;
+        }
+      }
+      if (serverSnapshot == null ||
+          missingReferences.any(
+            (job) =>
+                !_snapshotReferencesAsset(serverSnapshot!, job.assetPublicId),
+          )) {
+        _scheduleRetryForNextEligibleJob(
+          minimumDelay: _blockedRetryDelay,
+        );
+        throw StateError(
+          'The strategy reference was not admitted to the durable outbox.',
+        );
+      }
+    }
+
+    await _putJobsAtomically([
+      for (final job in staged)
+        job.copyWith(
+          referenceDurable: true,
+          updatedAt: DateTime.now(),
+        ),
+    ]);
+    _refreshState();
+    await retryNow(ignoreBackoff: true);
   }
 
   Future<void> retryNow({bool ignoreBackoff = false}) async {
     _retryTimer?.cancel();
+    await _reconcileStagedJobReferences();
     _logMedia(
       'retry_now ignoreBackoff=$ignoreBackoff jobs=${_readJobs().length}',
     );
@@ -349,6 +450,9 @@ class CloudMediaUploadQueueNotifier
       ..sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
     final now = DateTime.now();
     for (final job in jobs) {
+      if (!job.referenceDurable) {
+        continue;
+      }
       if (ignoreBackoff || !_nextAttemptAt(job).isAfter(now)) {
         return job;
       }
@@ -616,8 +720,17 @@ class CloudMediaUploadQueueNotifier
 
   void _scheduleRetryForNextEligibleJob({Duration? minimumDelay}) {
     _retryTimer?.cancel();
-    final jobs = _readJobs();
+    final allJobs = _readJobs();
+    final jobs = allJobs
+        .where((job) => job.referenceDurable)
+        .toList(growable: false);
     if (jobs.isEmpty) {
+      if (allJobs.any((job) => !job.referenceDurable)) {
+        _retryTimer = Timer(
+          minimumDelay ?? _blockedRetryDelay,
+          () => unawaited(retryNow()),
+        );
+      }
       return;
     }
 
@@ -641,49 +754,205 @@ class CloudMediaUploadQueueNotifier
     }
     _logMedia(
         'retry.scheduled delayMs=${delay.inMilliseconds} jobs=${jobs.length}');
-    _retryTimer = Timer(delay, () {
-      unawaited(_processNextJob(ignoreBackoff: false));
-    });
+    _retryTimer = Timer(delay, () => unawaited(retryNow()));
+  }
+
+  Future<void> _reconcileStagedJobReferences() async {
+    final staged = _readJobs()
+        .where((job) => !job.referenceDurable)
+        .toList(growable: false);
+    if (staged.isEmpty) return;
+
+    final durableOps = ref.read(durableStrategyOutboxStoreProvider).load();
+    final pendingOps = <({String strategyPublicId, StrategyOp op})>[
+      for (final record in durableOps.records) ...[
+        (strategyPublicId: record.strategyPublicId, op: record.pending.op),
+        if (record.successorPending case final successor?)
+          (strategyPublicId: record.strategyPublicId, op: successor.op),
+      ],
+    ];
+    final readyFromDurableOps = staged
+        .where(
+          (job) => pendingOps.any(
+            (pending) =>
+                pending.strategyPublicId == job.strategyPublicId &&
+                _opReferencesAsset(pending.op, job.assetPublicId),
+          ),
+        )
+        .map(
+          (job) => job.copyWith(
+            referenceDurable: true,
+            updatedAt: DateTime.now(),
+          ),
+        )
+        .toList(growable: false);
+    if (readyFromDurableOps.isNotEmpty) {
+      await _putJobsAtomically(readyFromDurableOps);
+      _refreshState();
+    }
+
+    if (durableOps.issues.isNotEmpty) return;
+    final unresolved = _readJobs()
+        .where((job) => !job.referenceDurable)
+        .toList(growable: false);
+    if (unresolved.isEmpty ||
+        !ref.read(authProvider).isConvexUserReady ||
+        !ref.read(convexConnectionSnapshotProvider)) {
+      return;
+    }
+
+    final byStrategy = <String, List<CloudMediaUploadJob>>{};
+    for (final job in unresolved) {
+      (byStrategy[job.strategyPublicId] ??= []).add(job);
+    }
+    for (final entry in byStrategy.entries) {
+      late final RemoteFullStrategySnapshot snapshot;
+      try {
+        snapshot = await ref
+            .read(cloudMediaReferenceSnapshotLoaderProvider)(entry.key);
+      } catch (error) {
+        _logMedia(
+          'reference_reconcile.deferred strategy=${entry.key} error=$error',
+        );
+        continue;
+      }
+
+      final referenced = entry.value
+          .where(
+            (job) => _snapshotReferencesAsset(snapshot, job.assetPublicId),
+          )
+          .map(
+            (job) => job.copyWith(
+              referenceDurable: true,
+              updatedAt: DateTime.now(),
+            ),
+          )
+          .toList(growable: false);
+      await _putJobsAtomically(referenced);
+      final referencedIds = referenced.map((job) => job.jobId).toSet();
+      for (final orphan in entry.value) {
+        if (!referencedIds.contains(orphan.jobId) &&
+            _restoredStagedJobIds.contains(orphan.jobId)) {
+          await _deleteJob(orphan.jobId);
+          _logMedia(
+            'reference_reconcile.removed_orphan job=${orphan.jobId} '
+            'strategy=${orphan.strategyPublicId}',
+          );
+        }
+      }
+      _refreshState();
+    }
+  }
+
+  bool _snapshotReferencesAsset(
+    RemoteFullStrategySnapshot snapshot,
+    String assetPublicId,
+  ) {
+    for (final elements in snapshot.elementsByPage.values) {
+      if (elements.any(
+        (element) =>
+            !element.deleted &&
+            element.elementType == 'image' &&
+            element.publicId == assetPublicId,
+      )) {
+        return true;
+      }
+    }
+    for (final lineups in snapshot.lineupsByPage.values) {
+      if (lineups.any(
+        (lineup) =>
+            !lineup.deleted &&
+            _jsonContainsAssetId(lineup.payload, assetPublicId),
+      )) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _opReferencesAsset(StrategyOp op, String assetPublicId) {
+    if (op is ElementAddOp) {
+      return op.elementPublicId == assetPublicId;
+    }
+    if (op is ElementPatchOp) {
+      return op.elementPublicId == assetPublicId;
+    }
+    if (op is LineupAddOp) {
+      return _jsonContainsAssetId(op.payload, assetPublicId);
+    }
+    if (op is LineupPatchOp) {
+      return _jsonContainsAssetId(op.payload, assetPublicId);
+    }
+    return false;
+  }
+
+  bool _jsonContainsAssetId(Object? value, String assetPublicId) {
+    if (value is Map) {
+      if (value['id'] == assetPublicId) return true;
+      return value.values.any(
+        (child) => _jsonContainsAssetId(child, assetPublicId),
+      );
+    }
+    if (value is Iterable) {
+      return value.any(
+        (child) => _jsonContainsAssetId(child, assetPublicId),
+      );
+    }
+    return false;
   }
 
   Future<void> _upsertJob(CloudMediaUploadJob nextJob) async {
-    final existing = _getJob(nextJob.jobId);
-    if (existing != null) {
-      final merged = existing.isFailed
-          ? existing.copyWith(
-              strategyPublicId: nextJob.strategyPublicId,
-              assetPublicId: nextJob.assetPublicId,
-              fileExtension: nextJob.fileExtension,
-              mimeType: nextJob.mimeType,
-              width: nextJob.width,
-              height: nextJob.height,
-              byteSize: nextJob.byteSize,
-              state: CloudMediaJobState.pendingUpload,
-              attempts: 0,
-              provider: null,
-              uploadId: null,
-              objectKey: null,
-              storageId: null,
-              etag: null,
-              uploadUrlExpiresAt: null,
-              lastError: null,
-              updatedAt: DateTime.now(),
-            )
-          : existing.copyWith(
-              strategyPublicId: nextJob.strategyPublicId,
-              assetPublicId: nextJob.assetPublicId,
-              fileExtension: nextJob.fileExtension,
-              mimeType: nextJob.mimeType,
-              width: nextJob.width,
-              height: nextJob.height,
-              byteSize: nextJob.byteSize,
-              updatedAt: DateTime.now(),
-            );
-      await _putJob(nextJob.jobId, merged);
-    } else {
-      await _putJob(nextJob.jobId, nextJob);
-    }
+    await _putJob(nextJob.jobId, _mergeJob(nextJob));
     _refreshState();
+  }
+
+  Future<void> _upsertJobsAtomically(
+    Iterable<CloudMediaUploadJob> nextJobs,
+  ) async {
+    final mergedById = <String, CloudMediaUploadJob>{};
+    for (final nextJob in nextJobs) {
+      mergedById[nextJob.jobId] = _mergeJob(nextJob);
+    }
+    await _putJobsAtomically(mergedById.values);
+    _refreshState();
+  }
+
+  CloudMediaUploadJob _mergeJob(CloudMediaUploadJob nextJob) {
+    final existing = _getJob(nextJob.jobId);
+    if (existing == null) return nextJob;
+    if (existing.isFailed) {
+      return existing.copyWith(
+        strategyPublicId: nextJob.strategyPublicId,
+        assetPublicId: nextJob.assetPublicId,
+        fileExtension: nextJob.fileExtension,
+        mimeType: nextJob.mimeType,
+        width: nextJob.width,
+        height: nextJob.height,
+        byteSize: nextJob.byteSize,
+        state: nextJob.state,
+        referenceDurable: nextJob.referenceDurable,
+        attempts: 0,
+        provider: null,
+        uploadId: null,
+        objectKey: null,
+        storageId: null,
+        etag: null,
+        uploadUrlExpiresAt: null,
+        lastError: null,
+        updatedAt: DateTime.now(),
+      );
+    }
+    return existing.copyWith(
+      strategyPublicId: nextJob.strategyPublicId,
+      assetPublicId: nextJob.assetPublicId,
+      fileExtension: nextJob.fileExtension,
+      mimeType: nextJob.mimeType,
+      width: nextJob.width,
+      height: nextJob.height,
+      byteSize: nextJob.byteSize,
+      referenceDurable: existing.referenceDurable || nextJob.referenceDurable,
+      updatedAt: DateTime.now(),
+    );
   }
 
   List<CloudMediaUploadJob> _readJobs() {
@@ -704,10 +973,30 @@ class CloudMediaUploadQueueNotifier
     }
   }
 
+  Future<void> _putJobsAtomically(
+    Iterable<CloudMediaUploadJob> jobs,
+  ) async {
+    final jobList = jobs.toList(growable: false);
+    if (jobList.isEmpty) return;
+    try {
+      await _store.putAll(jobList);
+      for (final job in jobList) {
+        _jobsById[job.jobId] = job;
+        if (job.referenceDurable) {
+          _restoredStagedJobIds.remove(job.jobId);
+        }
+      }
+    } catch (error, stackTrace) {
+      _recordDurabilityFailure(error, stackTrace);
+      rethrow;
+    }
+  }
+
   Future<void> _deleteJob(String jobId) async {
     try {
       await _store.remove(jobId);
       _jobsById.remove(jobId);
+      _restoredStagedJobIds.remove(jobId);
     } catch (error, stackTrace) {
       _recordDurabilityFailure(error, stackTrace);
       rethrow;
@@ -737,7 +1026,10 @@ class CloudMediaUploadQueueNotifier
 
   void _syncUploadProgressToast() {
     final activeUploadCount = state.jobs
-        .where((job) => job.state != CloudMediaJobState.failed)
+        .where(
+          (job) =>
+              job.state != CloudMediaJobState.failed && job.referenceDurable,
+        )
         .length;
 
     if (activeUploadCount > 0) {
@@ -812,7 +1104,10 @@ class CloudMediaUploadQueueNotifier
   double _currentUploadProgress(int totalJobs) {
     var progressUnits = _uploadCompletedJobs.length.toDouble();
     final activeJobIds = state.jobs
-        .where((job) => job.state != CloudMediaJobState.failed)
+        .where(
+          (job) =>
+              job.state != CloudMediaJobState.failed && job.referenceDurable,
+        )
         .map((job) => job.jobId);
 
     for (final jobId in activeJobIds) {
@@ -949,7 +1244,10 @@ class CloudMediaUploadQueueNotifier
 
   void _publishUploadProgressToast() {
     final activeUploadCount = state.jobs
-        .where((job) => job.state != CloudMediaJobState.failed)
+        .where(
+          (job) =>
+              job.state != CloudMediaJobState.failed && job.referenceDurable,
+        )
         .length;
     if (activeUploadCount <= 0) {
       return;

--- a/lib/providers/collab/cloud_sync_status_provider.dart
+++ b/lib/providers/collab/cloud_sync_status_provider.dart
@@ -3,7 +3,9 @@ import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/strategy_save_state_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/providers/text_draft_provider.dart';
+import 'package:icarus/strategy/strategy_page_models.dart';
 
 enum CloudSyncStatus { synced, editing, syncing, offline, attention }
 
@@ -11,6 +13,12 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   final saveState = ref.watch(strategySaveStateProvider);
   final opQueueState = ref.watch(strategyOpQueueProvider);
   final mediaQueueState = ref.watch(cloudMediaUploadQueueProvider);
+  final strategy = ref.watch(strategyProvider);
+  final activeMediaJobs = mediaQueueState.jobsForStrategy(
+    strategy.source == StrategySource.cloud ? strategy.strategyId : null,
+  );
+  final activeMediaErrorCount =
+      activeMediaJobs.where((job) => job.isFailed).length;
   final hasTextDrafts = ref.watch(
     textDraftProvider.select((drafts) => drafts.isNotEmpty),
   );
@@ -23,7 +31,9 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   if (hasDurabilityProblem) {
     return CloudSyncStatus.attention;
   }
-  if (opQueueState.needsAttention || saveState.mediaSyncErrorCount > 0) {
+  if (opQueueState.needsAttention ||
+      saveState.mediaSyncErrorCount > 0 ||
+      activeMediaErrorCount > 0) {
     return CloudSyncStatus.attention;
   }
   if (!isConnected) {
@@ -38,6 +48,7 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   if (saveState.isSaving ||
       saveState.hasPendingCloudSync ||
       saveState.hasPendingMediaSync ||
+      activeMediaJobs.isNotEmpty ||
       !opQueueState.durableLoaded ||
       !mediaQueueState.durableLoaded) {
     return CloudSyncStatus.syncing;

--- a/lib/providers/collab/cloud_sync_status_provider.dart
+++ b/lib/providers/collab/cloud_sync_status_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/convex_connection_provider.dart';
+import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
+import 'package:icarus/providers/strategy_save_state_provider.dart';
+import 'package:icarus/providers/text_draft_provider.dart';
+
+enum CloudSyncStatus { synced, editing, syncing, offline, attention }
+
+final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
+  final saveState = ref.watch(strategySaveStateProvider);
+  final opQueueState = ref.watch(strategyOpQueueProvider);
+  final mediaQueueState = ref.watch(cloudMediaUploadQueueProvider);
+  final hasTextDrafts = ref.watch(
+    textDraftProvider.select((drafts) => drafts.isNotEmpty),
+  );
+  final isConnected = ref.watch(convexConnectionProvider).valueOrNull ?? true;
+
+  final hasDurabilityProblem = opQueueState.loadIssues.isNotEmpty ||
+      opQueueState.hasDurabilityFailure ||
+      mediaQueueState.loadIssues.isNotEmpty ||
+      mediaQueueState.durabilityError != null;
+  if (hasDurabilityProblem) {
+    return CloudSyncStatus.attention;
+  }
+  if (!isConnected) {
+    return CloudSyncStatus.offline;
+  }
+  if (opQueueState.needsAttention ||
+      saveState.cloudSyncError != null ||
+      saveState.mediaSyncErrorCount > 0) {
+    return CloudSyncStatus.attention;
+  }
+  if (hasTextDrafts) {
+    return CloudSyncStatus.editing;
+  }
+  if (saveState.isSaving ||
+      saveState.hasPendingCloudSync ||
+      saveState.hasPendingMediaSync ||
+      !opQueueState.durableLoaded ||
+      !mediaQueueState.durableLoaded) {
+    return CloudSyncStatus.syncing;
+  }
+  return CloudSyncStatus.synced;
+});

--- a/lib/providers/collab/cloud_sync_status_provider.dart
+++ b/lib/providers/collab/cloud_sync_status_provider.dart
@@ -23,12 +23,13 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   if (hasDurabilityProblem) {
     return CloudSyncStatus.attention;
   }
+  if (opQueueState.needsAttention || saveState.mediaSyncErrorCount > 0) {
+    return CloudSyncStatus.attention;
+  }
   if (!isConnected) {
     return CloudSyncStatus.offline;
   }
-  if (opQueueState.needsAttention ||
-      saveState.cloudSyncError != null ||
-      saveState.mediaSyncErrorCount > 0) {
+  if (saveState.cloudSyncError != null) {
     return CloudSyncStatus.attention;
   }
   if (hasTextDrafts) {

--- a/lib/providers/collab/cloud_sync_status_provider.dart
+++ b/lib/providers/collab/cloud_sync_status_provider.dart
@@ -17,6 +17,9 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   final activeMediaJobs = mediaQueueState.jobsForStrategy(
     strategy.source == StrategySource.cloud ? strategy.strategyId : null,
   );
+  final unknownOwnerMediaJobs = mediaQueueState.unknownOwnerJobsForStrategy(
+    strategy.source == StrategySource.cloud ? strategy.strategyId : null,
+  );
   final activeMediaErrorCount =
       activeMediaJobs.where((job) => job.isFailed).length;
   final hasTextDrafts = ref.watch(
@@ -33,7 +36,8 @@ final cloudSyncStatusProvider = Provider<CloudSyncStatus>((ref) {
   }
   if (opQueueState.needsAttention ||
       saveState.mediaSyncErrorCount > 0 ||
-      activeMediaErrorCount > 0) {
+      activeMediaErrorCount > 0 ||
+      unknownOwnerMediaJobs.isNotEmpty) {
     return CloudSyncStatus.attention;
   }
   if (!isConnected) {

--- a/lib/providers/collab/strategy_op_queue_provider.dart
+++ b/lib/providers/collab/strategy_op_queue_provider.dart
@@ -25,6 +25,7 @@ class StrategyOpQueueState {
     this.attentionByEntityKey = const <EntitySyncKey, QueuedEntityIntent>{},
     this.loadIssues = const <DurableOutboxLoadIssue>[],
     this.durableLoaded = false,
+    this.hasDurabilityFailure = false,
     this.isFlushing = false,
     this.lastError,
     this.lastFlushAt,
@@ -42,6 +43,7 @@ class StrategyOpQueueState {
   final Map<EntitySyncKey, QueuedEntityIntent> attentionByEntityKey;
   final List<DurableOutboxLoadIssue> loadIssues;
   final bool durableLoaded;
+  final bool hasDurabilityFailure;
   final bool isFlushing;
   final String? lastError;
   final DateTime? lastFlushAt;
@@ -52,6 +54,9 @@ class StrategyOpQueueState {
       loadIssues.isNotEmpty ||
       pausedByEntityKey.isNotEmpty ||
       attentionByEntityKey.isNotEmpty;
+
+  bool get outboxIsReliable =>
+      durableLoaded && loadIssues.isEmpty && !hasDurabilityFailure;
 
   List<PendingOp> get pending => <PendingOp>[
         ...queuedByEntityKey.values.map((intent) => intent.pending),
@@ -67,6 +72,7 @@ class StrategyOpQueueState {
     Map<EntitySyncKey, QueuedEntityIntent>? successorByEntityKey,
     Map<EntitySyncKey, QueuedEntityIntent>? pausedByEntityKey,
     Map<EntitySyncKey, QueuedEntityIntent>? attentionByEntityKey,
+    bool? hasDurabilityFailure,
     bool? isFlushing,
     String? lastError,
     bool clearError = false,
@@ -85,6 +91,8 @@ class StrategyOpQueueState {
       attentionByEntityKey: attentionByEntityKey ?? this.attentionByEntityKey,
       loadIssues: loadIssues,
       durableLoaded: durableLoaded,
+      hasDurabilityFailure:
+          hasDurabilityFailure ?? this.hasDurabilityFailure,
       isFlushing: isFlushing ?? this.isFlushing,
       lastError: clearError ? null : (lastError ?? this.lastError),
       lastFlushAt: lastFlushAt ?? this.lastFlushAt,
@@ -132,6 +140,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
       clientId: const Uuid().v4(),
       loadIssues: loaded.issues,
       durableLoaded: true,
+      hasDurabilityFailure: loaded.issues.isNotEmpty,
       lastError: loaded.issues.isEmpty
           ? null
           : 'The cloud outbox contains unreadable saved work.',
@@ -194,6 +203,8 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
       attentionByEntityKey: attention,
       loadIssues: state.loadIssues,
       durableLoaded: true,
+      hasDurabilityFailure:
+          state.hasDurabilityFailure || state.loadIssues.isNotEmpty,
       lastError: _loadedAttentionMessage(
         loadIssues: state.loadIssues,
         paused: paused,
@@ -303,6 +314,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
         state = state.copyWith(
           lastError:
               'Cloud work could not be queued without an active account.',
+          hasDurabilityFailure: true,
         );
       }
       return;
@@ -940,6 +952,7 @@ class StrategyOpQueueNotifier extends Notifier<StrategyOpQueueState> {
     state = state.copyWith(
       isFlushing: false,
       lastError: 'Cloud work could not be saved to the durable outbox: $error',
+      hasDurabilityFailure: true,
     );
   }
 

--- a/lib/providers/image_provider.dart
+++ b/lib/providers/image_provider.dart
@@ -169,6 +169,23 @@ class PlacedImageProvider extends Notifier<ImageState> {
       tagColorValue: tagColorValue,
     );
 
+    if (strategySource == StrategySource.cloud && strategyId != null) {
+      AppErrorReporter.reportInfo(
+        'Image enqueueing cloud upload: image=${placedImage.id} '
+        'strategy=$strategyId extension=$fileExtension',
+        source: 'cloud_media.image_provider',
+      );
+      await ref
+          .read(cloudMediaUploadQueueProvider.notifier)
+          .enqueuePlacedImageUpload(
+            strategyPublicId: strategyId,
+            imagePublicId: placedImage.id,
+            fileExtension: fileExtension,
+            width: null,
+            height: null,
+          );
+    }
+
     final action = UserAction(
       type: ActionType.addition,
       id: placedImage.id,
@@ -187,22 +204,6 @@ class PlacedImageProvider extends Notifier<ImageState> {
       source: 'cloud_media.image_provider',
     );
 
-    if (strategySource == StrategySource.cloud && strategyId != null) {
-      AppErrorReporter.reportInfo(
-        'Image enqueueing cloud upload: image=${placedImage.id} '
-        'strategy=$strategyId extension=$fileExtension',
-        source: 'cloud_media.image_provider',
-      );
-      await ref
-          .read(cloudMediaUploadQueueProvider.notifier)
-          .enqueuePlacedImageUpload(
-            strategyPublicId: strategyId,
-            imagePublicId: placedImage.id,
-            fileExtension: fileExtension,
-            width: null,
-            height: null,
-          );
-    }
   }
 
   void removeImageAsAction(String id) {

--- a/lib/providers/image_provider.dart
+++ b/lib/providers/image_provider.dart
@@ -204,6 +204,14 @@ class PlacedImageProvider extends Notifier<ImageState> {
       source: 'cloud_media.image_provider',
     );
 
+    if (strategySource == StrategySource.cloud && strategyId != null) {
+      await ref
+          .read(cloudMediaUploadQueueProvider.notifier)
+          .commitStagedMediaReferences(
+        strategyPublicId: strategyId,
+        assetPublicIds: [placedImage.id],
+      );
+    }
   }
 
   void removeImageAsAction(String id) {

--- a/lib/providers/strategy_save_state_provider.dart
+++ b/lib/providers/strategy_save_state_provider.dart
@@ -94,8 +94,10 @@ class StrategySaveStateNotifier extends Notifier<StrategySaveState> {
         return;
       }
 
-      final failedJobs = next.jobs.where((job) => job.isFailed).length;
-      final hasPendingMedia = next.jobs.isNotEmpty;
+      final strategyId = ref.read(strategyProvider).strategyId;
+      final strategyJobs = next.jobsForStrategy(strategyId);
+      final failedJobs = strategyJobs.where((job) => job.isFailed).length;
+      final hasPendingMedia = strategyJobs.isNotEmpty;
       final hasPendingCloudSync = state.hasPendingCloudSync || hasPendingMedia;
       state = state.copyWith(
         hasPendingMediaSync: hasPendingMedia,

--- a/lib/services/unsaved_strategy_guard.dart
+++ b/lib/services/unsaved_strategy_guard.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/collab/cloud_sync_error_message.dart';
-import 'package:icarus/collab/convex_client.dart';
 import 'package:icarus/providers/auth_provider.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/strategy_save_state_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
@@ -20,7 +20,7 @@ enum UnsavedStrategyDecision {
 
 enum CloudExitDecision {
   stay,
-  cancelUpload,
+  leaveAnyway,
   retrySync,
   retryAuth,
 }
@@ -69,7 +69,7 @@ Future<UnsavedStrategyDecision> showUnsavedStrategyDialog(
 Future<CloudExitDecision> _showCloudSyncBlockedDialog(
   BuildContext context, {
   required String message,
-  required bool showCancelUpload,
+  required bool allowLeaveAnyway,
   required bool showRetryAuth,
 }) async {
   final result = await showShadDialog<CloudExitDecision>(
@@ -77,6 +77,7 @@ Future<CloudExitDecision> _showCloudSyncBlockedDialog(
     builder: (context) {
       return ShadDialog.alert(
         title: const Text('Cloud sync pending'),
+        actionsAxis: Axis.vertical,
         description: Padding(
           padding: const EdgeInsets.all(8),
           child: Text(message),
@@ -95,12 +96,12 @@ Future<CloudExitDecision> _showCloudSyncBlockedDialog(
               },
               child: const Text('Retry Convex Auth'),
             ),
-          if (showCancelUpload)
-            ShadButton.destructive(
+          if (allowLeaveAnyway)
+            ShadButton.secondary(
               onPressed: () {
-                Navigator.of(context).pop(CloudExitDecision.cancelUpload);
+                Navigator.of(context).pop(CloudExitDecision.leaveAnyway);
               },
-              child: const Text('Cancel Upload'),
+              child: const Text('Leave Anyway'),
             ),
           ShadButton(
             onPressed: () {
@@ -123,12 +124,17 @@ Future<bool> _waitForCloudSync(
 }) async {
   final deadline = DateTime.now().add(timeout);
   while (DateTime.now().isBefore(deadline)) {
+    final strategyId = ref.read(strategyProvider).strategyId;
     final saveState = ref.read(strategySaveStateProvider);
     final queueState = ref.read(strategyOpQueueProvider);
+    final mediaQueueState = ref.read(cloudMediaUploadQueueProvider);
+    final mediaJobs = mediaQueueState.jobsForStrategy(strategyId);
     if (!saveState.hasPendingCloudSync &&
         !saveState.hasPendingMediaSync &&
+        mediaJobs.isEmpty &&
         queueState.pending.isEmpty &&
         !queueState.isFlushing &&
+        !mediaQueueState.isProcessing &&
         saveState.cloudSyncError == null &&
         saveState.mediaSyncErrorCount == 0) {
       return true;
@@ -144,8 +150,10 @@ Future<bool> _guardCloudStrategyExit({
   required Future<void> Function() onContinue,
 }) async {
   final openingStrategy = ref.read(strategyProvider);
-  if (ref.read(textDraftProvider).isNotEmpty &&
+  final openingSaveState = ref.read(strategySaveStateProvider);
+  if ((ref.read(textDraftProvider).isNotEmpty || openingSaveState.isDirty) &&
       openingStrategy.strategyId != null) {
+    ref.read(textDraftProvider.notifier).commitAllDrafts();
     try {
       await ref
           .read(strategyProvider.notifier)
@@ -167,14 +175,23 @@ Future<bool> _guardCloudStrategyExit({
     final queueState = ref.read(strategyOpQueueProvider);
     final authState = ref.read(authProvider);
     final mediaQueueState = ref.read(cloudMediaUploadQueueProvider);
-    final hasPendingMediaJobs =
-        mediaQueueState.jobsForStrategy(strategyState.strategyId).isNotEmpty;
+    final mediaJobs = mediaQueueState.jobsForStrategy(strategyState.strategyId);
+    final hasPendingMediaJobs = mediaJobs.isNotEmpty;
 
     final hasPendingSync = saveState.hasPendingCloudSync ||
         saveState.hasPendingMediaSync ||
         hasPendingMediaJobs ||
         queueState.pending.isNotEmpty;
     final cloudError = saveState.cloudSyncError ?? queueState.lastError;
+    final hasDurablePendingWork =
+        queueState.pending.isNotEmpty || hasPendingMediaJobs;
+    final hasUnstagedWork = ref.read(textDraftProvider).isNotEmpty ||
+        (saveState.isDirty && !hasDurablePendingWork);
+    final canLeaveWithDurableWork = hasDurablePendingWork &&
+        !hasUnstagedWork &&
+        queueState.outboxIsReliable &&
+        mediaQueueState.outboxIsReliable;
+    final isConnected = ref.read(convexConnectionSnapshotProvider);
     AppErrorReporter.reportInfo(
       'Cloud exit guard check: strategy=${strategyState.strategyId} '
       'dirty=${saveState.isDirty} saving=${saveState.isSaving} '
@@ -188,7 +205,9 @@ Future<bool> _guardCloudStrategyExit({
       'auth=${authState.isAuthenticated} '
       'userReady=${authState.isConvexUserReady} '
       'authIncident=${authState.hasActiveAuthIncident} '
-      'connected=${ConvexClient.instance.isConnected} '
+      'connected=$isConnected '
+      'durablePending=$hasDurablePendingWork '
+      'canLeaveWithDurableWork=$canLeaveWithDurableWork '
       'cloudError=${cloudError ?? 'none'}',
       source: 'cloud_media.exit_guard',
     );
@@ -204,7 +223,8 @@ Future<bool> _guardCloudStrategyExit({
       return true;
     }
 
-    if (queueState.isFlushing && cloudError == null) {
+    if ((queueState.isFlushing || mediaQueueState.isProcessing) &&
+        cloudError == null) {
       AppErrorReporter.reportInfo(
         'Cloud exit guard waiting for active op flush: '
         'strategy=${strategyState.strategyId}',
@@ -230,12 +250,13 @@ Future<bool> _guardCloudStrategyExit({
 
     final decision = await _showCloudSyncBlockedDialog(
       context,
-      message: cloudError != null
-          ? friendlyCloudSyncError(cloudError)
-          : (saveState.mediaSyncErrorCount > 0
-              ? 'Some media uploads failed. Retry sync or stay here until the queue clears.'
-              : 'Icarus is still syncing cloud edits and media. Stay on this screen until sync completes.'),
-      showCancelUpload: hasPendingMediaJobs,
+      message: _cloudSyncBlockedMessage(
+        isConnected: isConnected,
+        cloudError: cloudError,
+        mediaErrorCount: saveState.mediaSyncErrorCount,
+        canLeaveWithDurableWork: canLeaveWithDurableWork,
+      ),
+      allowLeaveAnyway: canLeaveWithDurableWork,
       showRetryAuth: authState.hasActiveAuthIncident,
     );
 
@@ -255,20 +276,16 @@ Future<bool> _guardCloudStrategyExit({
             .read(authProvider.notifier)
             .reinitializeConvexAuth(source: 'cloud_exit_guard');
         break;
-      case CloudExitDecision.cancelUpload:
+      case CloudExitDecision.leaveAnyway:
         AppErrorReporter.reportInfo(
-          'Cloud exit guard canceling media uploads.',
+          'Cloud exit guard leaving with work pending in durable outboxes.',
           source: 'cloud_media.exit_guard',
         );
-        final strategyId = strategyState.strategyId;
-        if (strategyId == null) {
+        if (!canLeaveWithDurableWork || !context.mounted) {
           return false;
         }
-        await ref
-            .read(cloudMediaUploadQueueProvider.notifier)
-            .cancelUploadsForStrategy(strategyId);
-        await ref.read(strategyProvider.notifier).forceSaveNow(strategyId);
-        break;
+        await onContinue();
+        return true;
       case CloudExitDecision.retrySync:
         AppErrorReporter.reportInfo(
           'Cloud exit guard retrying sync.',
@@ -282,6 +299,27 @@ Future<bool> _guardCloudStrategyExit({
         break;
     }
   }
+}
+
+String _cloudSyncBlockedMessage({
+  required bool isConnected,
+  required String? cloudError,
+  required int mediaErrorCount,
+  required bool canLeaveWithDurableWork,
+}) {
+  final base = !isConnected
+      ? 'Icarus is offline, so these changes have not reached the cloud.'
+      : (cloudError != null
+          ? friendlyCloudSyncError(cloudError)
+          : (mediaErrorCount > 0
+              ? 'Some images have not reached the cloud.'
+              : 'Icarus is still sending cloud edits and images.'));
+  if (canLeaveWithDurableWork) {
+    return '$base The pending work is saved on this device. You can leave '
+        'and Icarus will retry it later.';
+  }
+  return '$base Stay here and retry because Icarus could not confirm that '
+      'all pending work is saved on this device.';
 }
 
 Future<bool> guardUnsavedStrategyExit({

--- a/lib/services/unsaved_strategy_guard.dart
+++ b/lib/services/unsaved_strategy_guard.dart
@@ -185,7 +185,11 @@ Future<bool> _guardCloudStrategyExit({
     final cloudError = saveState.cloudSyncError ?? queueState.lastError;
     final hasDurablePendingWork =
         queueState.pending.isNotEmpty || hasPendingMediaJobs;
+    final hasUncommittedMediaReferences = mediaJobs.any(
+      (job) => !job.referenceDurable,
+    );
     final hasUnstagedWork = ref.read(textDraftProvider).isNotEmpty ||
+        hasUncommittedMediaReferences ||
         (saveState.isDirty && !hasDurablePendingWork);
     final canLeaveWithDurableWork = hasDurablePendingWork &&
         !hasUnstagedWork &&
@@ -207,6 +211,7 @@ Future<bool> _guardCloudStrategyExit({
       'authIncident=${authState.hasActiveAuthIncident} '
       'connected=$isConnected '
       'durablePending=$hasDurablePendingWork '
+      'uncommittedMediaReferences=$hasUncommittedMediaReferences '
       'canLeaveWithDurableWork=$canLeaveWithDurableWork '
       'cloudError=${cloudError ?? 'none'}',
       source: 'cloud_media.exit_guard',

--- a/lib/services/unsaved_strategy_guard.dart
+++ b/lib/services/unsaved_strategy_guard.dart
@@ -176,15 +176,26 @@ Future<bool> _guardCloudStrategyExit({
     final authState = ref.read(authProvider);
     final mediaQueueState = ref.read(cloudMediaUploadQueueProvider);
     final mediaJobs = mediaQueueState.jobsForStrategy(strategyState.strategyId);
+    final unknownOwnerMediaJobs =
+        mediaQueueState.unknownOwnerJobsForStrategy(strategyState.strategyId);
     final hasPendingMediaJobs = mediaJobs.isNotEmpty;
+    final outboxError = !queueState.outboxIsReliable
+        ? 'Icarus could not confirm that cloud edits are saved on this device.'
+        : (!mediaQueueState.outboxIsReliable
+            ? (mediaQueueState.durabilityError ??
+                'Icarus could not confirm that media work is saved on this device.')
+            : null);
 
     final hasPendingSync = saveState.hasPendingCloudSync ||
         saveState.hasPendingMediaSync ||
         hasPendingMediaJobs ||
+        unknownOwnerMediaJobs.isNotEmpty ||
         queueState.pending.isNotEmpty;
-    final cloudError = saveState.cloudSyncError ?? queueState.lastError;
-    final hasDurablePendingWork =
-        queueState.pending.isNotEmpty || hasPendingMediaJobs;
+    final cloudError =
+        saveState.cloudSyncError ?? queueState.lastError ?? outboxError;
+    final hasDurablePendingWork = queueState.pending.isNotEmpty ||
+        hasPendingMediaJobs ||
+        unknownOwnerMediaJobs.isNotEmpty;
     final hasUncommittedMediaReferences = mediaJobs.any(
       (job) => !job.referenceDurable,
     );
@@ -205,6 +216,7 @@ Future<bool> _guardCloudStrategyExit({
       'opPending=${queueState.pending.length} '
       'opFlushing=${queueState.isFlushing} '
       'mediaJobs=${mediaQueueState.jobs.length} '
+      'unknownOwnerMediaJobs=${unknownOwnerMediaJobs.length} '
       'mediaProcessing=${mediaQueueState.isProcessing} '
       'auth=${authState.isAuthenticated} '
       'userReady=${authState.isConvexUserReady} '
@@ -260,6 +272,7 @@ Future<bool> _guardCloudStrategyExit({
         cloudError: cloudError,
         mediaErrorCount: saveState.mediaSyncErrorCount,
         canLeaveWithDurableWork: canLeaveWithDurableWork,
+        hasUnknownOwnerMediaWork: unknownOwnerMediaJobs.isNotEmpty,
       ),
       allowLeaveAnyway: canLeaveWithDurableWork,
       showRetryAuth: authState.hasActiveAuthIncident,
@@ -311,15 +324,23 @@ String _cloudSyncBlockedMessage({
   required String? cloudError,
   required int mediaErrorCount,
   required bool canLeaveWithDurableWork,
+  required bool hasUnknownOwnerMediaWork,
 }) {
-  final base = !isConnected
-      ? 'Icarus is offline, so these changes have not reached the cloud.'
-      : (cloudError != null
-          ? friendlyCloudSyncError(cloudError)
-          : (mediaErrorCount > 0
-              ? 'Some images have not reached the cloud.'
-              : 'Icarus is still sending cloud edits and images.'));
+  final base = hasUnknownOwnerMediaWork
+      ? 'Icarus found pending media saved before its account ownership could '
+          'be verified. It has not reached the cloud.'
+      : !isConnected
+          ? 'Icarus is offline, so these changes have not reached the cloud.'
+          : (cloudError != null
+              ? friendlyCloudSyncError(cloudError)
+              : (mediaErrorCount > 0
+                  ? 'Some images have not reached the cloud.'
+                  : 'Icarus is still sending cloud edits and images.'));
   if (canLeaveWithDurableWork) {
+    if (hasUnknownOwnerMediaWork) {
+      return '$base The record remains saved on this device and will not be '
+          'sent automatically. You can leave without deleting it.';
+    }
     return '$base The pending work is saved on this device. You can leave '
         'and Icarus will retry it later.';
   }

--- a/lib/widgets/cloud_sync_status_chip.dart
+++ b/lib/widgets/cloud_sync_status_chip.dart
@@ -5,12 +5,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/collab/cloud_sync_error_message.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
-import 'package:icarus/providers/collab/convex_connection_provider.dart';
+import 'package:icarus/providers/collab/cloud_sync_status_provider.dart';
 import 'package:icarus/providers/collab/strategy_conflict_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/providers/strategy_save_state_provider.dart';
-import 'package:icarus/providers/text_draft_provider.dart';
 import 'package:icarus/strategy/strategy_page_models.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -105,28 +104,13 @@ class _CloudSyncStatusChipState extends ConsumerState<CloudSyncStatusChip> {
 
     final saveState = ref.watch(strategySaveStateProvider);
     final opQueueState = ref.watch(strategyOpQueueProvider);
-    final hasTextDrafts = ref.watch(
-      textDraftProvider.select((drafts) => drafts.isNotEmpty),
-    );
-    final isConnected = ref.watch(convexConnectionProvider).valueOrNull ?? true;
-
-    final _SyncStatus status;
-    if (opQueueState.needsAttention ||
-        saveState.cloudSyncError != null ||
-        saveState.mediaSyncErrorCount > 0) {
-      status = _SyncStatus.attention;
-    } else if (!isConnected) {
-      status = _SyncStatus.offline;
-    } else if (hasTextDrafts) {
-      status = _SyncStatus.editing;
-    } else if (saveState.isSaving ||
-        saveState.hasPendingCloudSync ||
-        saveState.hasPendingMediaSync ||
-        !opQueueState.durableLoaded) {
-      status = _SyncStatus.syncing;
-    } else {
-      status = _SyncStatus.synced;
-    }
+    final status = switch (ref.watch(cloudSyncStatusProvider)) {
+      CloudSyncStatus.synced => _SyncStatus.synced,
+      CloudSyncStatus.editing => _SyncStatus.editing,
+      CloudSyncStatus.syncing => _SyncStatus.syncing,
+      CloudSyncStatus.offline => _SyncStatus.offline,
+      CloudSyncStatus.attention => _SyncStatus.attention,
+    };
 
     return ShadPopover(
       controller: _popoverController,

--- a/lib/widgets/dialogs/create_lineup_dialog.dart
+++ b/lib/widgets/dialogs/create_lineup_dialog.dart
@@ -36,6 +36,7 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
   final TextEditingController _youtubeLinkController = TextEditingController();
   final TextEditingController _notesController = TextEditingController();
   final List<SimpleImageData> _imagePaths = [];
+  final Set<String> _initialImageIds = {};
 
   Future<void> _enqueueLineupMediaJobs({
     required List<SimpleImageData> images,
@@ -46,15 +47,29 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
       return;
     }
 
-    for (final image in images) {
-      await ref
-          .read(cloudMediaUploadQueueProvider.notifier)
-          .enqueueJobForLocalFile(
-            strategyPublicId: strategyState.strategyId!,
-            assetPublicId: image.id,
-            fileExtension: image.fileExtension,
-          );
+    await ref
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueueLineupMediaJobs(
+          strategyPublicId: strategyState.strategyId!,
+          images: images,
+        );
+  }
+
+  Future<void> _commitLineupMediaJobs({
+    required List<SimpleImageData> images,
+  }) async {
+    final strategyState = ref.read(strategyProvider);
+    if (strategyState.source != StrategySource.cloud ||
+        strategyState.strategyId == null ||
+        images.isEmpty) {
+      return;
     }
+    await ref
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .commitStagedMediaReferences(
+          strategyPublicId: strategyState.strategyId!,
+          assetPublicIds: images.map((image) => image.id),
+        );
   }
 
   bool get _isEditing =>
@@ -72,6 +87,7 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
         _youtubeLinkController.text = item.youtubeLink;
         _notesController.text = item.notes;
         _imagePaths.addAll(item.images);
+        _initialImageIds.addAll(item.images.map((image) => image.id));
       }
     }
   }
@@ -84,8 +100,30 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
   }
 
   Future<void> _save() async {
+    final lineUpState = ref.read(lineUpProvider);
+    final notifier = ref.read(lineUpProvider.notifier);
+    final existingItem = _isEditing
+        ? notifier.getItemById(
+            groupId: widget.lineUpGroupId!,
+            itemId: widget.lineUpItemId!,
+          )
+        : null;
+    if (_isEditing && existingItem == null) {
+      return;
+    }
+    if (!_isEditing && lineUpState.currentAbility == null) {
+      return;
+    }
+    if (!_isEditing &&
+        lineUpState.currentGroupId == null &&
+        lineUpState.currentAgent == null) {
+      return;
+    }
+    final imagesNeedingUpload = _imagePaths
+        .where((image) => !_initialImageIds.contains(image.id))
+        .toList(growable: false);
     try {
-      await _enqueueLineupMediaJobs(images: _imagePaths);
+      await _enqueueLineupMediaJobs(images: imagesNeedingUpload);
     } catch (_) {
       Settings.showToast(
         message: 'Could not queue these images for cloud sync. '
@@ -95,34 +133,22 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
       return;
     }
 
-    final lineUpState = ref.read(lineUpProvider);
-    final notifier = ref.read(lineUpProvider.notifier);
-
     if (_isEditing) {
-      final existingItem = notifier.getItemById(
-        groupId: widget.lineUpGroupId!,
-        itemId: widget.lineUpItemId!,
+      ref.read(actionProvider.notifier).performTransaction(
+        groups: const [ActionGroup.lineUp],
+        mutation: () {
+          notifier.updateItem(
+            groupId: widget.lineUpGroupId!,
+            item: existingItem!.copyWith(
+              youtubeLink: _youtubeLinkController.text,
+              notes: _notesController.text,
+              images: _imagePaths,
+            ),
+          );
+        },
       );
-      if (existingItem != null) {
-        ref.read(actionProvider.notifier).performTransaction(
-          groups: const [ActionGroup.lineUp],
-          mutation: () {
-            notifier.updateItem(
-              groupId: widget.lineUpGroupId!,
-              item: existingItem.copyWith(
-                youtubeLink: _youtubeLinkController.text,
-                notes: _notesController.text,
-                images: _imagePaths,
-              ),
-            );
-          },
-        );
-      }
     } else {
-      final currentAbility = lineUpState.currentAbility;
-      if (currentAbility == null) {
-        return;
-      }
+      final currentAbility = lineUpState.currentAbility!;
 
       final item = LineUpItem(
         id: const Uuid().v4(),
@@ -147,10 +173,7 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
           },
         );
       } else {
-        final currentAgent = lineUpState.currentAgent;
-        if (currentAgent == null) {
-          return;
-        }
+        final currentAgent = lineUpState.currentAgent!;
 
         final groupId = const Uuid().v4();
         notifier.addGroup(
@@ -175,6 +198,16 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
             'has_images': _imagePaths.isNotEmpty,
           },
         ),
+      );
+    }
+
+    try {
+      await _commitLineupMediaJobs(images: imagesNeedingUpload);
+    } catch (_) {
+      Settings.showToast(
+        message: 'The lineup is kept in the editor, but its cloud work is '
+            'still pending. Use Save before leaving.',
+        backgroundColor: Settings.tacticalVioletTheme.destructive,
       );
     }
 

--- a/lib/widgets/dialogs/create_lineup_dialog.dart
+++ b/lib/widgets/dialogs/create_lineup_dialog.dart
@@ -84,6 +84,17 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
   }
 
   Future<void> _save() async {
+    try {
+      await _enqueueLineupMediaJobs(images: _imagePaths);
+    } catch (_) {
+      Settings.showToast(
+        message: 'Could not queue these images for cloud sync. '
+            'They remain on this device. Try again before closing.',
+        backgroundColor: Settings.tacticalVioletTheme.destructive,
+      );
+      return;
+    }
+
     final lineUpState = ref.read(lineUpProvider);
     final notifier = ref.read(lineUpProvider.notifier);
 
@@ -166,8 +177,6 @@ class _CreateLineupDialogState extends ConsumerState<CreateLineupDialog> {
         ),
       );
     }
-
-    await _enqueueLineupMediaJobs(images: _imagePaths);
 
     ref
         .read(interactionStateProvider.notifier)

--- a/test/cloud_media_upload_queue_provider_test.dart
+++ b/test/cloud_media_upload_queue_provider_test.dart
@@ -1,13 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/collab/cloud_media_models.dart';
+import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/collab/durable_cloud_media_outbox.dart';
+import 'package:icarus/collab/durable_strategy_outbox.dart';
 import 'package:icarus/const/line_provider.dart';
 import 'package:icarus/providers/auth_provider.dart';
+import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
+import 'package:icarus/providers/image_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/providers/strategy_save_state_provider.dart';
 import 'package:icarus/strategy/strategy_page_models.dart';
@@ -19,6 +23,17 @@ class _SignedOutAuthProvider extends AuthProvider {
         isAuthenticated: false,
         isConvexUserReady: false,
         convexAuthStatus: ConvexAuthStatus.signedOut,
+        user: null,
+      );
+}
+
+class _CloudReadyAuthProvider extends AuthProvider {
+  @override
+  AppAuthState build() => const AppAuthState(
+        isLoading: false,
+        isAuthenticated: true,
+        isConvexUserReady: true,
+        convexAuthStatus: ConvexAuthStatus.ready,
         user: null,
       );
 }
@@ -39,6 +54,11 @@ class _ActiveCloudStrategy extends StrategyProvider {
         source: StrategySource.cloud,
         isOpen: true,
       );
+}
+
+class _NoOpenStrategy extends StrategyProvider {
+  @override
+  StrategyState build() => const StrategyState();
 }
 
 class _SettledOpQueue extends StrategyOpQueueNotifier {
@@ -63,18 +83,109 @@ class _MutableMediaQueue extends CloudMediaUploadQueueNotifier {
   }
 }
 
-ProviderContainer _container(MemoryDurableCloudMediaOutboxStore store) {
+class _FixedOpQueue extends StrategyOpQueueNotifier {
+  _FixedOpQueue(this.initialState);
+
+  final StrategyOpQueueState initialState;
+
+  @override
+  StrategyOpQueueState build() => initialState;
+}
+
+class _FailingBatchStore extends MemoryDurableCloudMediaOutboxStore {
+  bool failBatch = false;
+
+  @override
+  Future<void> putAll(Iterable<CloudMediaUploadJob> jobs) async {
+    if (failBatch) {
+      throw StateError('batch write failed');
+    }
+    await super.putAll(jobs);
+  }
+}
+
+ProviderContainer _container(
+  MemoryDurableCloudMediaOutboxStore store, {
+  MemoryDurableStrategyOutboxStore? strategyStore,
+  StrategyOpQueueState? opQueueState,
+  bool strategyOpen = true,
+  bool cloudReady = false,
+  CloudMediaReferenceSnapshotLoader? referenceSnapshotLoader,
+}) {
+  final resolvedOpQueueState = opQueueState ??
+      (strategyOpen
+          ? const StrategyOpQueueState(
+              accountId: 'account-a',
+              strategyPublicId: 'strategy-a',
+              clientId: 'client-a',
+              durableLoaded: true,
+            )
+          : const StrategyOpQueueState(durableLoaded: true));
   return ProviderContainer(
     overrides: [
       durableCloudMediaOutboxStoreProvider.overrideWithValue(store),
-      authProvider.overrideWith(_SignedOutAuthProvider.new),
+      durableStrategyOutboxStoreProvider.overrideWithValue(
+        strategyStore ?? MemoryDurableStrategyOutboxStore(),
+      ),
+      authProvider.overrideWith(
+        cloudReady ? _CloudReadyAuthProvider.new : _SignedOutAuthProvider.new,
+      ),
       cloudCollabModeProvider.overrideWith(_DisabledCloudCollabMode.new),
-      convexConnectionProvider.overrideWith((ref) => Stream.value(false)),
+      convexConnectionSnapshotProvider.overrideWithValue(cloudReady),
+      convexConnectionProvider.overrideWith(
+        (ref) => Stream.value(cloudReady),
+      ),
+      strategyProvider.overrideWith(
+        strategyOpen ? _ActiveCloudStrategy.new : _NoOpenStrategy.new,
+      ),
+      strategyOpQueueProvider.overrideWith(
+        () => _FixedOpQueue(resolvedOpQueueState),
+      ),
+      if (referenceSnapshotLoader != null)
+        cloudMediaReferenceSnapshotLoaderProvider.overrideWithValue(
+          referenceSnapshotLoader,
+        ),
     ],
   );
 }
 
+DurableOutboxRecord _durableRecord(StrategyOp op) {
+  final entityKey = EntitySyncKey.forStrategyOp(op)!;
+  return DurableOutboxRecord(
+    accountId: 'account-a',
+    strategyPublicId: 'strategy-a',
+    entityKey: entityKey,
+    pending: PendingOp(op: op, clientId: 'client-a'),
+    status: DurableOutboxStatus.queued,
+    createdAt: DateTime.utc(2026, 9, 3),
+    updatedAt: DateTime.utc(2026, 9, 3),
+  );
+}
+
+RemoteFullStrategySnapshot _fullSnapshot({
+  List<RemoteElement> elements = const [],
+  List<RemoteLineup> lineups = const [],
+}) {
+  final now = DateTime.utc(2026, 9, 3);
+  return RemoteFullStrategySnapshot(
+    header: RemoteStrategyHeader(
+      publicId: 'strategy-a',
+      name: 'Strategy A',
+      mapData: 'ascent',
+      revision: 1,
+      createdAt: now,
+      updatedAt: now,
+    ),
+    pages: const [],
+    elementsByPage: {'page-a': elements},
+    lineupsByPage: {'page-a': lineups},
+    assetsById: const {},
+  );
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('restart restores unfinished lineup media from the durable outbox',
       () async {
     final store = MemoryDurableCloudMediaOutboxStore();
@@ -99,6 +210,32 @@ void main() {
     expect(state.jobs.single.assetPublicId, 'lineup-image');
     expect(state.jobs.single.strategyPublicId, 'strategy-a');
     expect(state.jobs.single.fileExtension, '.png');
+    expect(state.jobs.single.referenceDurable, isFalse);
+  });
+
+  test('restart keeps an interrupted placement staged and non-runnable',
+      () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final first = _container(store);
+
+    await first
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueuePlacedImageUpload(
+          strategyPublicId: 'strategy-a',
+          imagePublicId: 'interrupted-image',
+          fileExtension: '.png',
+        );
+    first.dispose();
+
+    final restarted = _container(store);
+    addTearDown(restarted.dispose);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    final job = restarted.read(cloudMediaUploadQueueProvider).jobs.single;
+
+    expect(job.assetPublicId, 'interrupted-image');
+    expect(job.referenceDurable, isFalse);
+    expect(job.attempts, 0);
+    expect(restarted.read(cloudMediaUploadQueueProvider).isProcessing, isFalse);
   });
 
   test('restart restores an image job without visiting its page', () async {
@@ -114,6 +251,7 @@ void main() {
           width: 640,
           height: 360,
         );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
     first.dispose();
 
     final restarted = _container(store);
@@ -121,6 +259,7 @@ void main() {
     final restored = restarted
         .read(cloudMediaUploadQueueProvider)
         .jobsForStrategy('strategy-a');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
 
     expect(restored, hasLength(1));
     expect(restored.single.assetPublicId, 'unvisited-page-image');
@@ -148,6 +287,227 @@ void main() {
     expect(store.values, contains('offline-image'));
   });
 
+  test('lineup staging is atomic when the durable batch write fails', () async {
+    final store = _FailingBatchStore();
+    final container = _container(store);
+    addTearDown(container.dispose);
+    await container
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueueJobForLocalFile(
+          strategyPublicId: 'strategy-a',
+          assetPublicId: 'existing-image',
+          fileExtension: '.png',
+        );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    store.failBatch = true;
+
+    await expectLater(
+      container
+          .read(cloudMediaUploadQueueProvider.notifier)
+          .enqueueLineupMediaJobs(
+        strategyPublicId: 'strategy-a',
+        images: [
+          SimpleImageData(id: 'lineup-image-1', fileExtension: '.png'),
+          SimpleImageData(id: 'lineup-image-2', fileExtension: '.png'),
+        ],
+      ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(store.values.keys, ['existing-image']);
+    expect(
+      container
+          .read(cloudMediaUploadQueueProvider)
+          .jobs
+          .map((job) => job.assetPublicId),
+      ['existing-image'],
+    );
+  });
+
+  test('restart promotes a staged lineup batch without opening its strategy',
+      () async {
+    const lineupOp = LineupAddOp(
+      opId: 'lineup-op',
+      lineupPublicId: 'lineup-a',
+      pagePublicId: 'page-a',
+      payload: <String, dynamic>{
+        'images': [
+          {'id': 'lineup-image-1'},
+          {'id': 'lineup-image-2'},
+        ],
+      },
+      sortIndex: 0,
+    );
+    final mediaStore = MemoryDurableCloudMediaOutboxStore();
+    await mediaStore.putAll([
+      for (final assetId in ['lineup-image-1', 'lineup-image-2'])
+        CloudMediaUploadJob(
+          jobId: assetId,
+          strategyPublicId: 'strategy-a',
+          assetPublicId: assetId,
+          fileExtension: '.png',
+          mimeType: 'image/png',
+          state: CloudMediaJobState.pendingUpload,
+          referenceDurable: false,
+          attempts: 0,
+          updatedAt: DateTime.utc(2026, 9, 3),
+        ),
+    ]);
+    final strategyStore = MemoryDurableStrategyOutboxStore();
+    await strategyStore.put(_durableRecord(lineupOp));
+    final container = _container(
+      mediaStore,
+      strategyStore: strategyStore,
+      strategyOpen: false,
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .retryNow(ignoreBackoff: true);
+
+    expect(container.read(strategyProvider).isOpen, isFalse);
+    expect(
+      container
+          .read(cloudMediaUploadQueueProvider)
+          .jobs
+          .map((job) => job.referenceDurable),
+      everyElement(isTrue),
+    );
+  });
+
+  test('restart recovers when the strategy op was acked before promotion',
+      () async {
+    final mediaStore = MemoryDurableCloudMediaOutboxStore();
+    await mediaStore.put(
+      CloudMediaUploadJob(
+        jobId: 'acked-image',
+        strategyPublicId: 'strategy-a',
+        assetPublicId: 'acked-image',
+        fileExtension: '.png',
+        mimeType: 'image/png',
+        state: CloudMediaJobState.pendingUpload,
+        referenceDurable: false,
+        attempts: 0,
+        updatedAt: DateTime.utc(2026, 9, 3),
+      ),
+    );
+    var snapshotReads = 0;
+    final snapshot = _fullSnapshot(
+      elements: [
+        RemoteElement(
+          publicId: 'acked-image',
+          strategyPublicId: 'strategy-a',
+          pagePublicId: 'page-a',
+          elementType: 'image',
+          payload: cloudElementPayload(
+            kind: 'image',
+            data: const {'id': 'acked-image', 'elementType': 'image'},
+          ),
+          sortIndex: 0,
+          revision: 1,
+          deleted: false,
+        ),
+      ],
+    );
+    final container = _container(
+      mediaStore,
+      strategyStore: MemoryDurableStrategyOutboxStore(),
+      strategyOpen: false,
+      cloudReady: true,
+      referenceSnapshotLoader: (strategyId) async {
+        snapshotReads += 1;
+        expect(strategyId, 'strategy-a');
+        return snapshot;
+      },
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .retryNow(ignoreBackoff: true);
+
+    expect(snapshotReads, greaterThanOrEqualTo(1));
+    expect(container.read(strategyProvider).isOpen, isFalse);
+    expect(
+      container
+          .read(cloudMediaUploadQueueProvider)
+          .jobs
+          .single
+          .referenceDurable,
+      isTrue,
+    );
+  });
+
+  test('restart removes only an unreferenced staged job, not its source',
+      () async {
+    const assetId = 'orphan-image';
+    final source = await PlacedImageProvider.getImageFile(
+      strategyID: 'strategy-a',
+      imageID: assetId,
+      fileExtension: '.png',
+    );
+    await source.writeAsBytes([1, 2, 3]);
+    addTearDown(() async {
+      if (await source.exists()) await source.delete();
+    });
+    final mediaStore = MemoryDurableCloudMediaOutboxStore();
+    await mediaStore.put(
+      CloudMediaUploadJob(
+        jobId: assetId,
+        strategyPublicId: 'strategy-a',
+        assetPublicId: assetId,
+        fileExtension: '.png',
+        mimeType: 'image/png',
+        state: CloudMediaJobState.pendingUpload,
+        referenceDurable: false,
+        attempts: 0,
+        updatedAt: DateTime.utc(2026, 9, 3),
+      ),
+    );
+    final container = _container(
+      mediaStore,
+      strategyStore: MemoryDurableStrategyOutboxStore(),
+      strategyOpen: false,
+      cloudReady: true,
+      referenceSnapshotLoader: (_) async => _fullSnapshot(),
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .retryNow(ignoreBackoff: true);
+
+    expect(container.read(cloudMediaUploadQueueProvider).jobs, isEmpty);
+    expect(mediaStore.values, isEmpty);
+    expect(await source.exists(), isTrue);
+  });
+
+  test('a newly staged job is not pruned before its mutation is admitted',
+      () async {
+    final mediaStore = MemoryDurableCloudMediaOutboxStore();
+    final container = _container(
+      mediaStore,
+      strategyStore: MemoryDurableStrategyOutboxStore(),
+      cloudReady: true,
+      referenceSnapshotLoader: (_) async => _fullSnapshot(),
+    );
+    addTearDown(container.dispose);
+    final queue = container.read(cloudMediaUploadQueueProvider.notifier);
+
+    await queue.enqueuePlacedImageUpload(
+      strategyPublicId: 'strategy-a',
+      imagePublicId: 'new-image',
+      fileExtension: '.png',
+    );
+    await queue.retryNow(ignoreBackoff: true);
+
+    final job = container.read(cloudMediaUploadQueueProvider).jobs.single;
+    expect(job.assetPublicId, 'new-image');
+    expect(job.referenceDurable, isFalse);
+    expect(mediaStore.values, contains('new-image'));
+  });
+
   test('restart preserves an uploaded object that still needs attachment',
       () async {
     final store = MemoryDurableCloudMediaOutboxStore();
@@ -172,6 +532,7 @@ void main() {
     final restarted = _container(store);
     addTearDown(restarted.dispose);
     final job = restarted.read(cloudMediaUploadQueueProvider).jobs.single;
+    await Future<void>.delayed(const Duration(milliseconds: 20));
 
     expect(job.state, CloudMediaJobState.pendingAttach);
     expect(job.uploadId, 'upload-a');

--- a/test/cloud_media_upload_queue_provider_test.dart
+++ b/test/cloud_media_upload_queue_provider_test.dart
@@ -1,14 +1,19 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
 import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/collab/durable_cloud_media_outbox.dart';
 import 'package:icarus/collab/durable_strategy_outbox.dart';
 import 'package:icarus/const/line_provider.dart';
+import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/providers/auth_provider.dart';
 import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/cloud_sync_status_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/image_provider.dart';
@@ -110,6 +115,7 @@ ProviderContainer _container(
   StrategyOpQueueState? opQueueState,
   bool strategyOpen = true,
   bool cloudReady = false,
+  String? accountId = 'account-a',
   CloudMediaReferenceSnapshotLoader? referenceSnapshotLoader,
 }) {
   final resolvedOpQueueState = opQueueState ??
@@ -130,6 +136,7 @@ ProviderContainer _container(
       authProvider.overrideWith(
         cloudReady ? _CloudReadyAuthProvider.new : _SignedOutAuthProvider.new,
       ),
+      cloudMediaAccountIdProvider.overrideWithValue(accountId),
       cloudCollabModeProvider.overrideWith(_DisabledCloudCollabMode.new),
       convexConnectionSnapshotProvider.overrideWithValue(cloudReady),
       convexConnectionProvider.overrideWith(
@@ -183,8 +190,61 @@ RemoteFullStrategySnapshot _fullSnapshot({
   );
 }
 
+Map<String, Object?> _legacyJob({
+  required String jobId,
+  required String strategyPublicId,
+}) {
+  return <String, Object?>{
+    'outboxVersion': 1,
+    'jobId': jobId,
+    'strategyPublicId': strategyPublicId,
+    'assetPublicId': jobId,
+    'fileExtension': '.png',
+    'mimeType': 'image/png',
+    'state': CloudMediaJobState.pendingUpload.name,
+    'referenceDurable': false,
+    'attempts': 0,
+    'updatedAt': DateTime.utc(2026, 9, 3).toIso8601String(),
+  };
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('v1 preparation preserves unknown-owner records byte-for-byte',
+      () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'icarus-media-outbox-v1-',
+    );
+    try {
+      Hive.init(directory.path);
+      final box = await Hive.openBox<dynamic>(
+        HiveBoxNames.cloudMediaOutboxBox,
+      );
+      final legacy = _legacyJob(
+        jobId: 'legacy-image',
+        strategyPublicId: 'strategy-a',
+      );
+      await box.put(durableCloudMediaOutboxVersionKey, 1);
+      await box.put('legacy-image', legacy);
+
+      await prepareDurableCloudMediaOutbox();
+
+      expect(
+        box.get(durableCloudMediaOutboxVersionKey),
+        durableCloudMediaOutboxRecordVersion,
+      );
+      expect(box.get('legacy-image'), legacy);
+      final loaded = HiveDurableCloudMediaOutboxStore().load();
+      expect(loaded.issues, isEmpty);
+      expect(loaded.jobs.single.accountId, isNull);
+    } finally {
+      await Hive.close();
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    }
+  });
 
   test('restart restores unfinished lineup media from the durable outbox',
       () async {
@@ -211,6 +271,143 @@ void main() {
     expect(state.jobs.single.strategyPublicId, 'strategy-a');
     expect(state.jobs.single.fileExtension, '.png');
     expect(state.jobs.single.referenceDurable, isFalse);
+  });
+
+  test('account B cannot restore or reconcile account A media', () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final accountA = _container(store, accountId: 'account-a');
+    await accountA
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueuePlacedImageUpload(
+          strategyPublicId: 'strategy-a',
+          imagePublicId: 'account-a-image',
+          fileExtension: '.png',
+        );
+    accountA.dispose();
+
+    var snapshotReads = 0;
+    final accountB = _container(
+      store,
+      accountId: 'account-b',
+      cloudReady: true,
+      referenceSnapshotLoader: (_) async {
+        snapshotReads += 1;
+        return _fullSnapshot();
+      },
+    );
+    addTearDown(accountB.dispose);
+    final queue = accountB.read(cloudMediaUploadQueueProvider.notifier);
+
+    await queue.retryNow(ignoreBackoff: true);
+
+    expect(accountB.read(cloudMediaUploadQueueProvider).jobs, isEmpty);
+    expect(snapshotReads, 0);
+    final preserved = store.load().jobs.single;
+    expect(preserved.accountId, 'account-a');
+    expect(preserved.assetPublicId, 'account-a-image');
+    expect(preserved.referenceDurable, isFalse);
+  });
+
+  test('enqueue fails before writing when no account owns the job', () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final container = _container(store, accountId: null);
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(cloudMediaUploadQueueProvider.notifier)
+          .enqueuePlacedImageUpload(
+            strategyPublicId: 'strategy-a',
+            imagePublicId: 'unowned-image',
+            fileExtension: '.png',
+          ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(store.values, isEmpty);
+  });
+
+  test('account-scoped keys isolate identical asset IDs and removal', () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    CloudMediaUploadJob job(String accountId) => CloudMediaUploadJob(
+          jobId: 'shared-image',
+          accountId: accountId,
+          strategyPublicId: 'strategy-a',
+          assetPublicId: 'shared-image',
+          fileExtension: '.png',
+          mimeType: 'image/png',
+          state: CloudMediaJobState.pendingUpload,
+          attempts: 0,
+          updatedAt: DateTime.utc(2026, 9, 3),
+        );
+    final accountAJob = job('account-a');
+    final accountBJob = job('account-b');
+
+    await store.putAll([accountAJob, accountBJob]);
+    expect(
+      store.values.keys,
+      containsAll(['account-a|shared-image', 'account-b|shared-image']),
+    );
+
+    await store.remove(accountAJob);
+
+    final remaining = store.load().jobs.single;
+    expect(remaining.accountId, 'account-b');
+    expect(remaining.assetPublicId, 'shared-image');
+  });
+
+  test('current-strategy v1 work is visible but never reconciled', () async {
+    final store = MemoryDurableCloudMediaOutboxStore({
+      'legacy-image': _legacyJob(
+        jobId: 'legacy-image',
+        strategyPublicId: 'strategy-a',
+      ),
+    });
+    var snapshotReads = 0;
+    final container = _container(
+      store,
+      accountId: 'account-b',
+      cloudReady: true,
+      referenceSnapshotLoader: (_) async {
+        snapshotReads += 1;
+        return _fullSnapshot();
+      },
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+    final queue = container.read(cloudMediaUploadQueueProvider.notifier);
+
+    await queue.retryNow(ignoreBackoff: true);
+
+    final state = container.read(cloudMediaUploadQueueProvider);
+    expect(state.jobs, isEmpty);
+    expect(state.unknownOwnerJobsForStrategy('strategy-a'), hasLength(1));
+    expect(state.outboxIsReliable, isTrue);
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.attention);
+    expect(snapshotReads, 0);
+    expect(store.values, contains('legacy-image'));
+    expect(store.load().jobs.single.accountId, isNull);
+  });
+
+  test('unrelated-strategy v1 work causes no false attention', () async {
+    final store = MemoryDurableCloudMediaOutboxStore({
+      'legacy-image': _legacyJob(
+        jobId: 'legacy-image',
+        strategyPublicId: 'strategy-b',
+      ),
+    });
+    final container = _container(
+      store,
+      accountId: 'account-b',
+      cloudReady: true,
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+
+    final state = container.read(cloudMediaUploadQueueProvider);
+    expect(state.unknownOwnerJobsForStrategy('strategy-a'), isEmpty);
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.synced);
+    expect(store.values, contains('legacy-image'));
   });
 
   test('restart keeps an interrupted placement staged and non-runnable',
@@ -284,7 +481,7 @@ void main() {
     final state = container.read(cloudMediaUploadQueueProvider);
     expect(state.isProcessing, isFalse);
     expect(state.jobs.single.attempts, 0);
-    expect(store.values, contains('offline-image'));
+    expect(store.values, contains('account-a|offline-image'));
   });
 
   test('lineup staging is atomic when the durable batch write fails', () async {
@@ -314,7 +511,7 @@ void main() {
       throwsA(isA<StateError>()),
     );
 
-    expect(store.values.keys, ['existing-image']);
+    expect(store.values.keys, ['account-a|existing-image']);
     expect(
       container
           .read(cloudMediaUploadQueueProvider)
@@ -343,6 +540,7 @@ void main() {
       for (final assetId in ['lineup-image-1', 'lineup-image-2'])
         CloudMediaUploadJob(
           jobId: assetId,
+          accountId: 'account-a',
           strategyPublicId: 'strategy-a',
           assetPublicId: assetId,
           fileExtension: '.png',
@@ -382,6 +580,7 @@ void main() {
     await mediaStore.put(
       CloudMediaUploadJob(
         jobId: 'acked-image',
+        accountId: 'account-a',
         strategyPublicId: 'strategy-a',
         assetPublicId: 'acked-image',
         fileExtension: '.png',
@@ -455,6 +654,7 @@ void main() {
     await mediaStore.put(
       CloudMediaUploadJob(
         jobId: assetId,
+        accountId: 'account-a',
         strategyPublicId: 'strategy-a',
         assetPublicId: assetId,
         fileExtension: '.png',
@@ -505,7 +705,7 @@ void main() {
     final job = container.read(cloudMediaUploadQueueProvider).jobs.single;
     expect(job.assetPublicId, 'new-image');
     expect(job.referenceDurable, isFalse);
-    expect(mediaStore.values, contains('new-image'));
+    expect(mediaStore.values, contains('account-a|new-image'));
   });
 
   test('restart preserves an uploaded object that still needs attachment',
@@ -514,6 +714,7 @@ void main() {
     await store.put(
       CloudMediaUploadJob(
         jobId: 'pending-attach-image',
+        accountId: 'account-a',
         strategyPublicId: 'strategy-a',
         assetPublicId: 'pending-attach-image',
         fileExtension: '.png',
@@ -555,6 +756,7 @@ void main() {
     mediaQueue.replaceJobs([
       CloudMediaUploadJob(
         jobId: 'other-image',
+        accountId: 'account-a',
         strategyPublicId: 'strategy-b',
         assetPublicId: 'other-image',
         fileExtension: '.png',

--- a/test/cloud_media_upload_queue_provider_test.dart
+++ b/test/cloud_media_upload_queue_provider_test.dart
@@ -7,6 +7,10 @@ import 'package:icarus/providers/auth_provider.dart';
 import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
+import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_save_state_provider.dart';
+import 'package:icarus/strategy/strategy_page_models.dart';
 
 class _SignedOutAuthProvider extends AuthProvider {
   @override
@@ -25,6 +29,38 @@ class _DisabledCloudCollabMode extends CloudCollabModeNotifier {
         featureFlagEnabled: false,
         forceLocalFallback: false,
       );
+}
+
+class _ActiveCloudStrategy extends StrategyProvider {
+  @override
+  StrategyState build() => const StrategyState(
+        strategyId: 'strategy-a',
+        strategyName: 'Strategy A',
+        source: StrategySource.cloud,
+        isOpen: true,
+      );
+}
+
+class _SettledOpQueue extends StrategyOpQueueNotifier {
+  @override
+  StrategyOpQueueState build() => const StrategyOpQueueState(
+        accountId: 'account-a',
+        strategyPublicId: 'strategy-a',
+        clientId: 'client-a',
+        durableLoaded: true,
+      );
+}
+
+class _MutableMediaQueue extends CloudMediaUploadQueueNotifier {
+  @override
+  CloudMediaUploadQueueState build() => const CloudMediaUploadQueueState(
+        jobs: [],
+        isProcessing: false,
+      );
+
+  void replaceJobs(List<CloudMediaUploadJob> jobs) {
+    state = CloudMediaUploadQueueState(jobs: jobs, isProcessing: false);
+  }
 }
 
 ProviderContainer _container(MemoryDurableCloudMediaOutboxStore store) {
@@ -141,5 +177,37 @@ void main() {
     expect(job.uploadId, 'upload-a');
     expect(job.objectKey, contains('pending-attach-image.png'));
     expect(job.etag, 'etag-a');
+  });
+
+  test('media from another strategy does not affect the active save state', () {
+    final mediaQueue = _MutableMediaQueue();
+    final container = ProviderContainer(
+      overrides: [
+        strategyProvider.overrideWith(_ActiveCloudStrategy.new),
+        strategyOpQueueProvider.overrideWith(_SettledOpQueue.new),
+        cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(strategySaveStateProvider);
+
+    mediaQueue.replaceJobs([
+      CloudMediaUploadJob(
+        jobId: 'other-image',
+        strategyPublicId: 'strategy-b',
+        assetPublicId: 'other-image',
+        fileExtension: '.png',
+        mimeType: 'image/png',
+        state: CloudMediaJobState.failed,
+        attempts: 1,
+        lastError: 'Local media file is missing.',
+        updatedAt: DateTime.utc(2026, 9, 3),
+      ),
+    ]);
+
+    final saveState = container.read(strategySaveStateProvider);
+    expect(saveState.hasPendingMediaSync, isFalse);
+    expect(saveState.mediaSyncErrorCount, 0);
+    expect(saveState.isDirty, isFalse);
   });
 }

--- a/test/cloud_media_upload_queue_provider_test.dart
+++ b/test/cloud_media_upload_queue_provider_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/collab/cloud_media_models.dart';
+import 'package:icarus/collab/durable_cloud_media_outbox.dart';
+import 'package:icarus/const/line_provider.dart';
+import 'package:icarus/providers/auth_provider.dart';
+import 'package:icarus/providers/collab/cloud_collab_provider.dart';
+import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/convex_connection_provider.dart';
+
+class _SignedOutAuthProvider extends AuthProvider {
+  @override
+  AppAuthState build() => const AppAuthState(
+        isLoading: false,
+        isAuthenticated: false,
+        isConvexUserReady: false,
+        convexAuthStatus: ConvexAuthStatus.signedOut,
+        user: null,
+      );
+}
+
+class _DisabledCloudCollabMode extends CloudCollabModeNotifier {
+  @override
+  CloudCollabModeState build() => const CloudCollabModeState(
+        featureFlagEnabled: false,
+        forceLocalFallback: false,
+      );
+}
+
+ProviderContainer _container(MemoryDurableCloudMediaOutboxStore store) {
+  return ProviderContainer(
+    overrides: [
+      durableCloudMediaOutboxStoreProvider.overrideWithValue(store),
+      authProvider.overrideWith(_SignedOutAuthProvider.new),
+      cloudCollabModeProvider.overrideWith(_DisabledCloudCollabMode.new),
+      convexConnectionProvider.overrideWith((ref) => Stream.value(false)),
+    ],
+  );
+}
+
+void main() {
+  test('restart restores unfinished lineup media from the durable outbox',
+      () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final first = _container(store);
+
+    await first
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueueLineupMediaJobs(
+      strategyPublicId: 'strategy-a',
+      images: [
+        SimpleImageData(id: 'lineup-image', fileExtension: '.png'),
+      ],
+    );
+    first.dispose();
+
+    final restarted = _container(store);
+    addTearDown(restarted.dispose);
+    final state = restarted.read(cloudMediaUploadQueueProvider);
+
+    expect(state.outboxIsReliable, isTrue);
+    expect(state.jobs, hasLength(1));
+    expect(state.jobs.single.assetPublicId, 'lineup-image');
+    expect(state.jobs.single.strategyPublicId, 'strategy-a');
+    expect(state.jobs.single.fileExtension, '.png');
+  });
+
+  test('restart restores an image job without visiting its page', () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final first = _container(store);
+
+    await first
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueueJobForLocalFile(
+          strategyPublicId: 'strategy-a',
+          assetPublicId: 'unvisited-page-image',
+          fileExtension: '.webp',
+          width: 640,
+          height: 360,
+        );
+    first.dispose();
+
+    final restarted = _container(store);
+    addTearDown(restarted.dispose);
+    final restored = restarted
+        .read(cloudMediaUploadQueueProvider)
+        .jobsForStrategy('strategy-a');
+
+    expect(restored, hasLength(1));
+    expect(restored.single.assetPublicId, 'unvisited-page-image');
+    expect(restored.single.width, 640);
+    expect(restored.single.height, 360);
+  });
+
+  test('blocked uploads yield and keep their durable job pending', () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    final container = _container(store);
+    addTearDown(container.dispose);
+
+    await container
+        .read(cloudMediaUploadQueueProvider.notifier)
+        .enqueueJobForLocalFile(
+          strategyPublicId: 'strategy-a',
+          assetPublicId: 'offline-image',
+          fileExtension: '.jpg',
+        );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    final state = container.read(cloudMediaUploadQueueProvider);
+    expect(state.isProcessing, isFalse);
+    expect(state.jobs.single.attempts, 0);
+    expect(store.values, contains('offline-image'));
+  });
+
+  test('restart preserves an uploaded object that still needs attachment',
+      () async {
+    final store = MemoryDurableCloudMediaOutboxStore();
+    await store.put(
+      CloudMediaUploadJob(
+        jobId: 'pending-attach-image',
+        strategyPublicId: 'strategy-a',
+        assetPublicId: 'pending-attach-image',
+        fileExtension: '.png',
+        mimeType: 'image/png',
+        provider: 'r2',
+        uploadId: 'upload-a',
+        objectKey: 'strategies/strategy-a/images/pending-attach-image.png',
+        etag: 'etag-a',
+        byteSize: 1024,
+        state: CloudMediaJobState.pendingAttach,
+        attempts: 0,
+        updatedAt: DateTime.utc(2026, 9, 3),
+      ),
+    );
+
+    final restarted = _container(store);
+    addTearDown(restarted.dispose);
+    final job = restarted.read(cloudMediaUploadQueueProvider).jobs.single;
+
+    expect(job.state, CloudMediaJobState.pendingAttach);
+    expect(job.uploadId, 'upload-a');
+    expect(job.objectKey, contains('pending-attach-image.png'));
+    expect(job.etag, 'etag-a');
+  });
+}

--- a/test/image_provider_cloud_durability_test.dart
+++ b/test/image_provider_cloud_durability_test.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/const/coordinate_system.dart';
+import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/image_provider.dart';
+import 'package:icarus/strategy/strategy_page_models.dart';
+
+class _RecordingImageProvider extends PlacedImageProvider {
+  final List<String> locallySavedImageIds = [];
+
+  @override
+  Future<void> saveSecureImage(
+    Uint8List imageBytes,
+    String imageID,
+    String fileExtenstion, {
+    required String? strategyId,
+  }) async {
+    locallySavedImageIds.add(imageID);
+  }
+}
+
+class _FailingMediaQueue extends CloudMediaUploadQueueNotifier {
+  bool enqueueAttempted = false;
+
+  @override
+  CloudMediaUploadQueueState build() => const CloudMediaUploadQueueState(
+        jobs: [],
+        isProcessing: false,
+      );
+
+  @override
+  Future<void> enqueuePlacedImageUpload({
+    required String imagePublicId,
+    String? strategyPublicId,
+    String? fileExtension,
+    String? mimeType,
+    int? width,
+    int? height,
+  }) async {
+    enqueueAttempted = true;
+    throw StateError('outbox write failed');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  CoordinateSystem(playAreaSize: const Size(1920, 1080));
+
+  test('failed media outbox write keeps the local source and fails closed',
+      () async {
+    final imageProvider = _RecordingImageProvider();
+    final mediaQueue = _FailingMediaQueue();
+    final container = ProviderContainer(
+      overrides: [
+        placedImageProvider.overrideWith(() => imageProvider),
+        cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(placedImageProvider.notifier).addImage(
+            imageBytes: Uint8List.fromList([1, 2, 3]),
+            strategyId: 'strategy-a',
+            strategySource: StrategySource.cloud,
+            fileExtension: '.png',
+            aspectRatio: 1,
+          ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(mediaQueue.enqueueAttempted, isTrue);
+    expect(imageProvider.locallySavedImageIds, hasLength(1));
+    expect(container.read(placedImageProvider).images, isEmpty);
+  });
+}

--- a/test/unsaved_strategy_guard_test.dart
+++ b/test/unsaved_strategy_guard_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/const/app_provider_container.dart';
 import 'package:icarus/const/coordinate_system.dart';
@@ -117,11 +118,17 @@ class _GuardOpQueue extends StrategyOpQueueNotifier {
 }
 
 class _GuardMediaQueue extends CloudMediaUploadQueueNotifier {
+  _GuardMediaQueue([
+    this.initialState = const CloudMediaUploadQueueState(
+      jobs: [],
+      isProcessing: false,
+    ),
+  ]);
+
+  final CloudMediaUploadQueueState initialState;
+
   @override
-  CloudMediaUploadQueueState build() => const CloudMediaUploadQueueState(
-        jobs: [],
-        isProcessing: false,
-      );
+  CloudMediaUploadQueueState build() => initialState;
 }
 
 const _guardEntityKey = EntitySyncKey.strategy();
@@ -721,6 +728,122 @@ void main() {
       await tester.tap(find.text('Stay Here'));
       await tester.pumpAndSettle();
       expect(await guardFuture, isFalse);
+    });
+
+    testWidgets('an unreliable media outbox cannot leave', (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final mediaQueue = _GuardMediaQueue(
+        CloudMediaUploadQueueState(
+          jobs: [
+            CloudMediaUploadJob(
+              jobId: 'image-a',
+              strategyPublicId: 'cloud-strategy',
+              assetPublicId: 'image-a',
+              fileExtension: '.png',
+              mimeType: 'image/png',
+              state: CloudMediaJobState.pendingUpload,
+              attempts: 0,
+              updatedAt: DateTime.utc(2026, 9, 3),
+            ),
+          ],
+          isProcessing: false,
+          durabilityError: 'Media work could not be saved on this device.',
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(
+            () => _GuardOpQueue(
+              const StrategyOpQueueState(
+                accountId: 'account-a',
+                strategyPublicId: 'cloud-strategy',
+                clientId: 'guard-client',
+                durableLoaded: true,
+              ),
+            ),
+          ),
+          cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-unreliable-media',
+        onContinue: () async {},
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsNothing);
+      expect(find.textContaining('could not confirm'), findsOneWidget);
+      await tester.tap(find.text('Stay Here'));
+      await tester.pumpAndSettle();
+      expect(await guardFuture, isFalse);
+    });
+
+    testWidgets('cloud exit stages an active text draft before leaving',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(
+            () => _GuardOpQueue(
+              const StrategyOpQueueState(
+                accountId: 'account-a',
+                strategyPublicId: 'cloud-strategy',
+                clientId: 'guard-client',
+                durableLoaded: true,
+              ),
+            ),
+          ),
+          cloudMediaUploadQueueProvider.overrideWith(_GuardMediaQueue.new),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(textDraftProvider.notifier)
+          .setDraft('text-a', 'active cloud draft');
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final result = await guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-cloud-draft',
+        onContinue: () async {
+          continueCalls++;
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+      expect(continueCalls, 1);
+      expect(notifier.forceSaveCalls, 1);
+      expect(container.read(textDraftProvider), isEmpty);
     });
 
     testWidgets('active cloud flush completes and exits without a dialog',

--- a/test/unsaved_strategy_guard_test.dart
+++ b/test/unsaved_strategy_guard_test.dart
@@ -745,6 +745,7 @@ void main() {
           jobs: [
             CloudMediaUploadJob(
               jobId: 'image-a',
+              accountId: 'account-a',
               strategyPublicId: 'cloud-strategy',
               assetPublicId: 'image-a',
               fileExtension: '.png',
@@ -794,6 +795,145 @@ void main() {
       expect(await guardFuture, isFalse);
     });
 
+    testWidgets(
+        'current-strategy unknown-owner media can leave but never claims retry',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final mediaQueue = _GuardMediaQueue(
+        CloudMediaUploadQueueState(
+          jobs: const [],
+          unknownOwnerJobs: [
+            CloudMediaUploadJob(
+              jobId: 'legacy-image',
+              accountId: null,
+              strategyPublicId: 'cloud-strategy',
+              assetPublicId: 'legacy-image',
+              fileExtension: '.png',
+              mimeType: 'image/png',
+              state: CloudMediaJobState.pendingUpload,
+              attempts: 0,
+              updatedAt: DateTime.utc(2026, 9, 3),
+            ),
+          ],
+          isProcessing: false,
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(
+            () => _GuardOpQueue(
+              const StrategyOpQueueState(
+                accountId: 'account-b',
+                strategyPublicId: 'cloud-strategy',
+                clientId: 'guard-client',
+                durableLoaded: true,
+              ),
+            ),
+          ),
+          cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-unknown-owner',
+        onContinue: () async {
+          continueCalls += 1;
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsOneWidget);
+      expect(find.textContaining('will not be sent automatically'),
+          findsOneWidget);
+      await tester.tap(find.text('Leave Anyway'));
+      await tester.pumpAndSettle();
+      expect(await guardFuture, isTrue);
+      expect(continueCalls, 1);
+    });
+
+    testWidgets('unrelated unknown-owner media does not block exit',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final mediaQueue = _GuardMediaQueue(
+        CloudMediaUploadQueueState(
+          jobs: const [],
+          unknownOwnerJobs: [
+            CloudMediaUploadJob(
+              jobId: 'legacy-image',
+              accountId: null,
+              strategyPublicId: 'other-strategy',
+              assetPublicId: 'legacy-image',
+              fileExtension: '.png',
+              mimeType: 'image/png',
+              state: CloudMediaJobState.pendingUpload,
+              attempts: 0,
+              updatedAt: DateTime.utc(2026, 9, 3),
+            ),
+          ],
+          isProcessing: false,
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(
+            () => _GuardOpQueue(
+              const StrategyOpQueueState(
+                accountId: 'account-b',
+                strategyPublicId: 'cloud-strategy',
+                clientId: 'guard-client',
+                durableLoaded: true,
+              ),
+            ),
+          ),
+          cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final result = await guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-unrelated-unknown-owner',
+        onContinue: () async {
+          continueCalls += 1;
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+      expect(continueCalls, 1);
+      expect(find.text('Cloud sync pending'), findsNothing);
+    });
+
     testWidgets('media without a durable strategy reference cannot leave',
         (tester) async {
       notifier = _FakeGuardStrategyProvider(
@@ -810,6 +950,7 @@ void main() {
           jobs: [
             CloudMediaUploadJob(
               jobId: 'staged-image',
+              accountId: 'account-a',
               strategyPublicId: 'cloud-strategy',
               assetPublicId: 'staged-image',
               fileExtension: '.png',

--- a/test/unsaved_strategy_guard_test.dart
+++ b/test/unsaved_strategy_guard_test.dart
@@ -794,6 +794,70 @@ void main() {
       expect(await guardFuture, isFalse);
     });
 
+    testWidgets('media without a durable strategy reference cannot leave',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final mediaQueue = _GuardMediaQueue(
+        CloudMediaUploadQueueState(
+          jobs: [
+            CloudMediaUploadJob(
+              jobId: 'staged-image',
+              strategyPublicId: 'cloud-strategy',
+              assetPublicId: 'staged-image',
+              fileExtension: '.png',
+              mimeType: 'image/png',
+              state: CloudMediaJobState.pendingUpload,
+              referenceDurable: false,
+              attempts: 0,
+              updatedAt: DateTime.utc(2026, 9, 3),
+            ),
+          ],
+          isProcessing: false,
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(
+            () => _GuardOpQueue(
+              const StrategyOpQueueState(
+                accountId: 'account-a',
+                strategyPublicId: 'cloud-strategy',
+                clientId: 'guard-client',
+                durableLoaded: true,
+              ),
+            ),
+          ),
+          cloudMediaUploadQueueProvider.overrideWith(() => mediaQueue),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-staged-media',
+        onContinue: () async {},
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsNothing);
+      await tester.tap(find.text('Stay Here'));
+      await tester.pumpAndSettle();
+      expect(await guardFuture, isFalse);
+    });
+
     testWidgets('cloud exit stages an active text draft before leaving',
         (tester) async {
       notifier = _FakeGuardStrategyProvider(

--- a/test/unsaved_strategy_guard_test.dart
+++ b/test/unsaved_strategy_guard_test.dart
@@ -4,12 +4,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/const/app_provider_container.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/placed_classes.dart';
 import 'package:icarus/hive/hive_registration.dart';
+import 'package:icarus/providers/auth_provider.dart';
+import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
+import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/convex_connection_provider.dart';
+import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/folder_provider.dart';
 import 'package:icarus/providers/in_app_debug_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
@@ -78,6 +84,58 @@ class _ThrowingSaveStrategyProvider extends StrategyProvider {
     throw StateError('save failed');
   }
 }
+
+class _GuardAuthProvider extends AuthProvider {
+  @override
+  AppAuthState build() => const AppAuthState(
+        isLoading: false,
+        isAuthenticated: true,
+        isConvexUserReady: true,
+        convexAuthStatus: ConvexAuthStatus.ready,
+        user: null,
+      );
+}
+
+class _GuardOpQueue extends StrategyOpQueueNotifier {
+  _GuardOpQueue(this.initialState);
+
+  final StrategyOpQueueState initialState;
+
+  @override
+  StrategyOpQueueState build() => initialState;
+
+  StrategyOpQueueState get currentState => state;
+
+  void settle() {
+    state = StrategyOpQueueState(
+      accountId: initialState.accountId,
+      strategyPublicId: initialState.strategyPublicId,
+      clientId: initialState.clientId,
+      durableLoaded: true,
+    );
+  }
+}
+
+class _GuardMediaQueue extends CloudMediaUploadQueueNotifier {
+  @override
+  CloudMediaUploadQueueState build() => const CloudMediaUploadQueueState(
+        jobs: [],
+        isProcessing: false,
+      );
+}
+
+const _guardEntityKey = EntitySyncKey.strategy();
+const _guardPendingIntent = QueuedEntityIntent(
+  entityKey: _guardEntityKey,
+  pending: PendingOp(
+    op: StrategyPatchOp(
+      opId: 'guard-op',
+      payload: <String, dynamic>{'name': 'pending'},
+      expectedStrategyRevision: 1,
+    ),
+    clientId: 'guard-client',
+  ),
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -505,6 +563,215 @@ void main() {
       expect(logs, isNotEmpty);
       expect(logs.last.message, 'Failed to save strategy before leaving.');
       expect(logs.last.source, 'guard-test-error');
+    });
+
+    testWidgets('offline durable work can leave and remains queued',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final opQueue = _GuardOpQueue(
+        StrategyOpQueueState(
+          accountId: 'account-a',
+          strategyPublicId: 'cloud-strategy',
+          clientId: 'guard-client',
+          queuedByEntityKey: {_guardEntityKey: _guardPendingIntent},
+          durableLoaded: true,
+          lastError: 'Cloud connection is offline.',
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(() => opQueue),
+          cloudMediaUploadQueueProvider.overrideWith(_GuardMediaQueue.new),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-cloud-offline',
+        onContinue: () async {
+          continueCalls++;
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsOneWidget);
+      expect(
+        find.textContaining('have not reached the cloud'),
+        findsOneWidget,
+      );
+      expect(opQueue.currentState.pending, hasLength(1));
+      await tester.tap(find.text('Leave Anyway'));
+      await tester.pumpAndSettle();
+
+      expect(await guardFuture, isTrue);
+      expect(continueCalls, 1);
+      expect(opQueue.currentState.pending, hasLength(1));
+    });
+
+    testWidgets('paused viewer work has a leave-anyway path', (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final opQueue = _GuardOpQueue(
+        StrategyOpQueueState(
+          accountId: 'account-a',
+          strategyPublicId: 'cloud-strategy',
+          clientId: 'guard-client',
+          pausedByEntityKey: {_guardEntityKey: _guardPendingIntent},
+          durableLoaded: true,
+          lastError: 'This viewer edit cannot be retried automatically.',
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(() => opQueue),
+          cloudMediaUploadQueueProvider.overrideWith(_GuardMediaQueue.new),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(true),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-cloud-viewer',
+        onContinue: () async {
+          continueCalls++;
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsOneWidget);
+      await tester.tap(find.text('Leave Anyway'));
+      await tester.pumpAndSettle();
+
+      expect(await guardFuture, isTrue);
+      expect(continueCalls, 1);
+      expect(opQueue.currentState.pausedByEntityKey, isNotEmpty);
+    });
+
+    testWidgets('non-durable cloud work cannot leave', (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final opQueue = _GuardOpQueue(
+        StrategyOpQueueState(
+          accountId: 'account-a',
+          strategyPublicId: 'cloud-strategy',
+          clientId: 'guard-client',
+          queuedByEntityKey: {_guardEntityKey: _guardPendingIntent},
+          durableLoaded: true,
+          hasDurabilityFailure: true,
+          lastError: 'Cloud work could not be saved to the durable outbox.',
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(() => opQueue),
+          cloudMediaUploadQueueProvider.overrideWith(_GuardMediaQueue.new),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(true),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-cloud-nondurable',
+        onContinue: () async {},
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Anyway'), findsNothing);
+      expect(find.text('Stay Here'), findsOneWidget);
+      await tester.tap(find.text('Stay Here'));
+      await tester.pumpAndSettle();
+      expect(await guardFuture, isFalse);
+    });
+
+    testWidgets('active cloud flush completes and exits without a dialog',
+        (tester) async {
+      notifier = _FakeGuardStrategyProvider(
+        initialState: const StrategyState(
+          strategyId: 'cloud-strategy',
+          strategyName: 'Cloud Strategy',
+          source: StrategySource.cloud,
+          isOpen: true,
+        ),
+        flushResult: true,
+      );
+      final opQueue = _GuardOpQueue(
+        StrategyOpQueueState(
+          accountId: 'account-a',
+          strategyPublicId: 'cloud-strategy',
+          clientId: 'guard-client',
+          queuedByEntityKey: {_guardEntityKey: _guardPendingIntent},
+          durableLoaded: true,
+          isFlushing: true,
+        ),
+      );
+      container = ProviderContainer(
+        overrides: [
+          strategyProvider.overrideWith(() => notifier),
+          strategyOpQueueProvider.overrideWith(() => opQueue),
+          cloudMediaUploadQueueProvider.overrideWith(_GuardMediaQueue.new),
+          authProvider.overrideWith(_GuardAuthProvider.new),
+          convexConnectionSnapshotProvider.overrideWithValue(true),
+        ],
+      );
+      addTearDown(container.dispose);
+      await pumpHarness(tester);
+
+      var continueCalls = 0;
+      final guardFuture = guardUnsavedStrategyExit(
+        context: context,
+        ref: ref,
+        source: 'guard-test-cloud-flush',
+        onContinue: () async {
+          continueCalls++;
+        },
+      );
+      await tester.pump();
+      opQueue.settle();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      expect(await guardFuture, isTrue);
+      expect(continueCalls, 1);
+      expect(find.text('Cloud sync pending'), findsNothing);
     });
   });
 }

--- a/test/widgets/cloud_sync_status_chip_test.dart
+++ b/test/widgets/cloud_sync_status_chip_test.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
+import 'package:icarus/providers/collab/cloud_sync_status_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
 import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/strategy_save_state_provider.dart';
 import 'package:icarus/providers/text_draft_provider.dart';
 import 'package:icarus/strategy/strategy_models.dart';
 import 'package:icarus/strategy/strategy_page_models.dart';
@@ -40,13 +42,29 @@ class _EmptyMediaQueue extends CloudMediaUploadQueueNotifier {
       );
 }
 
-ProviderContainer _createContainer({bool connected = true}) {
+class _FixedSaveState extends StrategySaveStateNotifier {
+  _FixedSaveState(this.initialState);
+
+  final StrategySaveState initialState;
+
+  @override
+  StrategySaveState build() => initialState;
+}
+
+ProviderContainer _createContainer({
+  bool connected = true,
+  StrategySaveState? saveState,
+}) {
   return ProviderContainer(
     overrides: [
       strategyProvider.overrideWith(_CloudStrategyProvider.new),
       strategyOpQueueProvider.overrideWith(_SettledOpQueue.new),
       cloudMediaUploadQueueProvider.overrideWith(_EmptyMediaQueue.new),
       convexConnectionProvider.overrideWith((ref) => Stream.value(connected)),
+      if (saveState != null)
+        strategySaveStateProvider.overrideWith(
+          () => _FixedSaveState(saveState),
+        ),
     ],
   );
 }
@@ -110,5 +128,56 @@ void main() {
     expect(find.text('Offline'), findsOneWidget);
     expect(find.text('Editing…'), findsNothing);
     expect(find.text('Synced'), findsNothing);
+  });
+
+  test('status provider prioritizes connectivity over an offline flush error',
+      () async {
+    final container = _createContainer(
+      connected: false,
+      saveState: const StrategySaveState(
+        isDirty: true,
+        isSaving: false,
+        hasPendingCloudSync: true,
+        cloudSyncError: 'Cloud connection is offline.',
+        hasPendingMediaSync: false,
+        mediaSyncErrorCount: 0,
+        lastPersistedAt: null,
+      ),
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.offline);
+  });
+
+  testWidgets('offline flush errors render Offline instead of Needs attention',
+      (tester) async {
+    final container = _createContainer(
+      connected: false,
+      saveState: const StrategySaveState(
+        isDirty: true,
+        isSaving: false,
+        hasPendingCloudSync: true,
+        cloudSyncError: 'Cloud connection is offline.',
+        hasPendingMediaSync: false,
+        mediaSyncErrorCount: 0,
+        lastPersistedAt: null,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const ShadApp(
+          home: Scaffold(body: CloudSyncStatusChip()),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Offline'), findsOneWidget);
+    expect(find.text('Needs attention'), findsNothing);
   });
 }

--- a/test/widgets/cloud_sync_status_chip_test.dart
+++ b/test/widgets/cloud_sync_status_chip_test.dart
@@ -107,6 +107,7 @@ void main() {
         jobs: [
           CloudMediaUploadJob(
             jobId: 'restored-image',
+            accountId: 'account-a',
             strategyPublicId: 'cloud-strategy',
             assetPublicId: 'restored-image',
             fileExtension: 'png',
@@ -137,6 +138,7 @@ void main() {
         jobs: [
           CloudMediaUploadJob(
             jobId: 'missing-image',
+            accountId: 'account-a',
             strategyPublicId: 'cloud-strategy',
             assetPublicId: 'missing-image',
             fileExtension: 'png',

--- a/test/widgets/cloud_sync_status_chip_test.dart
+++ b/test/widgets/cloud_sync_status_chip_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/collab/cloud_media_models.dart';
 import 'package:icarus/collab/collab_models.dart';
 import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
@@ -44,6 +45,15 @@ class _EmptyMediaQueue extends CloudMediaUploadQueueNotifier {
       );
 }
 
+class _FixedMediaQueue extends CloudMediaUploadQueueNotifier {
+  _FixedMediaQueue(this.initialState);
+
+  final CloudMediaUploadQueueState initialState;
+
+  @override
+  CloudMediaUploadQueueState build() => initialState;
+}
+
 class _FixedOpQueue extends StrategyOpQueueNotifier {
   _FixedOpQueue(this.initialState);
 
@@ -65,6 +75,7 @@ class _FixedSaveState extends StrategySaveStateNotifier {
 ProviderContainer _createContainer({
   bool connected = true,
   StrategyOpQueueState? opQueueState,
+  CloudMediaUploadQueueState? mediaQueueState,
   StrategySaveState? saveState,
 }) {
   return ProviderContainer(
@@ -75,7 +86,11 @@ ProviderContainer _createContainer({
             ? _SettledOpQueue.new
             : () => _FixedOpQueue(opQueueState),
       ),
-      cloudMediaUploadQueueProvider.overrideWith(_EmptyMediaQueue.new),
+      cloudMediaUploadQueueProvider.overrideWith(
+        mediaQueueState == null
+            ? _EmptyMediaQueue.new
+            : () => _FixedMediaQueue(mediaQueueState),
+      ),
       convexConnectionProvider.overrideWith((ref) => Stream.value(connected)),
       if (saveState != null)
         strategySaveStateProvider.overrideWith(
@@ -86,6 +101,61 @@ ProviderContainer _createContainer({
 }
 
 void main() {
+  test('restored active-strategy media renders as syncing', () {
+    final container = _createContainer(
+      mediaQueueState: CloudMediaUploadQueueState(
+        jobs: [
+          CloudMediaUploadJob(
+            jobId: 'restored-image',
+            strategyPublicId: 'cloud-strategy',
+            assetPublicId: 'restored-image',
+            fileExtension: 'png',
+            mimeType: 'image/png',
+            state: CloudMediaJobState.pendingUpload,
+            referenceDurable: false,
+            attempts: 0,
+            updatedAt: DateTime.utc(2026),
+          ),
+        ],
+        isProcessing: false,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.syncing);
+    expect(
+      container.read(cloudSyncStatusProvider),
+      isNot(CloudSyncStatus.synced),
+    );
+  });
+
+  test('restored active-strategy media errors remain visible offline',
+      () async {
+    final container = _createContainer(
+      connected: false,
+      mediaQueueState: CloudMediaUploadQueueState(
+        jobs: [
+          CloudMediaUploadJob(
+            jobId: 'missing-image',
+            strategyPublicId: 'cloud-strategy',
+            assetPublicId: 'missing-image',
+            fileExtension: 'png',
+            mimeType: 'image/png',
+            state: CloudMediaJobState.failed,
+            attempts: 1,
+            lastError: 'Local media file is missing.',
+            updatedAt: DateTime.utc(2026),
+          ),
+        ],
+        isProcessing: false,
+      ),
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.attention);
+  });
+
   testWidgets('an active text draft can never appear synced', (tester) async {
     final container = _createContainer();
     addTearDown(container.dispose);

--- a/test/widgets/cloud_sync_status_chip_test.dart
+++ b/test/widgets/cloud_sync_status_chip_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/collab/collab_models.dart';
+import 'package:icarus/providers/collab/active_page_live_sync_models.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
 import 'package:icarus/providers/collab/cloud_sync_status_provider.dart';
 import 'package:icarus/providers/collab/convex_connection_provider.dart';
@@ -42,6 +44,15 @@ class _EmptyMediaQueue extends CloudMediaUploadQueueNotifier {
       );
 }
 
+class _FixedOpQueue extends StrategyOpQueueNotifier {
+  _FixedOpQueue(this.initialState);
+
+  final StrategyOpQueueState initialState;
+
+  @override
+  StrategyOpQueueState build() => initialState;
+}
+
 class _FixedSaveState extends StrategySaveStateNotifier {
   _FixedSaveState(this.initialState);
 
@@ -53,12 +64,17 @@ class _FixedSaveState extends StrategySaveStateNotifier {
 
 ProviderContainer _createContainer({
   bool connected = true,
+  StrategyOpQueueState? opQueueState,
   StrategySaveState? saveState,
 }) {
   return ProviderContainer(
     overrides: [
       strategyProvider.overrideWith(_CloudStrategyProvider.new),
-      strategyOpQueueProvider.overrideWith(_SettledOpQueue.new),
+      strategyOpQueueProvider.overrideWith(
+        opQueueState == null
+            ? _SettledOpQueue.new
+            : () => _FixedOpQueue(opQueueState),
+      ),
       cloudMediaUploadQueueProvider.overrideWith(_EmptyMediaQueue.new),
       convexConnectionProvider.overrideWith((ref) => Stream.value(connected)),
       if (saveState != null)
@@ -148,6 +164,56 @@ void main() {
     await container.read(convexConnectionProvider.future);
 
     expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.offline);
+  });
+
+  test('real queue attention remains visible while offline', () async {
+    const entityKey = EntitySyncKey.strategy();
+    const intent = QueuedEntityIntent(
+      entityKey: entityKey,
+      pending: PendingOp(
+        op: StrategyPatchOp(
+          opId: 'conflicted-op',
+          payload: <String, dynamic>{'name': 'conflicted'},
+          expectedStrategyRevision: 1,
+        ),
+        clientId: 'client-a',
+      ),
+    );
+    final container = _createContainer(
+      connected: false,
+      opQueueState: StrategyOpQueueState(
+        accountId: 'account-a',
+        strategyPublicId: 'cloud-strategy',
+        clientId: 'client-a',
+        attentionByEntityKey: <EntitySyncKey, QueuedEntityIntent>{
+          entityKey: intent,
+        },
+        durableLoaded: true,
+      ),
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.attention);
+  });
+
+  test('media errors remain visible while offline', () async {
+    final container = _createContainer(
+      connected: false,
+      saveState: const StrategySaveState(
+        isDirty: false,
+        isSaving: false,
+        hasPendingCloudSync: true,
+        cloudSyncError: null,
+        hasPendingMediaSync: true,
+        mediaSyncErrorCount: 1,
+        lastPersistedAt: null,
+      ),
+    );
+    addTearDown(container.dispose);
+    await container.read(convexConnectionProvider.future);
+
+    expect(container.read(cloudSyncStatusProvider), CloudSyncStatus.attention);
   });
 
   testWidgets('offline flush errors render Offline instead of Needs attention',


### PR DESCRIPTION
## What changed

- Persist cloud media upload jobs in a versioned Hive outbox before the live queue accepts or advances them, then restore every strategy's lineup and placed-image work on startup.
- Keep local source images intact and fail closed when an image cannot be queued durably. Removed the destructive upload-cancel path.
- Let strategy and window close leave queued work behind only after all current edits are staged and both durable outboxes are reliable. The dialog says the work has not reached the cloud and will retry later.
- Derive the sync chip from connectivity first for ordinary transport failures, so an offline outbox reads Offline instead of Needs attention.
- Yield blocked media processing with delayed and reconnect-driven retries instead of spinning.

## Verification

- `flutter test test/cloud_media_upload_queue_provider_test.dart test/widgets/cloud_sync_status_chip_test.dart test/unsaved_strategy_guard_test.dart test/strategy_op_queue_provider_test.dart test/strategy_integrity_test.dart` (73 passed)
- `flutter test` (615 passed, 2 expected environment-only skips)
- `flutter analyze` (no errors or warnings; 35 existing info lints)