### PR TITLE
Enforce cloud strategy edit permissions

### DIFF
--- a/convex/accessControl.test.ts
+++ b/convex/accessControl.test.ts
@@ -19,6 +19,7 @@ const createStrategy = makeFunctionReference<"mutation">(
   "strategies:createWithInitialPage",
 );
 const updateStrategy = makeFunctionReference<"mutation">("strategies:update");
+const moveStrategy = makeFunctionReference<"mutation">("strategies:move");
 const deleteStrategy = makeFunctionReference<"mutation">("strategies:delete");
 const listStrategies = makeFunctionReference<"query">(
   "strategies:listForFolder",
@@ -304,6 +305,106 @@ describe("A/B/C access boundary", () => {
         name: "Redeemed editor remains durable",
       }),
     ).resolves.toMatchObject({ ok: true, revision: 2 });
+  });
+
+  test("only the owner can move a directly shared Strategy", async () => {
+    const { a, b } = await createHarness();
+    const sourceFolderPublicId = "direct-move-source";
+    const targetFolderPublicId = "direct-move-target";
+    const strategyPublicId = "directly-shared-strategy";
+
+    await a.mutation(createFolder, {
+      publicId: sourceFolderPublicId,
+      name: "Source",
+    });
+    await a.mutation(createFolder, {
+      publicId: targetFolderPublicId,
+      name: "Target",
+    });
+    await seedStrategy(
+      a,
+      strategyPublicId,
+      "directly-shared-page",
+      sourceFolderPublicId,
+    );
+    await a.mutation(createShare, {
+      targetType: "strategy",
+      targetPublicId: strategyPublicId,
+      token: "direct-move-editor-token",
+      role: "editor",
+    });
+    await b.mutation(redeemShare, { token: "direct-move-editor-token" });
+
+    await expect(
+      b.mutation(moveStrategy, {
+        strategyPublicId,
+        expectedRevision: 0,
+        folderPublicId: targetFolderPublicId,
+      }),
+    ).rejects.toThrow("Forbidden");
+    await expect(
+      a.query(listStrategies, {
+        folderPublicId: sourceFolderPublicId,
+        scope: "owned",
+      }),
+    ).resolves.toMatchObject([
+      { publicId: strategyPublicId, revision: 0 },
+    ]);
+
+    await expect(
+      a.mutation(moveStrategy, {
+        strategyPublicId,
+        expectedRevision: 0,
+        folderPublicId: targetFolderPublicId,
+      }),
+    ).resolves.toMatchObject({ ok: true, revision: 1 });
+    await expect(
+      a.query(listStrategies, {
+        folderPublicId: targetFolderPublicId,
+        scope: "owned",
+      }),
+    ).resolves.toMatchObject([
+      { publicId: strategyPublicId, revision: 1 },
+    ]);
+  });
+
+  test("an inherited folder editor cannot move a Strategy out of the share", async () => {
+    const { a, b } = await createHarness();
+    const sharedFolderPublicId = "inherited-move-source";
+    const strategyPublicId = "inherited-editor-strategy";
+
+    await a.mutation(createFolder, {
+      publicId: sharedFolderPublicId,
+      name: "Shared source",
+    });
+    await seedStrategy(
+      a,
+      strategyPublicId,
+      "inherited-editor-page",
+      sharedFolderPublicId,
+    );
+    await a.mutation(createShare, {
+      targetType: "folder",
+      targetPublicId: sharedFolderPublicId,
+      token: "inherited-move-editor-token",
+      role: "editor",
+    });
+    await b.mutation(redeemShare, { token: "inherited-move-editor-token" });
+
+    await expect(
+      b.mutation(moveStrategy, {
+        strategyPublicId,
+        expectedRevision: 0,
+      }),
+    ).rejects.toThrow("Forbidden");
+    await expect(
+      b.query(listStrategies, {
+        folderPublicId: sharedFolderPublicId,
+        scope: "shared",
+      }),
+    ).resolves.toMatchObject([
+      { publicId: strategyPublicId, role: "editor", revision: 0 },
+    ]);
   });
 
   test("deleting a Strategy removes its access records", async () => {

--- a/convex/strategies.ts
+++ b/convex/strategies.ts
@@ -570,7 +570,7 @@ export const move = mutation({
   returns: revisionResultValidator,
   handler: async (ctx, args) => {
     const strategy = await getStrategyByPublicId(ctx, args.strategyPublicId);
-    await assertStrategyRole(ctx, strategy, "editor");
+    await assertStrategyRole(ctx, strategy, "owner");
 
     if (args.expectedRevision !== strategy.revision) {
       throw conflictError("Strategy revision mismatch");

--- a/lib/collab/strategy_capabilities.dart
+++ b/lib/collab/strategy_capabilities.dart
@@ -1,0 +1,70 @@
+class StrategyCapabilities {
+  const StrategyCapabilities({
+    required this.canRenameStrategy,
+    required this.canDeleteStrategy,
+    required this.canDuplicateStrategy,
+    required this.canMoveStrategy,
+    required this.canEditPages,
+    required this.canAddPage,
+    required this.canRenamePage,
+    required this.canDeletePage,
+    required this.canReorderPages,
+    required this.canCreateFolder,
+    required this.canEditFolder,
+    required this.canDeleteFolder,
+    required this.canMoveFolder,
+  });
+
+  final bool canRenameStrategy;
+  final bool canDeleteStrategy;
+  final bool canDuplicateStrategy;
+  final bool canMoveStrategy;
+  final bool canEditPages;
+  final bool canAddPage;
+  final bool canRenamePage;
+  final bool canDeletePage;
+  final bool canReorderPages;
+  final bool canCreateFolder;
+  final bool canEditFolder;
+  final bool canDeleteFolder;
+  final bool canMoveFolder;
+
+  factory StrategyCapabilities.fullAccess() {
+    return const StrategyCapabilities(
+      canRenameStrategy: true,
+      canDeleteStrategy: true,
+      canDuplicateStrategy: true,
+      canMoveStrategy: true,
+      canEditPages: true,
+      canAddPage: true,
+      canRenamePage: true,
+      canDeletePage: true,
+      canReorderPages: true,
+      canCreateFolder: true,
+      canEditFolder: true,
+      canDeleteFolder: true,
+      canMoveFolder: true,
+    );
+  }
+
+  factory StrategyCapabilities.fromCloudRole(String? role) {
+    final normalized = role ?? 'viewer';
+    final canEdit = normalized == 'owner' || normalized == 'editor';
+    final isOwner = normalized == 'owner';
+    return StrategyCapabilities(
+      canRenameStrategy: canEdit,
+      canDeleteStrategy: isOwner,
+      canDuplicateStrategy: canEdit,
+      canMoveStrategy: isOwner,
+      canEditPages: canEdit,
+      canAddPage: canEdit,
+      canRenamePage: canEdit,
+      canDeletePage: canEdit,
+      canReorderPages: canEdit,
+      canCreateFolder: isOwner,
+      canEditFolder: isOwner,
+      canDeleteFolder: isOwner,
+      canMoveFolder: isOwner,
+    );
+  }
+}

--- a/lib/interactive_map.dart
+++ b/lib/interactive_map.dart
@@ -7,6 +7,7 @@ import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/ability_bar_provider.dart';
 import 'package:icarus/providers/canvas_resize_provider.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/interaction_state_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/user_preferences_provider.dart';
@@ -123,6 +124,11 @@ class _InteractiveMapState extends ConsumerState<InteractiveMap> {
   @override
   Widget build(BuildContext context) {
     bool isAttack = ref.watch(mapProvider).isAttack;
+    final canEditPages = ref.watch(
+      currentStrategyCapabilitiesProvider.select(
+        (capabilities) => capabilities.canEditPages,
+      ),
+    );
     final transitionPresentation = ref.watch(
       transitionProvider.select(
         (state) => (
@@ -322,16 +328,26 @@ class _InteractiveMapState extends ConsumerState<InteractiveMap> {
                                     ),
                                   ),
                                 Positioned.fill(
-                                  child: transitionPresentation.hideView
-                                      ? SizedBox.shrink()
-                                      : Opacity(
-                                          opacity: ref.watch(
-                                                      interactionStateProvider) ==
-                                                  InteractionState.lineUpPlacing
-                                              ? 0.2
-                                              : 1.0,
-                                          child: PlacedWidgetBuilder(),
-                                        ),
+                                  child: IgnorePointer(
+                                    key: const ValueKey(
+                                      'strategy-canvas-object-editor',
+                                    ),
+                                    ignoring: !canEditPages,
+                                    child: ExcludeFocus(
+                                      excluding: !canEditPages,
+                                      child: transitionPresentation.hideView
+                                          ? SizedBox.shrink()
+                                          : Opacity(
+                                              opacity: ref.watch(
+                                                          interactionStateProvider) ==
+                                                      InteractionState
+                                                          .lineUpPlacing
+                                                  ? 0.2
+                                                  : 1.0,
+                                              child: PlacedWidgetBuilder(),
+                                            ),
+                                    ),
+                                  ),
                                 ),
                                 Positioned.fill(
                                   child: transitionPresentation.hideView
@@ -368,21 +384,30 @@ class _InteractiveMapState extends ConsumerState<InteractiveMap> {
                                                   InteractionState.lineUpPlacing
                                               ? 0.2
                                               : 1.0;
-                                      return Opacity(
-                                        opacity:
-                                            transitionOpacity * lineUpOpacity,
-                                        child: Transform.flip(
-                                            flipX: !isAttack,
-                                            flipY: !isAttack,
-                                            child: InteractivePainter()),
+                                      return IgnorePointer(
+                                        key: const ValueKey(
+                                          'strategy-canvas-drawing-editor',
+                                        ),
+                                        ignoring: !canEditPages,
+                                        child: Opacity(
+                                          opacity:
+                                              transitionOpacity * lineUpOpacity,
+                                          child: Transform.flip(
+                                              flipX: !isAttack,
+                                              flipY: !isAttack,
+                                              child: InteractivePainter()),
+                                        ),
                                       );
                                     },
                                   ),
                                 ),
                                 if (ref.watch(interactionStateProvider) ==
                                     InteractionState.lineUpPlacing)
-                                  const Positioned.fill(
-                                    child: LineupPositionWidget(),
+                                  Positioned.fill(
+                                    child: IgnorePointer(
+                                      ignoring: !canEditPages,
+                                      child: const LineupPositionWidget(),
+                                    ),
                                   ),
                               ],
                             ),
@@ -395,15 +420,21 @@ class _InteractiveMapState extends ConsumerState<InteractiveMap> {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           crossAxisAlignment: CrossAxisAlignment.start,
-                          children: const [
-                            HoveredMapItemNameCard(),
-                            DeleteArea(),
+                          children: [
+                            const HoveredMapItemNameCard(),
+                            IgnorePointer(
+                              ignoring: !canEditPages,
+                              child: const DeleteArea(),
+                            ),
                           ],
                         ),
                       ),
                       Align(
                         alignment: Alignment.bottomRight,
-                        child: const LineupControlButtons(),
+                        child: IgnorePointer(
+                          ignoring: !canEditPages,
+                          child: const LineupControlButtons(),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/providers/collab/strategy_capabilities_provider.dart
+++ b/lib/providers/collab/strategy_capabilities_provider.dart
@@ -1,89 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:icarus/providers/collab/cloud_collab_provider.dart';
+import 'package:icarus/collab/strategy_capabilities.dart';
 import 'package:icarus/providers/collab/remote_strategy_snapshot_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:icarus/strategy/strategy_page_models.dart';
 
-class StrategyCapabilities {
-  const StrategyCapabilities({
-    required this.canRenameStrategy,
-    required this.canDeleteStrategy,
-    required this.canDuplicateStrategy,
-    required this.canMoveStrategy,
-    required this.canEditPages,
-    required this.canAddPage,
-    required this.canRenamePage,
-    required this.canDeletePage,
-    required this.canReorderPages,
-    required this.canCreateFolder,
-    required this.canEditFolder,
-    required this.canDeleteFolder,
-    required this.canMoveFolder,
-  });
-
-  final bool canRenameStrategy;
-  final bool canDeleteStrategy;
-  final bool canDuplicateStrategy;
-  final bool canMoveStrategy;
-  final bool canEditPages;
-  final bool canAddPage;
-  final bool canRenamePage;
-  final bool canDeletePage;
-  final bool canReorderPages;
-  final bool canCreateFolder;
-  final bool canEditFolder;
-  final bool canDeleteFolder;
-  final bool canMoveFolder;
-
-  factory StrategyCapabilities.fullAccess() {
-    return const StrategyCapabilities(
-      canRenameStrategy: true,
-      canDeleteStrategy: true,
-      canDuplicateStrategy: true,
-      canMoveStrategy: true,
-      canEditPages: true,
-      canAddPage: true,
-      canRenamePage: true,
-      canDeletePage: true,
-      canReorderPages: true,
-      canCreateFolder: true,
-      canEditFolder: true,
-      canDeleteFolder: true,
-      canMoveFolder: true,
-    );
-  }
-
-  factory StrategyCapabilities.fromCloudRole(String? role) {
-    final normalized = role ?? 'viewer';
-    final canEdit = normalized == 'owner' || normalized == 'editor';
-    final isOwner = normalized == 'owner';
-    return StrategyCapabilities(
-      canRenameStrategy: canEdit,
-      canDeleteStrategy: isOwner,
-      canDuplicateStrategy: canEdit,
-      canMoveStrategy: canEdit,
-      canEditPages: canEdit,
-      canAddPage: canEdit,
-      canRenamePage: canEdit,
-      canDeletePage: canEdit,
-      canReorderPages: canEdit,
-      canCreateFolder: isOwner,
-      canEditFolder: isOwner,
-      canDeleteFolder: isOwner,
-      canMoveFolder: isOwner,
-    );
-  }
-}
+export 'package:icarus/collab/strategy_capabilities.dart';
 
 final currentStrategyCapabilitiesProvider =
     Provider<StrategyCapabilities>((ref) {
-  final strategySource =
-      ref.watch(strategyProvider.select((value) => value.source));
-  if (strategySource != StrategySource.cloud ||
-      !ref.watch(isCloudCollabEnabledProvider)) {
+  final strategy = ref.watch(
+    strategyProvider.select((value) => (value.source, value.strategyId)),
+  );
+  if (strategy.$1 != StrategySource.cloud) {
     return StrategyCapabilities.fullAccess();
   }
-  final role = ref.watch(remoteEditorSnapshotProvider).valueOrNull?.header.role;
+  final header = ref.watch(remoteEditorSnapshotProvider).valueOrNull?.header;
+  final role = header?.publicId == strategy.$2 ? header?.role : null;
   return StrategyCapabilities.fromCloudRole(role);
 });
 

--- a/lib/providers/strategy_provider.dart
+++ b/lib/providers/strategy_provider.dart
@@ -33,6 +33,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:icarus/collab/canonical_json.dart';
 import 'package:icarus/collab/collab_models.dart';
+import 'package:icarus/collab/strategy_capabilities.dart';
 import 'package:icarus/collab/convex_strategy_repository.dart';
 import 'package:icarus/providers/collab/remote_library_provider.dart';
 import 'package:icarus/providers/collab/cloud_media_upload_queue_provider.dart';
@@ -136,7 +137,8 @@ class StrategyProvider extends Notifier<StrategyState> {
     if (!state.isOpen || state.strategyId == null || state.source == null) {
       return false;
     }
-    return !ref.read(strategyPageSessionProvider).isApplyingPage;
+    return !ref.read(strategyPageSessionProvider).isApplyingPage &&
+        _currentStrategyCanEditPages();
   }
 
   T _withoutPersistenceTracking<T>(T Function() callback) {
@@ -234,6 +236,17 @@ class StrategyProvider extends Notifier<StrategyState> {
     return state.source == StrategySource.cloud;
   }
 
+  bool _currentStrategyCanEditPages() {
+    if (!_currentStrategyIsCloud()) {
+      return true;
+    }
+    final snapshot = ref.read(remoteEditorSnapshotProvider).valueOrNull;
+    final role = snapshot?.header.publicId == state.strategyId
+        ? snapshot?.header.role
+        : null;
+    return StrategyCapabilities.fromCloudRole(role).canEditPages;
+  }
+
   bool _selectedWorkspaceIsCloud() {
     return ref.read(libraryWorkspaceProvider) == LibraryWorkspace.cloud;
   }
@@ -329,7 +342,9 @@ class StrategyProvider extends Notifier<StrategyState> {
     List<StrategyOp> ops, {
     bool flushImmediately = false,
   }) async {
-    if (!_currentStrategyIsCloud() || ops.isEmpty) {
+    if (!_currentStrategyIsCloud() ||
+        !_currentStrategyCanEditPages() ||
+        ops.isEmpty) {
       return;
     }
 
@@ -359,7 +374,7 @@ class StrategyProvider extends Notifier<StrategyState> {
 
   Future<void> notifyCloudMutation({bool flushImmediately = false}) async {
     _cloudMutationSyncScheduled = false;
-    if (!_currentStrategyIsCloud()) {
+    if (!_currentStrategyIsCloud() || !_currentStrategyCanEditPages()) {
       return;
     }
 
@@ -376,7 +391,7 @@ class StrategyProvider extends Notifier<StrategyState> {
     bool flushImmediately = false,
   }) async {
     _cloudStrategyMutationSyncScheduled = false;
-    if (!_currentStrategyIsCloud()) {
+    if (!_currentStrategyIsCloud() || !_currentStrategyCanEditPages()) {
       return;
     }
 
@@ -431,6 +446,9 @@ class StrategyProvider extends Notifier<StrategyState> {
       return;
     }
     if (ref.read(strategyPageSessionProvider).isApplyingPage) {
+      return;
+    }
+    if (!_currentStrategyCanEditPages()) {
       return;
     }
 
@@ -494,6 +512,9 @@ class StrategyProvider extends Notifier<StrategyState> {
     if (ref.read(strategyPageSessionProvider).isApplyingPage) {
       return;
     }
+    if (!_currentStrategyCanEditPages()) {
+      return;
+    }
 
     state = state.copyWith(isSaved: false);
 
@@ -511,6 +532,9 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> forceSaveNow(String id) async {
+    if (!_currentStrategyCanEditPages()) {
+      return;
+    }
     cancelPendingSave();
     if (_currentStrategyIsCloud()) {
       ref.read(strategySaveStateProvider.notifier)
@@ -615,6 +639,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> reorderPage(int oldIndex, int newIndex) async {
+    if (!_currentStrategyCanEditPages()) return;
     if (oldIndex == newIndex) return;
 
     if (_currentStrategyIsCloud()) {
@@ -865,6 +890,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> addPage([String? name]) async {
+    if (!_currentStrategyCanEditPages()) return;
     if (_currentStrategyIsCloud()) {
       final snapshot = ref.read(remoteEditorSnapshotProvider).valueOrNull;
       if (snapshot == null) return;
@@ -943,6 +969,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> renamePage(String pageId, String newName) async {
+    if (!_currentStrategyCanEditPages()) return;
     final trimmed = newName.trim();
     if (trimmed.isEmpty) {
       return;
@@ -986,6 +1013,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   }
 
   Future<void> deletePage(String pageId) async {
+    if (!_currentStrategyCanEditPages()) return;
     if (_currentStrategyIsCloud()) {
       final snapshot = ref.read(remoteEditorSnapshotProvider).valueOrNull;
       if (snapshot == null || snapshot.pages.length <= 1) {
@@ -1577,6 +1605,7 @@ class StrategyProvider extends Notifier<StrategyState> {
   Future<void> _applySettingsToAllPages(
     StrategySettings Function(StrategySettings settings) transform,
   ) async {
+    if (!_currentStrategyCanEditPages()) return;
     if (_currentStrategyIsCloud()) {
       final strategyId = state.strategyId;
       if (strategyId == null) {

--- a/lib/strategy/strategy_page_source.dart
+++ b/lib/strategy/strategy_page_source.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/collab/canonical_json.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:icarus/collab/collab_models.dart';
+import 'package:icarus/collab/strategy_capabilities.dart';
 import 'package:icarus/const/drawing_element.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/line_provider.dart';
@@ -309,6 +310,13 @@ class CloudStrategyPageSource implements StrategyPageSource {
 
   @override
   Future<void> flushCurrentPage() async {
+    final snapshot = ref.read(remoteEditorSnapshotProvider).valueOrNull;
+    if (snapshot == null ||
+        snapshot.header.publicId != strategyId ||
+        !StrategyCapabilities.fromCloudRole(snapshot.header.role)
+            .canEditPages) {
+      return;
+    }
     final pageId = activePageId();
     if (pageId == null) {
       return;

--- a/lib/strategy_view.dart
+++ b/lib/strategy_view.dart
@@ -20,6 +20,7 @@ import 'package:icarus/strategy/strategy_page_models.dart';
 import 'package:icarus/widgets/delete_capture.dart';
 import 'package:icarus/widgets/demo_tag.dart';
 import 'package:icarus/widgets/strategy_view_skeleton.dart';
+import 'package:icarus/widgets/strategy_edit_boundary.dart';
 import 'package:icarus/widgets/strategy_quick_switcher.dart';
 import 'package:icarus/widgets/map_selector.dart';
 import 'package:icarus/widgets/pages_bar.dart';
@@ -235,7 +236,10 @@ class _StrategyViewState extends ConsumerState<StrategyView>
                           icon: const Icon(Icons.home),
                         ),
                         const SizedBox(width: 5),
-                        const MapSelector(),
+                        const StrategyEditBoundary(
+                          disabledOpacity: 0.55,
+                          child: MapSelector(),
+                        ),
                         if (kIsWeb)
                           const Padding(
                             padding: EdgeInsets.symmetric(horizontal: 8.0),
@@ -284,7 +288,9 @@ class _StrategyViewState extends ConsumerState<StrategyView>
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                Positioned.fill(child: DeleteCapture()),
+                Positioned.fill(
+                  child: StrategyEditBoundary(child: DeleteCapture()),
+                ),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: RepaintBoundary(child: InteractiveMap()),
@@ -297,7 +303,13 @@ class _StrategyViewState extends ConsumerState<StrategyView>
                     child: PagesBar(),
                   ),
                 ),
-                Align(alignment: Alignment.centerRight, child: SideBarUI()),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: StrategyEditBoundary(
+                    disabledOpacity: 0.55,
+                    child: SideBarUI(),
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/widgets/global_shortcuts.dart
+++ b/lib/widgets/global_shortcuts.dart
@@ -6,6 +6,7 @@ import 'package:icarus/const/settings.dart';
 import 'package:icarus/const/shortcut_info.dart';
 import 'package:icarus/providers/action_provider.dart';
 import 'package:icarus/providers/agent_filter_provider.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/delete_menu_provider.dart';
 import 'package:icarus/providers/duplicate_drag_modifier_provider.dart';
 import 'package:icarus/providers/hovered_delete_target_provider.dart';
@@ -61,6 +62,8 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
 
   @override
   Widget build(BuildContext context) {
+    final capabilities = ref.watch(currentStrategyCapabilitiesProvider);
+
     return Focus(
       autofocus: true,
       // canRequestFocus: true,
@@ -102,6 +105,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             AddPageIntent: CallbackAction<AddPageIntent>(
               onInvoke: (intent) async {
+                if (!capabilities.canAddPage) return null;
                 _dismissDeleteMenu();
                 await ref.read(strategyProvider.notifier).addPage();
                 return null;
@@ -109,6 +113,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             ToggleLineupIntent: CallbackAction<ToggleLineupIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 if (ref.read(interactionStateProvider) ==
                     InteractionState.lineUpPlacing) {
@@ -132,6 +137,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             ContextualDeleteIntent: CallbackAction<ContextualDeleteIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 final hoveredTarget = ref.read(hoveredDeleteTargetProvider);
                 if (hoveredTarget != null) {
                   _dismissDeleteMenu();
@@ -154,6 +160,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             UndoActionIntent: CallbackAction<UndoActionIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 ref.read(actionProvider.notifier).undoAction();
                 return null;
@@ -161,6 +168,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             AddedTextIntent: CallbackAction<AddedTextIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 const uuid = Uuid();
                 final placementCenter = ref.read(placementCenterProvider);
@@ -183,6 +191,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             ToggleDrawingIntent: CallbackAction<ToggleDrawingIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 if (ref.read(interactionStateProvider) ==
                     InteractionState.drawing) {
@@ -199,6 +208,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             ToggleErasingIntent: CallbackAction<ToggleErasingIntent>(
               onInvoke: (intent) async {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 if (ref.read(interactionStateProvider) ==
                     InteractionState.erasing) {
@@ -216,6 +226,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             RedoActionIntent: CallbackAction<RedoActionIntent>(
               onInvoke: (intent) {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 ref.read(actionProvider.notifier).redoAction();
                 return null;
@@ -223,6 +234,7 @@ class _GlobalShortcutsState extends ConsumerState<GlobalShortcuts>
             ),
             SaveStrategyIntent: CallbackAction<SaveStrategyIntent>(
               onInvoke: (intent) async {
+                if (!capabilities.canEditPages) return null;
                 _dismissDeleteMenu();
                 final strategyId = ref.read(strategyProvider).strategyId;
                 if (strategyId == null) return null;

--- a/lib/widgets/image_drop_target.dart
+++ b/lib/widgets/image_drop_target.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/settings.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/image_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 
@@ -19,18 +20,29 @@ class _ImageDropTargetState extends ConsumerState<ImageDropTarget> {
 
   @override
   Widget build(BuildContext context) {
+    final canEditPages = ref.watch(
+      currentStrategyCapabilitiesProvider.select(
+        (capabilities) => capabilities.canEditPages,
+      ),
+    );
+
     return DropTarget(
       onDragEntered: (details) {
+        if (!canEditPages) return;
         setState(() {
           isDragging = true;
         });
       },
       onDragExited: (details) {
+        if (!canEditPages) return;
         setState(() {
           isDragging = false;
         });
       },
       onDragDone: (details) async {
+        if (!ref.read(currentStrategyCapabilitiesProvider).canEditPages) {
+          return;
+        }
         if (kIsWeb) {
           Settings.showToast(
             message: 'This feature is only supported in the Windows version.',

--- a/lib/widgets/save_and_load_button.dart
+++ b/lib/widgets/save_and_load_button.dart
@@ -8,7 +8,6 @@ import 'package:hive_ce/hive.dart';
 import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/hive_boxes.dart';
 import 'package:icarus/const/settings.dart';
-import 'package:icarus/providers/collab/cloud_collab_provider.dart';
 import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
@@ -231,8 +230,7 @@ class _SaveAndLoadButtonState extends ConsumerState<SaveAndLoadButton> {
 
   bool _isViewOnly() {
     final source = ref.watch(strategyProvider.select((value) => value.source));
-    if (source != StrategySource.cloud ||
-        !ref.watch(isCloudCollabEnabledProvider)) {
+    if (source != StrategySource.cloud) {
       return false;
     }
     // Read the cached role rather than the raw snapshot so the chip does not

--- a/lib/widgets/settings_tab.dart
+++ b/lib/widgets/settings_tab.dart
@@ -19,6 +19,7 @@ import 'package:icarus/widgets/account_avatar.dart';
 import 'package:icarus/widgets/dialogs/auth/auth_dialog.dart';
 import 'package:icarus/widgets/map_theme_settings_section.dart';
 import 'package:icarus/widgets/settings_scope_card.dart';
+import 'package:icarus/widgets/strategy_edit_boundary.dart';
 import 'package:icarus/widgets/text_editing_shortcut_scope.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -110,10 +111,13 @@ class _SettingsTabState extends ConsumerState<SettingsTab> {
                     child: SingleChildScrollView(
                       controller: _scrollController,
                       child: switch (_mode) {
-                        _SettingsMode.strategy => _StrategySettingsSections(
-                            key: const ValueKey('strategy-settings'),
-                            sectionKeys: _sectionKeys,
-                            strategySettings: strategySettings,
+                        _SettingsMode.strategy => StrategyEditBoundary(
+                            disabledOpacity: 0.55,
+                            child: _StrategySettingsSections(
+                              key: const ValueKey('strategy-settings'),
+                              sectionKeys: _sectionKeys,
+                              strategySettings: strategySettings,
+                            ),
                           ),
                         _SettingsMode.global => _GlobalSettingsSections(
                             key: const ValueKey('global-settings'),

--- a/lib/widgets/strategy_edit_boundary.dart
+++ b/lib/widgets/strategy_edit_boundary.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
+
+/// Disables controls that mutate the open strategy when it is view-only.
+class StrategyEditBoundary extends ConsumerWidget {
+  const StrategyEditBoundary({
+    super.key,
+    required this.child,
+    this.disabledOpacity = 1,
+  });
+
+  final Widget child;
+  final double disabledOpacity;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canEdit = ref.watch(
+      currentStrategyCapabilitiesProvider.select(
+        (capabilities) => capabilities.canEditPages,
+      ),
+    );
+
+    return AbsorbPointer(
+      absorbing: !canEdit,
+      child: ExcludeFocus(
+        excluding: !canEdit,
+        child: Opacity(
+          opacity: canEdit ? 1 : disabledOpacity,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/strategy_save_icon_button.dart
+++ b/lib/widgets/strategy_save_icon_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icarus/const/settings.dart';
 import 'package:icarus/providers/auto_save_notifier.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/strategy_save_state_provider.dart';
 import 'package:icarus/providers/strategy_provider.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -84,6 +85,11 @@ class _AutoSaveButtonState extends ConsumerState<AutoSaveButton>
   @override
   Widget build(BuildContext context) {
     final ping = ref.watch(autoSaveProvider);
+    final canEditPages = ref.watch(
+      currentStrategyCapabilitiesProvider.select(
+        (capabilities) => capabilities.canEditPages,
+      ),
+    );
 
     if (ping != _lastPing) {
       _lastPing = ping;
@@ -116,10 +122,11 @@ class _AutoSaveButtonState extends ConsumerState<AutoSaveButton>
     }
 
     return ShadTooltip(
-      builder: (context) => const Text("Save"),
+      builder: (context) => Text(canEditPages ? "Save" : "View only"),
       child: ShadIconButton.ghost(
         foregroundColor: Colors.white,
         icon: icon,
+        enabled: canEditPages,
         onPressed: () async {
           await ref
               .read(strategyProvider.notifier)

--- a/test/cloud_ui_parity_helpers_test.dart
+++ b/test/cloud_ui_parity_helpers_test.dart
@@ -53,6 +53,8 @@ void main() {
 
     expect(caps.canRenameStrategy, isFalse);
     expect(caps.canDeleteStrategy, isFalse);
+    expect(caps.canMoveStrategy, isFalse);
+    expect(caps.canEditPages, isFalse);
     expect(caps.canAddPage, isFalse);
     expect(caps.canReorderPages, isFalse);
   });
@@ -62,7 +64,17 @@ void main() {
 
     expect(caps.canRenameStrategy, isTrue);
     expect(caps.canDeleteStrategy, isTrue);
+    expect(caps.canMoveStrategy, isTrue);
+    expect(caps.canEditPages, isTrue);
     expect(caps.canAddPage, isTrue);
     expect(caps.canReorderPages, isTrue);
+  });
+
+  test('editor cloud capabilities allow page edits but not moves', () {
+    final caps = StrategyCapabilities.fromCloudRole('editor');
+
+    expect(caps.canRenameStrategy, isTrue);
+    expect(caps.canMoveStrategy, isFalse);
+    expect(caps.canEditPages, isTrue);
   });
 }

--- a/test/interactive_map_canonical_center_test.dart
+++ b/test/interactive_map_canonical_center_test.dart
@@ -5,6 +5,7 @@ import 'package:icarus/const/coordinate_system.dart';
 import 'package:icarus/const/maps.dart';
 import 'package:icarus/const/traversal_speed.dart';
 import 'package:icarus/interactive_map.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
 import 'package:icarus/providers/drawing_provider.dart';
 import 'package:icarus/providers/map_provider.dart';
 import 'package:icarus/providers/pen_provider.dart';
@@ -89,6 +90,60 @@ void main() {
     expect(
       defenseCenter.dy,
       closeTo(coordinates.normalizedHeight - attackCenter.dy, 0.0001),
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('viewer canvas keeps navigation but disables edit layers',
+      (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1500, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final container = ProviderContainer(
+      overrides: [
+        mapProvider.overrideWith(_FixedMapProvider.new),
+        drawingProvider.overrideWith(_EmptyDrawingProvider.new),
+        penProvider.overrideWith(_FixedPenProvider.new),
+        effectiveMapThemePaletteProvider.overrideWith(
+          (ref) => MapThemeProfilesProvider.immutableDefaultPalette,
+        ),
+        currentStrategyCapabilitiesProvider.overrideWithValue(
+          StrategyCapabilities.fromCloudRole('viewer'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const ShadApp(
+          home: Scaffold(body: InteractiveMap()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(InteractiveViewer), findsOneWidget);
+    expect(
+      tester
+          .widget<IgnorePointer>(
+            find.byKey(const ValueKey('strategy-canvas-object-editor')),
+          )
+          .ignoring,
+      isTrue,
+    );
+    expect(
+      tester
+          .widget<IgnorePointer>(
+            find.byKey(const ValueKey('strategy-canvas-drawing-editor')),
+          )
+          .ignoring,
+      isTrue,
     );
 
     await tester.pumpWidget(const SizedBox.shrink());

--- a/test/strategy_edit_access_test.dart
+++ b/test/strategy_edit_access_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:icarus/collab/collab_models.dart';
+import 'package:icarus/const/maps.dart';
+import 'package:icarus/const/shortcut_info.dart';
+import 'package:icarus/providers/collab/remote_strategy_snapshot_provider.dart';
+import 'package:icarus/providers/collab/strategy_capabilities_provider.dart';
+import 'package:icarus/providers/collab/strategy_op_queue_provider.dart';
+import 'package:icarus/providers/strategy_provider.dart';
+import 'package:icarus/providers/text_provider.dart';
+import 'package:icarus/strategy/strategy_page_models.dart';
+import 'package:icarus/widgets/global_shortcuts.dart';
+import 'package:icarus/widgets/strategy_edit_boundary.dart';
+
+class _RoleSnapshotNotifier extends RemoteEditorSnapshotNotifier {
+  _RoleSnapshotNotifier(this.role);
+
+  final String role;
+
+  @override
+  Future<RemoteEditorSnapshot?> build() async {
+    final now = DateTime.utc(2026);
+    return RemoteEditorSnapshot(
+      shell: RemoteStrategyShell(
+        header: RemoteStrategyHeader(
+          publicId: 'cloud-strategy',
+          name: 'Cloud Strategy',
+          mapData: Maps.mapNames[MapValue.ascent]!,
+          revision: 1,
+          createdAt: now,
+          updatedAt: now,
+          role: role,
+        ),
+        pages: const [],
+      ),
+      activePage: null,
+    );
+  }
+}
+
+class _RecordingStrategyOpQueue extends StrategyOpQueueNotifier {
+  final enqueued = <StrategyOp>[];
+
+  @override
+  StrategyOpQueueState build() => const StrategyOpQueueState(
+        accountId: 'account-a',
+        strategyPublicId: 'cloud-strategy',
+        clientId: 'test-client',
+        durableLoaded: true,
+      );
+
+  @override
+  Future<void> enqueueAll(
+    Iterable<StrategyOp> ops, {
+    bool flushImmediately = false,
+  }) async {
+    enqueued.addAll(ops);
+  }
+}
+
+Future<void> _invokeAddTextShortcut(
+  WidgetTester tester,
+  StrategyCapabilities capabilities,
+) async {
+  late WidgetRef widgetRef;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        currentStrategyCapabilitiesProvider.overrideWithValue(capabilities),
+      ],
+      child: MaterialApp(
+        home: GlobalShortcuts(
+          child: Consumer(
+            builder: (context, ref, _) {
+              widgetRef = ref;
+              return const SizedBox(
+                key: ValueKey('shortcut-target'),
+                width: 100,
+                height: 100,
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+
+  Actions.invoke(
+    tester.element(find.byKey(const ValueKey('shortcut-target'))),
+    const AddedTextIntent(),
+  );
+  await tester.pump();
+
+  expect(
+    widgetRef.read(textProvider).length,
+    capabilities.canEditPages ? 1 : 0,
+  );
+}
+
+void main() {
+  testWidgets('viewers cannot add text with an editor shortcut',
+      (tester) async {
+    await _invokeAddTextShortcut(
+      tester,
+      StrategyCapabilities.fromCloudRole('viewer'),
+    );
+  });
+
+  for (final role in ['editor', 'owner']) {
+    testWidgets('$role can add text with an editor shortcut', (tester) async {
+      await _invokeAddTextShortcut(
+        tester,
+        StrategyCapabilities.fromCloudRole(role),
+      );
+    });
+  }
+
+  testWidgets('view-only edit controls absorb pointer input', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          currentStrategyCapabilitiesProvider.overrideWithValue(
+            StrategyCapabilities.fromCloudRole('viewer'),
+          ),
+        ],
+        child: MaterialApp(
+          home: StrategyEditBoundary(
+            disabledOpacity: 0.55,
+            child: GestureDetector(
+              key: const ValueKey('edit-control'),
+              onTap: () => taps += 1,
+              child: const SizedBox(width: 100, height: 100),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('edit-control')),
+      warnIfMissed: false,
+    );
+    expect(taps, 0);
+    expect(
+      tester
+          .widget<ExcludeFocus>(
+            find.descendant(
+              of: find.byType(StrategyEditBoundary),
+              matching: find.byType(ExcludeFocus),
+            ),
+          )
+          .excluding,
+      isTrue,
+    );
+    expect(
+      tester
+          .widget<Opacity>(
+            find.descendant(
+              of: find.byType(StrategyEditBoundary),
+              matching: find.byType(Opacity),
+            ),
+          )
+          .opacity,
+      0.55,
+    );
+  });
+
+  test('a stale cloud role cannot grant access to another strategy', () async {
+    final container = ProviderContainer(
+      overrides: [
+        remoteEditorSnapshotProvider.overrideWith(
+          () => _RoleSnapshotNotifier('editor'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(remoteEditorSnapshotProvider.future);
+    container.read(strategyProvider.notifier).setFromState(
+          const StrategyState(
+            strategyId: 'different-cloud-strategy',
+            strategyName: 'Different Cloud Strategy',
+            source: StrategySource.cloud,
+            storageDirectory: null,
+            isOpen: true,
+          ),
+        );
+
+    expect(
+      container.read(currentStrategyCapabilitiesProvider).canEditPages,
+      isFalse,
+    );
+  });
+
+  for (final role in ['viewer', 'editor', 'owner']) {
+    test('$role cloud op queue access matches page edit capability', () async {
+      final queue = _RecordingStrategyOpQueue();
+      final container = ProviderContainer(
+        overrides: [
+          remoteEditorSnapshotProvider.overrideWith(
+            () => _RoleSnapshotNotifier(role),
+          ),
+          strategyOpQueueProvider.overrideWith(() => queue),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(remoteEditorSnapshotProvider.future);
+      container.read(strategyProvider.notifier).setFromState(
+            const StrategyState(
+              strategyId: 'cloud-strategy',
+              strategyName: 'Cloud Strategy',
+              source: StrategySource.cloud,
+              storageDirectory: null,
+              isOpen: true,
+            ),
+          );
+
+      await container.read(strategyProvider.notifier).enqueueOps(
+        const [
+          StrategyPatchOp(
+            opId: 'strategy-op',
+            payload: {'name': 'Changed'},
+            expectedStrategyRevision: 1,
+          ),
+        ],
+      );
+
+      expect(
+        queue.enqueued.length,
+        role == 'viewer' ? 0 : 1,
+      );
+    });
+  }
+}

--- a/test/strategy_page_session_provider_test.dart
+++ b/test/strategy_page_session_provider_test.dart
@@ -312,6 +312,7 @@ RemoteEditorSnapshot _editorSnapshot({
   int shellRevision = 1,
   String? mapData,
   String? themeProfileId,
+  String role = 'owner',
 }) {
   final now = DateTime.utc(2026);
   return RemoteEditorSnapshot(
@@ -324,6 +325,7 @@ RemoteEditorSnapshot _editorSnapshot({
         createdAt: now,
         updatedAt: now,
         themeProfileId: themeProfileId,
+        role: role,
       ),
       pages: pages,
     ),


### PR DESCRIPTION
## What changed

- Require the strategy owner role for moves, including moves out of inherited folder shares.
- Apply `canEditPages` at the strategy editor boundary so viewers can navigate and zoom but cannot use canvas, sidebar, map, settings, keyboard, or image-drop edit paths.
- Reject viewer dirty-state, save, page-flush, and op-queue admission paths, with stale or missing role snapshots failing closed.
- Keep the existing owner and editor page-edit behavior, while making strategy moves owner-only in the shared capability model.

## Verification

- `npx tsc --noEmit`
- `npm run test:convex` (35 passed)
- `flutter test test/strategy_edit_access_test.dart test/cloud_ui_parity_helpers_test.dart test/interactive_map_canonical_center_test.dart test/strategy_page_session_provider_test.dart` (36 passed)
- `flutter test` (614 passed, 2 skipped)
- `flutter analyze` (35 existing info diagnostics; no warnings or errors)